### PR TITLE
Closure identifiers

### DIFF
--- a/Core_Erlang_Determinism_Helpers.v
+++ b/Core_Erlang_Determinism_Helpers.v
@@ -84,6 +84,16 @@ Proof.
   * simpl. rewrite IHl. simpl. destruct l; auto.
 Qed.
 
+Theorem last_nth_equal (l : list nat) (def : nat) :
+  last l def = nth_id l def (length l).
+Proof.
+  induction l.
+  * auto.
+  * simpl. rewrite IHl. destruct l.
+    - auto.
+    - simpl. auto.
+Qed.
+
 End List_Length_Theorems.
 
 Lemma concatn_app {eff1 x1 : SideEffectList} {x6 : list SideEffectList} {i : nat} : 
@@ -1122,304 +1132,337 @@ repeat (rewrite app_assoc in Hyp)
 Lemma map_lists_equal_until_i_val {env : Environment} {kl : list Expression} : 
    forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (i i0 : nat) 
    (eff1 : SideEffectList) (eff eff7 : list SideEffectList) (ex0 : Exception) 
-   (eff5 eff2 eff4 eff6 : SideEffectList) (val val0 : Value) (ex : Exception) (id ),
+   (eff5 eff2 eff4 eff6 : SideEffectList) (val val0 : Value) (ex : Exception) (id id1 id2 id1' id2' : nat) (ids ids0 : list nat),
 (forall j : nat,
      j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | id'', v2, eff'' | ->
+     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\ nth_id ids id (S (2*j)) = id'')
 ->
 (forall j : nat,
      j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | id'', v2, eff'' | ->
+     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\ nth_id ids id (S (S (2*j))) = id'')
 ->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList),
-         | env, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | v2, eff'' | ->
-         inl val = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'')
+(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+         | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | id'', v2, eff'' | ->
+         inl val = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'' /\ id1 = id'')
 ->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList),
-         | env, nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2 | -e> | v2, eff'' | ->
-         inr ex = v2 /\ eff4 = eff'')
+(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+         | env, id1, nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2 | -e> | id'', v2, eff'' | ->
+         inr ex = v2 /\ eff4 = eff'' /\ id2 = id'')
 ->
 Datatypes.length kl = Datatypes.length vl ->
 Datatypes.length vvals = i ->
 Datatypes.length kvals = i ->
 i <= Datatypes.length kl ->
 Datatypes.length eff = (i * 2)%nat ->
+Datatypes.length ids = (i * 2)%nat ->
 (forall j : nat,
       j < i0 ->
-      | env, nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | inl (nth j kvals0 ErrorValue),
+      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
       concatn eff1 eff7 (S (2 * j)) |)
 ->
 (forall j : nat,
       j < i0 ->
-      | env, nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
-      | inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
+      | env, nth_id ids0 id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
+      | nth_id ids0 id (S (S (2*j))), inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
 ->
 Datatypes.length vvals0 = i0 ->
 Datatypes.length kvals0 = i0->
 i0 <= Datatypes.length kl ->
 Datatypes.length eff7 = (i0 * 2)%nat ->
-(| env, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
+Datatypes.length ids0 = (i0 * 2)%nat ->
+(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id1', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
 \/
-(| env, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | inl val0,
+(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id1', inl val0,
       concatn eff1 eff7 (2 * i0) ++ eff5 | /\
-| env, nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff5 | -e> | 
-      inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 ++ eff6 |)
+| env, id1', nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff5 | -e> | 
+      id2', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 ++ eff6 |)
 )
 ->
-i = i0 /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7.
+i = i0 /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7 /\ ids = ids0.
 Proof.
   induction kl.
-  * intros. inversion H3. apply eq_sym, length_zero_iff_nil in H16. subst. inversion H12.
-    apply length_zero_iff_nil in H10. subst. inversion H6. apply length_zero_iff_nil in H10.
-    subst. inversion H5. apply length_zero_iff_nil in H10. subst. inversion H7.
-    apply length_zero_iff_nil in H10. subst. inversion H11. apply length_zero_iff_nil in H10. subst.
-    inversion H13. apply length_zero_iff_nil in H10. subst. auto.
-  * intros. inversion H3. simpl in H3. 
-    pose (EE1 := element_exist Expression (length kl) vl H16). inversion EE1 as [ve]. inversion H15 as [ves]. subst.
+  * intros. inversion H3.
+    apply eq_sym, length_zero_iff_nil in H18. subst.
+    inversion H13. apply length_zero_iff_nil in H11. subst.
+    inversion H6. apply length_zero_iff_nil in H11. subst.
+    inversion H5. apply length_zero_iff_nil in H11. subst.
+    inversion H7. apply length_zero_iff_nil in H11. subst.
+    inversion H8. apply length_zero_iff_nil in H11. subst.
+    inversion H14. apply length_zero_iff_nil in H11. subst. 
+    inversion H15. apply length_zero_iff_nil in H11. subst.
+    inversion H12. apply length_zero_iff_nil in H11. subst.
+    auto.
+  * intros. inversion H3.
+    pose (EE1 := element_exist Expression (length kl) vl H18).
+    inversion EE1 as [ve]. inversion H17 as [ves]. subst.
     case_eq (length vvals); case_eq (length vvals0).
-    - intros. apply length_zero_iff_nil in H4. apply length_zero_iff_nil in H10. subst.
-      apply length_zero_iff_nil in H5. apply length_zero_iff_nil in H11.
-      apply length_zero_iff_nil in H13. apply length_zero_iff_nil in H7. subst. auto.
-    - intros. rewrite H4, H10 in *.
+    - intros.
+      apply length_zero_iff_nil in H4.
+      apply length_zero_iff_nil in H11. subst.
+      apply length_zero_iff_nil in H5.
       apply length_zero_iff_nil in H7.
-      pose (EE2 := element_exist SideEffectList _ eff7 (eq_sym H13)). inversion EE2. inversion H17. subst.
-      inversion H13. pose (EE3 := element_exist SideEffectList _ x0 (eq_sym H18)). inversion EE3. inversion H7.
+      apply length_zero_iff_nil in H8.
+      apply length_zero_iff_nil in H12.
+      apply length_zero_iff_nil in H14.
+      apply length_zero_iff_nil in H15.
+      subst. auto.
+    - intros. rewrite H4, H11 in *.
+      apply length_zero_iff_nil in H7.
+      pose (EE2 := element_exist SideEffectList _ eff7 (eq_sym H14)).
+      inversion EE2. inversion H19. subst.
+      inversion H14. 
+      pose (EE3 := element_exist SideEffectList _ x0 (eq_sym H20)). 
+      inversion EE3. inversion H7.
       subst.
-      pose (P1 := H8 0 (Nat.lt_0_succ n)). pose (P2 := H9 0 (Nat.lt_0_succ n)). simpl in P1, P2.
-      pose (P3 := H1 _ _ P1). inversion P3.
-      inversion H19. rewrite concatn_app in H20. simpl_concatn_H H20. apply app_inv_head in H20. subst.
+      pose (P1 := H9 0 (Nat.lt_0_succ n)).
+      pose (P2 := H10 0 (Nat.lt_0_succ n)). simpl in P1, P2.
+      apply length_zero_iff_nil in H8. subst.
+      pose (P3 := H1 _ _ _ P1). inversion P3.
+      inversion H8. destruct H21. rewrite concatn_app in H21. simpl_concatn_H H21. apply app_inv_head in H21. simpl in H22. subst.
       simpl_concatn_H H2. simpl_concatn_H P2.
-      pose (P4 := H2 _ _ P2). inversion P4. inversion H20.
-    - intros. rewrite H4, H10 in *. simpl_concatn_H H14.
-      inversion H14. 2: inversion H17.
+      pose (P4 := H2 _ _ _ P2). inversion P4. inversion H21.
+    - intros. rewrite H4, H11 in *. simpl_concatn_H H16.
+      inversion H16.
       (** KEY EXCEPTION *)
         + pose (P2 := H 0 (Nat.lt_0_succ n) (inr ex0) (eff1 ++ eff5)).
-          simpl_concatn_H P2. pose (P3 := P2 H17). inversion P3. inversion H18.
+          apply length_zero_iff_nil in H15. subst.
+          simpl_concatn_H P2. pose (P3 := P2 _ H19). inversion P3. inversion H15.
       (** VALUE EXCEPTION *)
-        + pose (P2 := H 0 (Nat.lt_0_succ n) (inl val0) (eff1 ++ eff5)). simpl_concatn_H P2.
-          inversion H17. pose (P3 := P2 H18).
-          inversion P3.
-          pose (P4 := H0 0 (Nat.lt_0_succ n) (inr ex0) (eff1 ++ eff5 ++ eff6)). simpl in P4.
-          inversion P3.
-          assert (concatn eff1 eff 1 = eff1 ++ eff5). { simpl_concatn. exact H23. }
-          rewrite H26 in P4. rewrite <- app_assoc in H19. pose (P5 := P4 H19). inversion P5. inversion H27.
+        + pose (P2 := H 0 (Nat.lt_0_succ n) (inl val0) (eff1 ++ eff5)).
+          apply length_zero_iff_nil in H15. subst.
+          simpl_concatn_H P2.
+          destruct H19. pose (P3 := P2 _ H15).
+          inversion P3. destruct H21. subst.
+          pose (P4 := H0 0 (Nat.lt_0_succ n) (inr ex0) (eff1 ++ eff5 ++ eff6)).
+          simpl in P4.
+          assert (concatn eff1 eff 1 = eff1 ++ eff5).
+          { simpl_concatn. exact H21. }
+          rewrite H22 in P4. rewrite <- app_assoc in H19. pose (P5 := P4 _ H19). inversion P5. inversion H23.
 
-    - intros. rewrite H4, H10 in *. simpl in H7, H13.
-      pose (EE2 := element_exist Value _ kvals0 (eq_sym H11)).
-      pose (EE3 := element_exist Value _ vvals0 (eq_sym H4)).
-      pose (EE4 := element_exist Value _ kvals (eq_sym H5)).
-      pose (EE5 := element_exist Value _ vvals (eq_sym H10)).
+    - intros. rewrite H4, H11 in *.
+      pose (EE2 := element_exist Value n kvals0 (eq_sym H12)).
+      pose (EE3 := element_exist Value n vvals0 (eq_sym H4)).
+      pose (EE4 := element_exist Value n0 kvals (eq_sym H5)).
+      pose (EE5 := element_exist Value n0 vvals (eq_sym H11)).
       pose (EE6 := element_exist SideEffectList _ eff (eq_sym H7)).
-      pose (EE7 := element_exist SideEffectList _ eff7 (eq_sym H13)).
-      inversion EE2 as [kv']. inversion EE3 as [vv']. inversion EE4 as [kv]. inversion EE5 as [vv].
-      inversion EE6 as [e1]. inversion EE7 as [e1'].
-      inversion H17. inversion H18. inversion H19. inversion H20. inversion H21. inversion H22. subst.
-      inversion H7. inversion H13.
-      pose (EE8 := element_exist SideEffectList _ x3 (eq_sym H24)).
-      pose (EE9 := element_exist SideEffectList _ x4 (eq_sym H25)).
-      inversion EE8 as [e2]. inversion EE9 as [e2']. inversion H23. inversion H26. subst.
+      pose (EE7 := element_exist SideEffectList _ eff7 (eq_sym H14)).
+      pose (EE8 := element_exist _ _ _ (eq_sym H8)).
+      pose (EE9 := element_exist _ _ _ (eq_sym H15)).
+      inversion EE2 as [kv']. inversion EE3 as [vv']. inversion EE4 as [kv]. 
+      inversion EE5 as [vv]. inversion EE6 as [e1]. inversion EE7 as [e1'].
+      inversion EE8 as [id01]. inversion EE9 as [id01'].
+      inversion H19. inversion H20. inversion H21. inversion H22.
+      inversion H23. inversion H24. inversion H25. inversion H26. subst.
+      inversion H7. inversion H14. inversion H8. inversion H15.
+      pose (EE10 := element_exist SideEffectList _ x3 (eq_sym H28)).
+      pose (EE11 := element_exist SideEffectList _ x4 (eq_sym H29)).
+      pose (EE12 := element_exist _ _ x5 (eq_sym H30)).
+      pose (EE13 := element_exist _ _ x6 (eq_sym H31)).
+      inversion EE10 as [e2]. inversion EE11 as [e2'].
+      inversion EE12 as [id02]. inversion EE13 as [id02'].
+      inversion H27. inversion H32. inversion H33. inversion H34. subst.
+      clear EE10. clear EE11. clear EE12. clear EE13.
+      clear EE6. clear EE7. clear EE8. clear EE9.
       (** FIRST ELEMENTS ARE EQUAL *)
-      pose (F1 := H8 0 (Nat.lt_0_succ n)).
-      pose (F2 := H 0 (Nat.lt_0_succ n0) _ _ F1). inversion F2. inversion H27.
-      simpl_concatn_app H28. simpl_concatn_H H28. apply app_inv_head in H28. subst.
-      pose (F3 := H9 0 (Nat.lt_0_succ n)).
-      pose (F4 := H0 0 (Nat.lt_0_succ n0) _ _ F3). inversion F4. 
-      inversion H28. simpl_concatn_app H29. simpl_concatn_H H29. 
-      apply app_inv_head in H29. subst.
+      pose (F1 := H9 0 (Nat.lt_0_succ n)).
+      pose (F2 := H 0 (Nat.lt_0_succ n0) _ _ _ F1). inversion F2. inversion H35.
+      destruct H36. simpl in H37.
+      simpl_concatn_app H36. simpl_concatn_H H36. apply app_inv_head in H36. subst.
+      pose (F3 := H10 0 (Nat.lt_0_succ n)).
+      pose (F4 := H0 0 (Nat.lt_0_succ n0) _ _ _ F3). inversion F4. 
+      inversion H36. destruct H37. simpl in H38.
+      simpl_concatn_app H37. simpl_concatn_H H37. 
+      apply app_inv_head in H37. subst.
       (** OTHER ELEMETS *)
-      assert (n0 = n /\ x1 = x /\ x2 = x0 /\ x5 = x6).
+      assert (n0 = n /\ x1 = x /\ x2 = x0 /\ x7 = x8 /\ x9 = x10).
       {
-        apply IHkl with (eff1 := eff1 ++ e1' ++ e2') (ex0 := ex0) (eff5 := eff5)
+        eapply IHkl with (eff1 := eff1 ++ e1' ++ e2') (ex0 := ex0) (eff5 := eff5)
              (eff4 := eff4) (eff2 := eff2) (val := val) (ex := ex) (vl := ves) (eff6 := eff6) (val0 := val0); auto.
-        * intros. assert (S j < S n0). { omega. } pose (P3 := H (S j) H31 v2 eff''). simpl in P3.
+        * intros. assert (S j < S n0). { omega. } pose (P3 := H (S j) H39 v2 eff''). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
-               <- app_assoc in P3. simpl in H30. rewrite Nat.add_0_r in H30.
-          pose (P4 := P3 H30). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. assert (S j < S n0). { omega. } pose (P3 := H0 (S j) H31 v2 eff''). simpl in P3.
+               <- app_assoc in P3. simpl in H38. rewrite Nat.add_0_r in H38.
+          pose (P4 := P3 _ H38). simpl. rewrite Nat.add_0_r. assumption.
+        * intros. assert (S j < S n0). { omega. } pose (P3 := H0 (S j) H39 v2 eff''). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
-               <- app_assoc in P3. simpl in H30. rewrite Nat.add_0_r in H30.
-          pose (P4 := P3 H30). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. pose (P3 := H1 v2 eff''). simpl in P3. simpl in P3.
+               <- app_assoc in P3. simpl in H38. rewrite Nat.add_0_r in H38.
+          pose (P4 := P3 _ H38). simpl. rewrite Nat.add_0_r. assumption.
+        * intros. pose (P3 := H1 v2 eff'').
+          rewrite <- last_element_equal, <- last_element_equal in P3. simpl in P3.
           rewrite concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app, <- app_assoc in P3.
-          simpl. rewrite Nat.add_0_r. simpl in H29. rewrite Nat.add_0_r in H29. apply (P3 H29).
-        * intros. pose (P3 := H2 v2 eff''). simpl in P3. simpl in P3.
+          simpl. rewrite Nat.add_0_r. simpl in H37. rewrite Nat.add_0_r in H37.
+          apply (P3 _ H37).
+        * intros. pose (P3 := H2 v2 eff''). simpl in P3.
           rewrite concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app, <- app_assoc in P3.
-          simpl in H29. rewrite Nat.add_0_r in H29. apply (P3 H29).
+          simpl in H37. rewrite Nat.add_0_r in H37. apply (P3 _ H37).
         * simpl in H6. omega.
-        * intros. assert (S j < S n). { omega. } pose (P3 := H8 (S j) H30). simpl in P3.
+        * intros. assert (S j < S n). { omega. } pose (P3 := H9 (S j) H38). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
              <- app_assoc in P3. simpl. rewrite Nat.add_0_r. assumption.
-        * intros. assert (S j < S n). { omega. } pose (P3 := H9 (S j) H30). simpl in P3.
+        * intros. assert (S j < S n). { omega. } pose (P3 := H10 (S j) H38). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
              <- app_assoc in P3. simpl. rewrite Nat.add_0_r. assumption.
         * simpl in H12. omega.
-        * simpl in H14. rewrite concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
-                            <- app_assoc in H14. simpl. rewrite Nat.add_0_r. assumption.
+        * rewrite <- last_element_equal, <- last_element_equal in H16. simpl in H16.
+          rewrite concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
+                            <- app_assoc in H16. simpl. rewrite Nat.add_0_r. exact H16.
       }
-      inversion H29. inversion H31. inversion H33. subst. auto.
-Qed.
-
-(** Map attribute restriction to shorter lists *)
-Lemma restrict_map {env : Environment} {kl : list Expression} (ves : list Expression) (eff1 : SideEffectList) 
-    (a ve : Expression) (e1' e2' : SideEffectList) (x5 : list SideEffectList) (n : nat) 
-    (eff2 : SideEffectList) (val : Value) (eff4 : SideEffectList) (ex : Exception) :
-((forall (v2 : Value + Exception) (eff'' : SideEffectList),
-        | env, nth (S n) (a :: kl) ErrorExp, concatn eff1 (e1' :: e2' :: x5) (2 * S n) | -e> | v2, eff'' | ->
-        inr ex = v2 /\ concatn eff1 (e1' :: e2' :: x5) (2 * S n) ++ eff2 = eff'') \/
-       (forall (v2 : Value + Exception) (eff'' : SideEffectList),
-        | env, nth (S n) (a :: kl) ErrorExp, concatn eff1 (e1' :: e2' :: x5) (2 * S n) | -e> | v2, eff'' | ->
-        inl val = v2 /\ concatn eff1 (e1' :: e2' :: x5) (2 * S n) ++ eff2 = eff'') /\
-       (forall (v2 : Value + Exception) (eff'' : SideEffectList),
-        | env, nth (S n) (ve :: ves) ErrorExp, concatn eff1 (e1' :: e2' :: x5) (2 * S n) ++ eff2 | -e> | v2,
-        eff'' | -> inr ex = v2 /\ eff4 = eff''))
-->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList),
- | env, nth n kl ErrorExp, concatn (eff1 ++ e1' ++ e2') x5 (2 * n) | -e> | v2, eff'' | ->
- inr ex = v2 /\ concatn (eff1 ++ e1' ++ e2') x5 (2 * n) ++ eff2 = eff'') \/
-(forall (v2 : Value + Exception) (eff'' : SideEffectList),
- | env, nth n kl ErrorExp, concatn (eff1 ++ e1' ++ e2') x5 (2 * n) | -e> | v2, eff'' | ->
- inl val = v2 /\ concatn (eff1 ++ e1' ++ e2') x5 (2 * n) ++ eff2 = eff'') /\
-(forall (v2 : Value + Exception) (eff'' : SideEffectList),
- | env, nth n ves ErrorExp, concatn (eff1 ++ e1' ++ e2') x5 (2 * n) ++ eff2 | -e> | v2, eff'' | ->
- inr ex = v2 /\ eff4 = eff'').
-Proof.
-  intros. inversion H.
-  * left. simpl in H0.
-    rewrite concatn_app, Nat.add_0_r, Nat.add_succ_r, concatn_app, <- app_assoc in H0. simpl.
-    rewrite Nat.add_0_r. exact H0.
-  * right. simpl in H0.
-    rewrite concatn_app, Nat.add_0_r, Nat.add_succ_r, concatn_app, <- app_assoc in H0.
-    simpl. rewrite Nat.add_0_r. exact H0.
+      destruct H37. destruct H38. destruct H39. destruct H40. subst. auto.
 Qed.
 
 (** Map generalised until i-th element equality *)
 Lemma map_lists_equal_until_i_key_or_val {env : Environment} {kl : list Expression} : 
 forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (i : nat) (eff1 : SideEffectList) 
-      (eff eff7 : list SideEffectList) (eff2 eff4 : SideEffectList) (val : Value) (ex : Exception),
+      (eff eff7 : list SideEffectList) (eff2 eff4 : SideEffectList) (val : Value) (ex : Exception) (ids ids0 : list nat) (id id1 id2: nat),
 (forall j : nat,
      j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | id'', v2, eff'' | ->
+     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\ nth_id ids id (S (2*j)) = id'')
 ->
 (forall j : nat,
      j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | id'', v2, eff'' | ->
+     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\ nth_id ids id (S (S (2*j))) = id'')
 ->
 (
-(forall (v2 : Value + Exception) (eff'' : SideEffectList),
-         | env, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | v2, eff'' | ->
-         inr ex = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'')
+(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+         | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | id'', v2, eff'' | ->
+         inr ex = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'' /\ id1 = id'')
 \/
-(forall (v2 : Value + Exception) (eff'' : SideEffectList),
-         | env, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | v2, eff'' | ->
-         inl val = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'')
+(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+         | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | id'', v2, eff'' | ->
+         inl val = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'' /\ id1 = id'')
 /\
-(forall (v2 : Value + Exception) (eff'' : SideEffectList),
-         | env, nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2 | -e> | v2, eff'' | ->
-         inr ex = v2 /\ eff4 = eff''))
+(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+         | env, id1, nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2 | -e> | id'', v2, eff'' | ->
+         inr ex = v2 /\ eff4 = eff'' /\ id2 = id''))
 ->
 Datatypes.length kl = Datatypes.length vl ->
 Datatypes.length vvals = i ->
 Datatypes.length kvals = i ->
 i <= Datatypes.length kl ->
 Datatypes.length eff = (i * 2)%nat ->
+Datatypes.length ids = (i * 2)%nat ->
 (forall j : nat,
       j < length vl ->
-      | env, nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | inl (nth j kvals0 ErrorValue),
+      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
       concatn eff1 eff7 (S (2 * j)) |)
 ->
 (forall j : nat,
       j < length vl ->
-      | env, nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
-      | inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
+      | env, nth_id ids0 id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
+      | nth_id ids0 id (S (S (2*j))), inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
 ->
 length kl = Datatypes.length vvals0 ->
 length kl = Datatypes.length kvals0 ->
-Datatypes.length eff7 = (length kl * 2)%nat
+Datatypes.length eff7 = (length kl * 2)%nat ->
+Datatypes.length ids0 = (length kl * 2)%nat
 ->
-i = length vl /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7.
+i = length vl /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7 /\ ids = ids0.
 Proof.
   induction kl.
-  * intros. simpl in H11. rewrite <- H11 in *. inversion H5. subst.
-    apply eq_sym, length_zero_iff_nil in H9.
-    apply eq_sym, length_zero_iff_nil in H10.
+  * intros. simpl in *. subst. inversion H5.
     apply eq_sym, length_zero_iff_nil in H2.
-    apply length_zero_iff_nil in H12.
-    apply length_zero_iff_nil in H11.
+    apply eq_sym, length_zero_iff_nil in H10.
+    apply eq_sym, length_zero_iff_nil in H11.
     subst.
-    simpl in H4, H6.
-    apply length_zero_iff_nil in H4.
+    apply length_zero_iff_nil in H12.
+    apply length_zero_iff_nil in H13.
+    apply length_zero_iff_nil in H14.
+    subst.
     apply length_zero_iff_nil in H6.
+    apply length_zero_iff_nil in H7.
+    apply length_zero_iff_nil in H4.
     subst. auto.
   * intros. inversion H2.
-    pose (EE1 := element_exist Expression (length kl) vl H13). inversion EE1 as [ve]. inversion H12 as [ves]. subst.
+    pose (EE1 := element_exist Expression (length kl) vl H15).
+    inversion EE1 as [ve]. inversion H14 as [ves]. subst.
     case_eq (length vvals).
     - intros. apply length_zero_iff_nil in H3. subst. simpl length in *.
+      apply length_zero_iff_nil in H6.
+      apply length_zero_iff_nil in H7.
       apply length_zero_iff_nil in H4. subst.
-      pose (E1 := H7 0 (Nat.lt_0_succ (length ves))).
-      pose (E2 := H8 0 (Nat.lt_0_succ (length ves))).
+      pose (E1 := H8 0 (Nat.lt_0_succ (length ves))).
+      pose (E2 := H9 0 (Nat.lt_0_succ (length ves))).
     (** CASE SEPARATION, KEY EXCEPTION OR VALUE EXCEPTION HAPPENED *)
       inversion H1.
-      + pose (P1 := H3 _ _ E1). inversion P1. inversion H4.
-      + inversion H3. pose (P1 := H4 _ _ E1). inversion P1. inversion H15.
-        rewrite <- H16 in E2.
-        pose (P2 := H14 _ _ E2). inversion P2. inversion H17.
+      + pose (P1 := H3 _ _ _ E1). inversion P1. inversion H4.
+      + inversion H3. pose (P1 := H4 _ _ _ E1). inversion P1. inversion H7. destruct H16.
+        rewrite <- H16 in E2. subst.
+        pose (P2 := H6 _ _ _ E2). inversion P2. inversion H17.
 
-    - intros. rewrite H3 in *. simpl mult in H11, H6. simpl length in *.
-      pose (EE2 := element_exist Value _ kvals0 H10).
-      pose (EE3 := element_exist Value _ vvals0 H9).
+    - intros. rewrite H3 in *.
+      pose (EE2 := element_exist Value _ kvals0 H11).
+      pose (EE3 := element_exist Value _ vvals0 H10).
       pose (EE4 := element_exist Value _ kvals (eq_sym H4)).
       pose (EE5 := element_exist Value _ vvals (eq_sym H3)).
       pose (EE6 := element_exist SideEffectList _ eff (eq_sym H6)).
-      pose (EE7 := element_exist SideEffectList _ eff7 (eq_sym H11)).
-      inversion EE2 as [kv']. inversion EE3 as [vv']. inversion EE4 as [kv]. inversion EE5 as [vv].
-      inversion EE6 as [e1]. inversion EE7 as [e1']. inversion H14. inversion H15. inversion H16. inversion H17. 
-      inversion H18. inversion H19. subst.
-      inversion H6. inversion H11.
-      pose (EE8 := element_exist SideEffectList _ x3 (eq_sym H21)).
-      pose (EE9 := element_exist SideEffectList _ x4 (eq_sym H22)).
-      inversion EE8 as [e2]. inversion EE9 as [e2']. inversion H20. inversion H23. subst.
+      pose (EE7 := element_exist SideEffectList _ eff7 (eq_sym H12)).
+      pose (EE8 := element_exist nat _ _ (eq_sym H7)).
+      pose (EE9 := element_exist nat _ _ (eq_sym H13)).
+      inversion EE2 as [kv']. inversion EE3 as [vv']. inversion EE4 as [kv]. 
+      inversion EE5 as [vv]. inversion EE6 as [e1]. inversion EE7 as [e1']. 
+      inversion EE8 as [id01]. inversion EE9 as [id01'].
+      inversion H16. inversion H17. inversion H18. inversion H19. 
+      inversion H20. inversion H21. inversion H22. inversion H23. subst.
+
+      inversion H6. inversion H12. inversion H7. inversion H13.
+      pose (EE10 := element_exist SideEffectList _ _ (eq_sym H25)).
+      pose (EE11 := element_exist SideEffectList _ _ (eq_sym H26)).
+      pose (EE12 := element_exist _ _ _ (eq_sym H27)).
+      pose (EE13 := element_exist _ _ _ (eq_sym H28)).
+      inversion EE10 as [e2]. inversion EE11 as [e2']. inversion EE12 as [id02]. inversion EE13 as [id02'].
+      inversion H24. inversion H29. inversion H30. inversion H31. subst.
       (** FIRST ELEMENTS ARE EQUAL *)
-      pose (F1 := H7 0 (Nat.lt_0_succ (length ves))).
-      pose (F2 := H 0 (Nat.lt_0_succ n) _ _ F1). inversion F2. inversion H24.
-      rewrite concatn_app, concatn_app in H25. simpl_concatn_H H25. apply app_inv_head in H25. subst.
-      pose (F3 := H8 0 (Nat.lt_0_succ (length ves))).
-      pose (F4 := H0 0 (Nat.lt_0_succ n) _ _ F3). inversion F4. inversion H25.
-      rewrite concatn_app, concatn_app in H26. simpl_concatn_H H26. apply app_inv_head in H26. subst.
+      pose (F1 := H8 0 (Nat.lt_0_succ (length ves))).
+      pose (F2 := H 0 (Nat.lt_0_succ n) _ _ _ F1). inversion F2. inversion H32.
+      destruct H33. simpl in H34.
+      rewrite concatn_app, concatn_app in H33. simpl_concatn_H H33. apply app_inv_head in H33. subst.
+      pose (F3 := H9 0 (Nat.lt_0_succ (length ves))).
+      pose (F4 := H0 0 (Nat.lt_0_succ n) _ _ _ F3). inversion F4. inversion H33.
+      destruct H34. simpl in H35.
+      rewrite concatn_app, concatn_app in H34. simpl_concatn_H H34. apply app_inv_head in H34. subst.
+      clear EE10. clear EE11. clear EE12. clear EE13.
+      clear EE6. clear EE7. clear EE8. clear EE9. clear EE2. clear EE3.
       (** OTHER ELEMETS *)
-      assert (n = length ves /\ x1 = x /\ x2 = x0 /\ x5 = x6).
+      assert (n = length ves /\ x1 = x /\ x2 = x0 /\ x7 = x8 /\ x9 = x10).
       {
         apply IHkl with (eff1 := eff1 ++ e1' ++ e2') (eff4 := eff4) (eff2 := eff2)
-                (val := val) (ex := ex) (vl := ves); auto.
+                (val := val) (ex := ex) (vl := ves) (id := id02') (id1 := id1) (id2 := id2); auto; clear IHkl.
         * intros. assert (S j < S n). { omega. }
-          pose (P3 := H (S j) H28 v2 eff''). simpl in P3.
+          pose (P3 := H (S j) H36 v2 eff''). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
-              <- app_assoc in P3. simpl in H27. rewrite Nat.add_0_r in H27.
-          pose (P4 := P3 H27). simpl. rewrite Nat.add_0_r. assumption.
+              <- app_assoc in P3. simpl in H35. rewrite Nat.add_0_r in H35.
+          pose (P4 := P3 _ H35). simpl. rewrite Nat.add_0_r. assumption.
         * intros. assert (S j < S n). { omega. }
-          pose (P3 := H0 (S j) H28 v2 eff''). simpl in P3.
+          pose (P3 := H0 (S j) H36 v2 eff''). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
-              <- app_assoc in P3. simpl in H27. rewrite Nat.add_0_r in H27.
-          pose (P4 := P3 H27). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. apply restrict_map in H1. assumption.
+              <- app_assoc in P3. simpl in H35. rewrite Nat.add_0_r in H35.
+          pose (P4 := P3 _ H35). simpl. rewrite Nat.add_0_r. assumption.
+        * intros. destruct H1 as [Def| Def'].
+          - left. intros. simpl mult in Def, H1. simpl mult. rewrite concatn_app, Nat.add_0_r, Nat.add_succ_r, concatn_app, <- app_assoc in Def. rewrite Nat.add_0_r. rewrite Nat.add_0_r in H1. apply Def.
+            rewrite <- last_element_equal, <- last_element_equal. simpl. assumption.
+          - right. simpl mult in Def'. rewrite concatn_app, Nat.add_0_r, Nat.add_succ_r, concatn_app, <- app_assoc, <- last_element_equal, <- last_element_equal in Def'. simpl in Def'. inversion Def'.
+            split.
+            + intros. simpl mult. rewrite Nat.add_0_r. apply H1. simpl mult in H35. rewrite Nat.add_0_r in H35. assumption.
+            + intros. apply H34. simpl mult in H35. rewrite Nat.add_0_r in H35. assumption.
+
         * simpl in H5. omega.
-        * intros. assert (S j < S (length ves)). { omega. } pose (P3 := H7 (S j) H27).
+        * intros. assert (S j < S (length ves)). { omega. } pose (P3 := H8 (S j) H35).
           simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm,
              concatn_app, <- app_assoc in P3. simpl. rewrite Nat.add_0_r. assumption.
         * intros. assert (S j < S (length ves)). { omega. }
-          pose (P3 := H8 (S j) H27). simpl in P3. 
+          pose (P3 := H9 (S j) H35). simpl in P3. 
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm,
                concatn_app, <- app_assoc in P3. simpl. rewrite Nat.add_0_r. assumption.
       }
-      inversion H26. inversion H28. inversion H30. subst. auto.
+      destruct H34. destruct H35. destruct H36. destruct H37. subst. auto.
 Qed.
-*)
+
 End Core_Erlang_Determinism_Helpers.

--- a/Core_Erlang_Determinism_Helpers.v
+++ b/Core_Erlang_Determinism_Helpers.v
@@ -202,56 +202,56 @@ Proof.
     inversion IH. inversion H37. subst. auto.
 Qed.
 
-(* Proposition nat_ge_or : forall {n m : nat}, n >= m <-> n = m \/ n > m.
+Proposition nat_ge_or : forall {n m : nat}, n >= m <-> n = m \/ n > m.
 Proof.
-intros. omega.
+  intros. omega.
 Qed.
 
 (** Based on determinism hypotheses, the same clause was chosen in case evaluation *)
 Lemma index_case_equality {env : Environment} {patterns : list Pattern} 
     {guards bodies : list Expression} {v0 : Value} (i i0 : nat) 
     (guard guard0 exp exp0 : Expression) (bindings bindings0 : list (Var * Value)) 
-    (eff1 : SideEffectList) : 
+    (eff1 : SideEffectList) (id' : nat) : 
   (forall j : nat,
      j < i ->
      forall (gg ee : Expression) (bb : list (Var * Value)),
      match_clause v0 patterns guards bodies j = Some (gg, ee, bb) ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | add_bindings bb env, gg, eff1 | -e> | v2, eff'' | ->
-     inl ffalse = v2 /\ eff1 = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | add_bindings bb env, id', gg, eff1 | -e> | id'', v2, eff'' | ->
+     inl ffalse = v2 /\ eff1 = eff'' /\ id' = id'')
   ->
   (forall j : nat,
       j < i0 ->
       forall (gg ee : Expression) (bb : list (Var * Value)),
       match_clause v0 patterns guards bodies j = Some (gg, ee, bb) ->
-      | add_bindings bb env, gg, eff1 | -e> | inl ffalse, eff1 |)
+      | add_bindings bb env, id', gg, eff1 | -e> | id', inl ffalse, eff1 |)
   ->
   match_clause v0 patterns guards bodies i = Some (guard, exp, bindings)
   ->
   match_clause v0 patterns guards bodies i0 = Some (guard0, exp0, bindings0)
   ->
-  | add_bindings bindings0 env, guard0, eff1 | -e> | inl ttrue, eff1 |
+  | add_bindings bindings0 env, id', guard0, eff1 | -e> | id', inl ttrue, eff1 |
   ->
-  | add_bindings bindings env, guard, eff1 | -e> | inl ttrue, eff1 |
+  | add_bindings bindings env, id', guard, eff1 | -e> | id', inl ttrue, eff1 |
   ->
-  (forall (v2 : Value + Exception) (eff'' : SideEffectList),
-         | add_bindings bindings env, guard, eff1 | -e> | v2, eff'' | ->
-         inl ttrue = v2 /\ eff1 = eff'')
+  (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+         | add_bindings bindings env, id', guard, eff1 | -e> | id'', v2, eff'' | ->
+         inl ttrue = v2 /\ eff1 = eff'' /\ id' = id'')
 ->
   i = i0.
 Proof.
   intros. pose (D := Nat.lt_decidable i i0). destruct D.
-  * pose (P1 := H0 i H6 guard exp bindings H1). pose (P2 := H5 (inl ffalse) _ P1). 
+  * pose (P1 := H0 i H6 guard exp bindings H1). pose (P2 := H5 (inl ffalse) _ _ P1). 
     inversion P2. inversion H7.
   * apply not_lt in H6. apply (nat_ge_or) in H6. inversion H6.
     - assumption.
-    - pose (P3 := H i0 H7 guard0 exp0 bindings0 H2 (inl ttrue) _ H3). inversion P3. inversion H8.
+    - pose (P3 := H i0 H7 guard0 exp0 bindings0 H2 (inl ttrue) _ _ H3). inversion P3. inversion H8.
 Qed.
 
 (** Based on determinism, until the i-th element, the side effects are equal *)
 Lemma firstn_eq {env : Environment} {eff : list SideEffectList} : 
 forall (eff5 : list SideEffectList) (exps : list Expression) (vals vals0 : list Value) 
-   (eff1 : SideEffectList),
+   (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat),
 length exps = length vals ->
 Datatypes.length exps = Datatypes.length eff
 ->
@@ -259,98 +259,119 @@ Datatypes.length eff5 = Datatypes.length vals0
 ->
 Datatypes.length vals0 < Datatypes.length exps 
 ->
+length exps = length ids
+->
+length ids0 = length vals0
+->
 (forall i : nat,
      i < Datatypes.length exps ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth i exps ErrorExp, concatn eff1 eff i | -e> | v2, eff'' | ->
-     inl (nth i vals ErrorValue) = v2 /\ concatn eff1 eff (S i) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id i, nth i exps ErrorExp, concatn eff1 eff i | -e> | id'', v2, eff'' | ->
+     inl (nth i vals ErrorValue) = v2 /\ concatn eff1 eff (S i) = eff'' /\ nth_id ids id (S i) = id'')
 ->
 (forall j : nat,
      j < Datatypes.length vals0 ->
-     | env, nth j exps ErrorExp, concatn eff1 eff5 j | -e> | inl (nth j vals0 ErrorValue),
+     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff5 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
      concatn eff1 eff5 (S j) |)
 ->
 firstn (Datatypes.length vals0) eff5 = firstn (Datatypes.length vals0) eff.
 Proof.
   induction eff.
-  * intros. inversion H0. rewrite H6 in H2. inversion H2.
+  * intros. inversion H0. rewrite H8 in H2. inversion H2.
   * intros. destruct eff5.
     - inversion H1. simpl. reflexivity.
     - inversion H1. simpl.
     (* first elements *)
-      inversion H0. assert (0 < length exps). { omega. } assert (0 < length vals0). { omega. }
+      inversion H0.
+      assert (0 < length exps). { omega. }
+      assert (0 < length vals0). { omega. }
+      assert (0 < length ids0). { omega. }
       simpl in H0, H1.
       (* single_unfold_list H1. *)
-      pose (EE1 := element_exist Expression (length eff) exps (eq_sym H7)).
-      pose (EE2 := element_exist Value (length eff5) vals0 H1).
+      assert (Datatypes.length exps = S (Datatypes.length eff)) as Helper. { auto. }
+      assert (Datatypes.length ids0 = Datatypes.length vals0) as Helper2. { auto. }
+      assert (Datatypes.length exps = Datatypes.length ids) as Helper3. { auto. }
+      pose (EE1 := element_exist _ _ _ (eq_sym H9)).
+      pose (EE2 := element_exist _ _ _ H1).
       rewrite H in H0.
-      pose (EE3 := element_exist Value (length eff) vals (eq_sym H0)). 
-      inversion EE1 as [e]. inversion EE2 as [v]. inversion EE3 as [v']. 
-      inversion H10. inversion H9. inversion H11. subst.
-      pose (P0 := H4 0 H8). simpl_concatn_H P0.
-      pose (P1 := H3 0 H5 (inl v) (eff1 ++ s ++ [])). simpl_concatn_H P1.
-      pose (P2 := P1 P0). destruct P2. apply app_inv_head in H13. subst.
+      pose (EE3 := element_exist _ _ _ (eq_sym H0)).
+      rewrite <- H1 in H4. rewrite H9 in H3.
+      pose (EE4 := element_exist _ _ _ H3).
+      pose (EE5 := element_exist _ _ _ (eq_sym H4)).
+      inversion EE1 as [e]. inversion EE2 as [v]. inversion EE3 as [v'].
+      inversion EE4 as [id']. inversion EE5 as [id'']. 
+      inversion H12. inversion H13. inversion H14. inversion H15. inversion H16. subst.
+      pose (P0 := H6 0 H10). simpl_concatn_H P0.
+      pose (P1 := H5 0 H7 (inl v) (eff1 ++ s ++ [])). simpl_concatn_H P1.
+      pose (P2 := P1 _ P0). destruct P2. destruct H18. apply app_inv_head in H18. subst.
     (* other elements *)
-      inversion H1. rewrite H14.
-      assert (firstn (Datatypes.length x) eff5 = firstn (Datatypes.length x) eff).
+      inversion H1.
+      assert (firstn (Datatypes.length x0) eff5 = firstn (Datatypes.length x0) eff).
       {
-        apply IHeff with (exps := x0) (vals := x1) (eff1 := eff1 ++ s); auto.
+        apply IHeff with (exps := x) (vals := x1) (eff1 := eff1 ++ s) (ids := x2) (ids0 := x3) (id := id''); auto.
         - intuition.
-        - intros. assert (S i < Datatypes.length (e :: x0)). { simpl. omega. } 
-          pose (A := H3 (S i) H16 v2 eff''). rewrite concatn_app, concatn_app in A. simpl in A. 
-          pose (B := A H15). assumption.
-        - intros. assert (S j < Datatypes.length (v :: x)). { omega. } 
-          pose (A := H4 (S j) H15). 
+        - intros. assert (S i < Datatypes.length (e :: x)). { simpl. omega. }
+          pose (A := H5 (S i) H21 v2 eff''). rewrite concatn_app, concatn_app in A. simpl in A. 
+          pose (B := A _ H20). assumption.
+        - intros. assert (S j < Datatypes.length (v :: x0)). { omega. } 
+          pose (A := H6 (S j) H20). 
           rewrite concatn_app, concatn_app in A. simpl in A. exact A.
       }
-      rewrite H13. reflexivity.
+      rewrite <- H19 in H18. rewrite H18. reflexivity.
 Qed.
 
 (** Side effect equality until the ith element using concatn *)
-Lemma eff_until_i {env : Environment} {exps : list Expression} (vals vals0 : list Value) 
-     (eff1 : SideEffectList) (eff eff5 : list SideEffectList) :
+Lemma eff_until_i {env : Environment} {eff : list SideEffectList} : 
+forall (eff5 : list SideEffectList) (exps : list Expression) (vals vals0 : list Value) 
+   (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat),
 length exps = length vals ->
 Datatypes.length exps = Datatypes.length eff
 ->
 Datatypes.length eff5 = Datatypes.length vals0
 ->
-Datatypes.length vals0 < Datatypes.length exps
+Datatypes.length vals0 < Datatypes.length exps 
+->
+length exps = length ids
+->
+length ids0 = length vals0
 ->
 (forall i : nat,
      i < Datatypes.length exps ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth i exps ErrorExp, concatn eff1 eff i | -e> | v2, eff'' | ->
-     inl (nth i vals ErrorValue) = v2 /\ concatn eff1 eff (S i) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id i, nth i exps ErrorExp, concatn eff1 eff i | -e> | id'', v2, eff'' | ->
+     inl (nth i vals ErrorValue) = v2 /\ concatn eff1 eff (S i) = eff'' /\ nth_id ids id (S i) = id'')
 ->
 (forall j : nat,
      j < Datatypes.length vals0 ->
-     | env, nth j exps ErrorExp, concatn eff1 eff5 j | -e> | inl (nth j vals0 ErrorValue),
-     concatn eff1 eff5 (S j) |) 
+     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff5 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
+     concatn eff1 eff5 (S j) |)
 ->
   concatn eff1 eff5 (Datatypes.length vals0) = concatn eff1 eff (Datatypes.length vals0).
 Proof.
-  intros. simpl_concatn. rewrite (firstn_eq eff5 exps vals vals0 eff1 H H0 H1 H2 H3 H4). reflexivity.
+  intros. simpl_concatn. rewrite (firstn_eq eff5 exps vals vals0 _ _ _ _ H H0 H1 H2 H3 H4 H5 H6). reflexivity.
 Qed.
 
 (** First i elements are equal, but with changed hypotheses *)
 Lemma firstn_eq_rev {env : Environment} {eff : list SideEffectList} : 
    forall (eff5 : list SideEffectList) (exps : list Expression) (vals vals0 : list Value) 
-          (eff1 : SideEffectList),
+          (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat),
 (forall j : nat,
      j < Datatypes.length vals ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j exps ErrorExp, concatn eff1 eff j | -e> | v2, eff'' | ->
-     inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id j, nth j exps ErrorExp, concatn eff1 eff j | -e> | id'', v2, eff'' | ->
+     inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'' /\ nth_id ids id (S j) = id'')
 ->
 (forall i : nat,
      i < Datatypes.length exps ->
-     | env, nth i exps ErrorExp, concatn eff1 eff5 i | -e> | inl (nth i vals0 ErrorValue),
+     | env, nth_id ids0 id i, nth i exps ErrorExp, concatn eff1 eff5 i | -e> | nth_id ids0 id (S i), inl (nth i vals0 ErrorValue),
      concatn eff1 eff5 (S i) |)
 ->
 Datatypes.length vals < Datatypes.length exps ->
 Datatypes.length eff = Datatypes.length vals ->
 Datatypes.length exps = Datatypes.length vals0 ->
-Datatypes.length exps = Datatypes.length eff5
+Datatypes.length exps = Datatypes.length eff5 ->
+length exps = length ids0 ->
+length ids = length vals
 ->
 firstn (Datatypes.length vals) eff5 = firstn (Datatypes.length vals) eff.
 Proof.
@@ -364,53 +385,63 @@ Proof.
       assert (S (Datatypes.length eff5) = Datatypes.length exps).
       { auto. }
       assert (Datatypes.length exps = Datatypes.length vals0) as LENGTH. { auto. }
+      assert (S (Datatypes.length eff) = Datatypes.length vals) as Helper1. { auto. }
+      assert (Datatypes.length exps = Datatypes.length ids0) as Helper2. { auto. }
       (* single_unfold_list H9. *)
-      pose (EE1 := element_exist Expression (length eff5) exps (eq_sym H7)).
-      pose (EE2 := element_exist Value (length eff) vals H6).
-      rewrite <- H9 in H3.
+      pose (EE1 := element_exist Expression (length eff5) exps (eq_sym H4)).
+      pose (EE2 := element_exist Value (length eff) vals H8).
+      rewrite H4 in H3, H5. rewrite <- H8 in H6.
       pose (EE3 := element_exist Value (length eff5) vals0 H3).
-      inversion EE1 as [e]. inversion EE2 as [v]. inversion EE3 as [v']. 
-      inversion H10. inversion H12. inversion H11. subst.
-      pose (P0 := H0 0 H5). simpl_concatn_H P0.
-      pose (P1 := H 0 H8 (inl v') (eff1 ++ s ++ [])). simpl_concatn_H P1.
-      pose (P2 := P1 P0). destruct P2. apply app_inv_head in H14. subst.
+      pose (EE4 := element_exist _ _ _ (eq_sym H6)).
+      pose (EE5 := element_exist _ _ _ H5).
+
+      inversion EE1 as [e]. inversion EE2 as [v]. inversion EE3 as [v'].
+      inversion EE4 as [id']. inversion EE5 as [id'']. 
+      inversion H12. inversion H13. inversion H14. inversion H15. inversion H16. subst.
+      pose (P0 := H0 0 H7). simpl_concatn_H P0.
+      pose (P1 := H 0 H10 (inl v') (eff1 ++ s ++ [])). simpl_concatn_H P1.
+      pose (P2 := P1 _ P0). destruct P2. destruct H18. apply app_inv_head in H18. inversion H17. subst.
     (* other elements *)
-      inversion H2. rewrite H15.
-      assert (firstn (Datatypes.length x1) eff5 = firstn (Datatypes.length x1) eff).
+      inversion H2.
+      assert (firstn (Datatypes.length x0) eff5 = firstn (Datatypes.length x0) eff).
       {
-        apply IHeff with (exps := x) (vals := x1) (eff1 := eff1 ++ s) (vals0 := x0); auto.
-        - intros. assert (S j < Datatypes.length (v :: x1)). { simpl. omega. } 
-          pose (A := H (S j) H17 v2 eff''). rewrite concatn_app, concatn_app in A. simpl in A. 
-          pose (B := A H16). assumption.
+        apply IHeff with (exps := x) (vals := x0) (eff1 := eff1 ++ s) (vals0 := x1) (ids := x2) (ids0 := x3) (id := id''); auto.
+        - intros. assert (S j < Datatypes.length (v' :: x0)). { simpl. omega. } 
+          pose (A := H (S j) H21 v2 eff''). rewrite concatn_app, concatn_app in A. simpl in A. 
+          pose (B := A _ H20). assumption.
         - intros. assert (S i < Datatypes.length (e :: x)). { simpl. omega. } 
-          pose (A := H0 (S i) H16). rewrite concatn_app, concatn_app in A. simpl in A. exact A.
+          pose (A := H0 (S i) H20). rewrite concatn_app, concatn_app in A. simpl in A. exact A.
         - intuition.
+        - inversion H6. omega.
       }
-      rewrite H14. reflexivity.
+      rewrite <- H19 in H18. rewrite H18. reflexivity.
 Qed.
 
 (** First i (length vals) element are equal with concatn *)
-Lemma eff_until_i_rev {env : Environment} {eff1 : SideEffectList} {eff : list SideEffectList} : 
-   forall (exps : list Expression) (vals vals0 : list Value) (eff5 : list SideEffectList),
+Lemma eff_until_i_rev {env : Environment} {eff : list SideEffectList} : 
+   forall (eff5 : list SideEffectList) (exps : list Expression) (vals vals0 : list Value) 
+          (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat),
 (forall j : nat,
      j < Datatypes.length vals ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j exps ErrorExp, concatn eff1 eff j | -e> | v2, eff'' | ->
-     inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id j, nth j exps ErrorExp, concatn eff1 eff j | -e> | id'', v2, eff'' | ->
+     inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'' /\ nth_id ids id (S j) = id'')
 ->
 (forall i : nat,
      i < Datatypes.length exps ->
-     | env, nth i exps ErrorExp, concatn eff1 eff5 i | -e> | inl (nth i vals0 ErrorValue),
+     | env, nth_id ids0 id i, nth i exps ErrorExp, concatn eff1 eff5 i | -e> | nth_id ids0 id (S i), inl (nth i vals0 ErrorValue),
      concatn eff1 eff5 (S i) |)
 ->
 Datatypes.length vals < Datatypes.length exps ->
 Datatypes.length eff = Datatypes.length vals ->
 Datatypes.length exps = Datatypes.length vals0 ->
-Datatypes.length exps = Datatypes.length eff5
+Datatypes.length exps = Datatypes.length eff5 ->
+length exps = length ids0 ->
+length ids = length vals
 ->
 concatn eff1 eff5 (Datatypes.length vals) = concatn eff1 eff (Datatypes.length vals).
 Proof.
-  intros. simpl_concatn. rewrite (firstn_eq_rev eff5 exps vals vals0 eff1 H H0 H1 H2 H3 H4). 
+  intros. simpl_concatn. rewrite (firstn_eq_rev eff5 exps vals vals0 eff1 _ _ _ H H0 H1 H2 H3 H4 H5 H6). 
   reflexivity.
 Qed.
 
@@ -421,19 +452,31 @@ Proof.
   * apply ex_intro with m0. reflexivity.
 Qed.
 
+Theorem last_element_equal {A : Type} (l : list A) (def def2 : A):
+  last l def = last (def :: l) def2.
+Proof.
+  induction l.
+  * auto.
+  * simpl. rewrite IHl. simpl. destruct l; auto.
+Qed.
+
 (** First i element are equal with concatn *)
 Lemma con_n_equality {env : Environment} {eff : list SideEffectList} : 
-  forall (exps : list Expression) (vals vals0 : list Value) eff1 eff6 i i0,
+  forall (exps : list Expression) (vals vals0 : list Value) eff1 eff6 i i0 ids ids0 id eff3 id' ex,
 (forall j : nat,
     j < i ->
-    forall (v2 : Value + Exception) (eff'' : SideEffectList),
-    | env, nth j exps ErrorExp, concatn eff1 eff j | -e> | v2, eff'' | ->
-    inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'')
+    forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+    | env, nth_id ids id j, nth j exps ErrorExp, concatn eff1 eff j | -e> | id'', v2, eff'' | ->
+    inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'' /\ nth_id ids id (S j) = id'')
 ->
 (forall j : nat,
      j < i0 ->
-     | env, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | inl (nth j vals0 ErrorValue),
+     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
      concatn eff1 eff6 (S j) |)
+->
+(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, last ids id, nth i exps ErrorExp, concatn eff1 eff i | -e> | id'', v2, eff'' | ->
+     inr ex = v2 /\ eff3 = eff'' /\ id' = id'')
 ->
 Datatypes.length eff = i ->
 i < Datatypes.length exps ->
@@ -441,37 +484,51 @@ Datatypes.length vals = i ->
 Datatypes.length vals0 = i0 ->
 i0 < Datatypes.length exps ->
 Datatypes.length eff6 = i0 ->
+length ids = i ->
+length ids0 = i0 ->
 i < i0
 ->
-concatn eff1 eff6 i = concatn eff1 eff i.
+False.
 Proof.
   induction eff.
-  * intros. simpl in H1. subst. simpl_concatn. reflexivity.
-  * intros. inversion H1. simpl in H1. rewrite <- H1 in H3.
-    pose (EE1 := element_exist Value (length eff) vals (eq_sym H3)). 
-    inversion EE1 as [v]. inversion H9 as [vs]. destruct eff6.
-    - simpl in H6. subst. rewrite <- H6 in H7. inversion H7.
-    - subst. simpl. simpl_concatn_H IHeff. rewrite concatn_app, concatn_app. simpl_concatn.
-      simpl in H6. (* single_unfold_list H6. *) 
-      pose (EE2 := element_exist Value (length eff6) vals0 H6). inversion EE2. 
-      inversion H1.
-      pose (nat_exist H2). inversion e.
-      pose (EE3 := element_exist Expression x1 exps (eq_sym H10)). inversion EE3. inversion H11.
-      assert (s = a). {
+  * intros. simpl in H1. subst. simpl in H10. pose (P := H0 0 H10).
+    simpl in H8, P. apply length_zero_iff_nil in H8. subst.
+    pose (P2 := H1 _ _ _ P). inversion P2. congruence.
+  * intros. inversion H2. simpl in H2. rewrite <- H2 in H4.
+    pose (EE1 := element_exist Value (length eff) vals (eq_sym H4)). 
+    inversion EE1 as [v]. inversion H12 as [vs]. destruct eff6.
+    - simpl in H7. subst. rewrite <- H7 in H10. inversion H10.
+    - subst. simpl. (* simpl_concatn_H IHeff. rewrite concatn_app, concatn_app. simpl_concatn. *)
+      simpl in H7. (* single_unfold_list H6. *) 
+      pose (EE2 := element_exist Value (length eff6) vals0 H7). inversion EE2. 
+      inversion H2.
+      pose (NE := nat_exist H3). inversion NE.
+      pose (EE3 := element_exist Expression x1 exps (eq_sym H13)). inversion EE3. inversion H14.
+      subst. 
+      pose (EE4 := element_exist _ _ _ (eq_sym H8)).
+      pose (EE5 := element_exist _ _ _ (eq_sym H9)).
+      inversion EE4 as [id0']. inversion EE5 as [id0''].
+      inversion H5. inversion H15. subst.
+      assert (s = a /\ id0' = id0''). {
         subst.
         assert (0 < Datatypes.length (x :: x0)). {  simpl. omega. }
-        pose (H0 0 H4).
+        pose (P := H0 0 H16).
         assert (0 < S (Datatypes.length eff)). {  simpl. omega. }
-        pose (H 0 H12 (inl (nth 0 (x :: x0) ErrorValue)) (concatn eff1 (s :: eff6) 1) e0). 
-        inversion a0.
-        simpl_concatn_H H14. apply app_inv_head in H14. symmetry. assumption.
+        pose (P2 := H 0 H17 (inl (nth 0 (x :: x0) ErrorValue)) (concatn eff1 (s :: eff6) 1) _ P). 
+        inversion P2.
+        simpl_concatn_H H19. destruct H19. apply app_inv_head in H19. auto.
       }
-      rewrite <- H13. subst.
-      apply IHeff with (exps := x3) (vals := vs) (vals0 := x0) (eff1 := eff1 ++ a) (i0 := length x0); auto.
-      + intros. assert (S j < S (Datatypes.length eff)). { simpl. omega. } pose (H (S j) H13 v2 eff''). 
-      rewrite concatn_app, concatn_app in a0. simpl in a0. pose (a0 H12). assumption.
+      destruct H16. subst.
+      
+      eapply IHeff with (exps := x3) (vals := vs) (vals0 := x0) (eff1 := eff1 ++ a) (i0 := length x0) (ids := x4) (ids0 := x5); auto.
+      + intros. assert (S j < S (Datatypes.length eff)). { simpl. omega. } pose (P := H (S j) H18 v2 eff'' id''). 
+        rewrite concatn_app, concatn_app in P. pose (P H17). assumption.
       + intros. assert (S j < Datatypes.length (x :: x0)). { simpl. omega. }
-        pose (H0 (S j) H12). rewrite concatn_app, concatn_app in e0. simpl in e0. assumption.
+        pose (P := H0 (S j) H17). rewrite concatn_app, concatn_app in P. simpl in P. exact P.
+      + intros. apply H1. rewrite concatn_app.
+        rewrite (last_element_equal _ _ id) in H16.
+        exact H16.
+      + intuition.
       + intuition.
       + intuition.
       + intuition.
@@ -479,16 +536,16 @@ Qed.
 
 (** Value lists are equal until ith value *)
 Lemma list_equal_until_i {env : Environment} {eff : list SideEffectList} :
-  forall (exps : list Expression) (vals vals0 : list Value) (eff6 : list SideEffectList) (eff1 : SideEffectList),
+  forall (exps : list Expression) (vals vals0 : list Value) (eff6 : list SideEffectList) (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat),
 (forall j : nat,
     j < Datatypes.length vals ->
-    forall (v2 : Value + Exception) (eff'' : SideEffectList),
-    | env, nth j exps ErrorExp, concatn eff1 eff j | -e> | v2, eff'' | ->
-    inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'')
+    forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+    | env, nth_id ids id j, nth j exps ErrorExp, concatn eff1 eff j | -e> | id'', v2, eff'' | ->
+    inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'' /\ nth_id ids id (S j) = id'')
 ->
 (forall j : nat,
      j < Datatypes.length vals0 ->
-     | env, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | inl (nth j vals0 ErrorValue),
+     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
      concatn eff1 eff6 (S j) |)
 ->
 Datatypes.length vals = Datatypes.length vals0
@@ -499,53 +556,61 @@ Datatypes.length eff6 = Datatypes.length vals0
 ->
 Datatypes.length vals0 < Datatypes.length exps
 ->
-eff = eff6 /\ vals = vals0.
+length ids = length vals
+->
+length ids0 = length vals0
+->
+eff = eff6 /\ vals = vals0 /\ ids = ids0.
 Proof.
   induction eff.
-  * intros. inversion H2. apply eq_sym, length_zero_iff_nil in H6. subst. simpl in H1. 
+  * intros. inversion H2. apply eq_sym, length_zero_iff_nil in H8. subst. simpl in H1. 
     apply eq_sym, length_zero_iff_nil in H1. subst. simpl in H3. apply length_zero_iff_nil in H3. 
-    subst. auto.
-  * intros. simpl in H2. rewrite <- H2 in H1. rewrite <- H1 in H3. pose (nat_exist H4). inversion e.
+    apply length_zero_iff_nil in H5. apply length_zero_iff_nil in H6. subst. auto.
+  * intros. simpl in H2. rewrite <- H2 in H1. rewrite <- H1 in H3. pose (NE := nat_exist H4). inversion NE.
     (* single_unfold_list H2. *)
     pose (EE1 := element_exist Value (length eff) vals H2).
     pose (EE2 := element_exist Value (length eff) vals0 H1).
     pose (EE3 := element_exist SideEffectList (length eff) eff6 (eq_sym H3)).
-    pose (EE4 := element_exist Expression x exps (eq_sym H5)).
+    pose (EE4 := element_exist Expression x exps (eq_sym H7)).
     inversion EE1 as [v]. inversion EE2 as [v']. inversion EE3 as [fe]. inversion EE4 as [e'].
-    inversion H6. inversion H7. inversion H8. inversion H9. subst.
+    inversion H8. inversion H9. inversion H10. inversion H11. subst.
+    pose (EE5 := element_exist _ _ _ (eq_sym H5)).
+    pose (EE6 := element_exist _ _ _ (eq_sym H6)).
+    inversion EE5 as [id']. inversion EE6 as [id''].
+    inversion H12. inversion H13. subst.
     assert (0 < Datatypes.length (v' :: x1)). { simpl. omega. }
-    pose (H0 0 H10).
+    pose (P := H0 0 H14).
     assert (0 < Datatypes.length (v :: x0)). { simpl. omega. }
-    pose (H 0 H11 (inl (nth 0 (v' :: x1) ErrorValue)) (concatn eff1 (fe :: x2) 1) e0). inversion a0.
-    simpl_concatn_H H13. apply app_inv_head in H13. inversion H12. subst.
+    pose (P1 := H 0 H15 (inl (nth 0 (v' :: x1) ErrorValue)) (concatn eff1 (fe :: x2) 1) _ P). inversion P1. destruct H17.
+    simpl_concatn_H H17. simpl in H18. apply app_inv_head in H17. inversion H16. subst.
     
-    assert (eff = x2 /\ x0 = x1).
+    assert (eff = x2 /\ x0 = x1 /\ x4 = x5).
     {
-      apply IHeff with (exps := x3) (vals := x0) (vals0 := x1) (eff1 := eff1 ++ fe); auto.
-      + intros. assert (S j < S (Datatypes.length x0)). { simpl. omega. } pose (H (S j) H15 v2 eff''). 
-        rewrite concatn_app, concatn_app in a. simpl in a. pose (a H14). assumption.
+      apply IHeff with (exps := x3) (vals := x0) (vals0 := x1) (eff1 := eff1 ++ fe) (id := id''); auto.
+      + intros. assert (S j < S (Datatypes.length x0)). { simpl. omega. } pose (P2 := H (S j) H19 v2 eff''). 
+        rewrite concatn_app, concatn_app in P2. simpl in P2. pose (P2 _ H18). assumption.
       + intros. assert (S j < Datatypes.length (v' :: x1)). { simpl. omega. }
-        pose (H0 (S j) H14). rewrite concatn_app, concatn_app in e4. simpl in e4. assumption.
+        pose (P3 := H0 (S j) H18). rewrite concatn_app, concatn_app in P3. simpl in P3. assumption.
       + inversion H2. inversion H3. inversion H1. auto.
       + inversion H2. inversion H3. inversion H1. auto.
       + intuition.
     }
-    inversion H13. subst. auto.
+    inversion H17. inversion H19. subst. auto.
 Qed.
 
 (** Slightly different hypotheses for i first element concatn equality *)
 Lemma con_n_equality_rev {env : Environment} {eff : list SideEffectList} : 
 forall (exps : list Expression) (vals vals0 : list Value) (eff1 : SideEffectList) 
-   (eff6 : list SideEffectList) (i i0 : nat),
+   (eff6 : list SideEffectList) (i i0 : nat) (id : nat) (ids ids0 : list nat) id' ex0 eff4,
 (forall j : nat,
     j < i ->
-    forall (v2 : Value + Exception) (eff'' : SideEffectList),
-    | env, nth j exps ErrorExp, concatn eff1 eff j | -e> | v2, eff'' | ->
-    inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'')
+    forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+    | env, nth_id ids id j, nth j exps ErrorExp, concatn eff1 eff j | -e> | id'', v2, eff'' | ->
+    inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'' /\ nth_id ids id (S j) = id'')
 ->
 (forall j : nat,
      j < i0 ->
-     | env, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | inl (nth j vals0 ErrorValue),
+     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
      concatn eff1 eff6 (S j) |)
 ->
 Datatypes.length eff = i ->
@@ -554,60 +619,72 @@ Datatypes.length vals = i ->
 Datatypes.length vals0 = i0 ->
 i0 < Datatypes.length exps ->
 Datatypes.length eff6 = i0 ->
-i > i0
+length ids = i ->
+length ids0 = i0 ->
+i > i0 ->
+(| env, last ids0 id, nth i0 exps ErrorExp, concatn eff1 eff6 i0 | -e> | id', 
+     inr ex0, concatn eff1 eff6 i0 ++ eff4 |)
 ->
-concatn eff1 eff6 i0 = concatn eff1 eff i0.
+False.
 Proof.
 induction eff.
-  * intros. simpl in H1. subst. simpl_concatn. inversion H7.
+  * intros. simpl in H1. subst. inversion H9.
   * intros. simpl in H1. rewrite <- H1 in H3.
     pose (EE1 := element_exist Value (length eff) vals (eq_sym H3)).
-    inversion EE1 as [v]. inversion H8 as [vs]. destruct eff6.
-    - simpl in H6. subst. rewrite <- H6 in H7. rewrite <- H6. simpl_concatn. simpl. reflexivity.
-    - subst. simpl. simpl_concatn_H IHeff. simpl in H6. rewrite <- H6. simpl_concatn.
-      simpl in H6. pose (EE2 := element_exist Value (length eff6) vals0 H6). inversion EE2. inversion H1.
-      pose (nat_exist H2). inversion e.
-      pose (EE3 := element_exist Expression x1 exps (eq_sym H9)). inversion EE3. inversion H10.
-      assert (s = a). {
+    inversion EE1 as [v]. inversion H11 as [vs]. destruct eff6.
+    - subst. apply eq_sym, length_zero_iff_nil in H6. subst. apply length_zero_iff_nil in H8. subst.
+      simpl in H10. pose (P := H 0 (Nat.lt_0_succ _) _ _ _ H10). inversion P. congruence.
+    - subst.
+      assert (Datatypes.length ids0 = Datatypes.length vals0) as Helper. { auto. }
+      pose (EE2 := element_exist Value (length eff6) vals0 H6). inversion EE2. inversion H1.
+      pose (NE := nat_exist H2). inversion NE.
+      pose (EE3 := element_exist Expression x1 exps (eq_sym H12)). inversion EE3. inversion H13. subst.
+      pose (EE4 := element_exist _ _ _ (eq_sym H7)).
+      pose (EE5 := element_exist _ _ _ (eq_sym H8)).
+      inversion EE4 as [id0']. inversion EE5 as [id0'']. inversion H4. inversion H14. subst.
+      assert (s = a /\ id0' = id0''). {
         subst.
         assert (0 < Datatypes.length (x :: x0)). {  simpl. omega. }
-        pose (H0 0 H4).
+        pose (P := H0 0 H15).
         assert (0 < S (Datatypes.length eff)). {  simpl. omega. }
-        pose (H 0 H11 (inl (nth 0 (x :: x0) ErrorValue)) (concatn eff1 (s :: eff6) 1) e0). inversion a0.
-        simpl_concatn_H H13. apply app_inv_head in H13. simpl in H13. symmetry. assumption.
+        pose (P1 := H 0 H16 (inl (nth 0 (x :: x0) ErrorValue)) (concatn eff1 (s :: eff6) 1) _ P). destruct P1. destruct H18.
+        simpl_concatn_H H18. apply app_inv_head in H18. simpl in H19. auto.
       }
-      rewrite <- H12. subst.
-      apply IHeff with (exps := x3) (vals := vs) (vals0 := x0) (eff1 := eff1 ++ a) 
-                       (i0 := length eff6) (i := length eff); auto.
+      destruct H15. subst.
+      eapply IHeff with (exps := x3) (vals := vs) (vals0 := x0) (eff1 := eff1 ++ a) 
+                       (i0 := length eff6) (i := length eff) (ids := x4) (ids0 := x5); auto.
       + intros. assert (S j < S (Datatypes.length eff)). { simpl. omega. }
-        pose (H (S j) H12 v2 eff''). rewrite concatn_app, concatn_app in a0. simpl in a0.
-        pose (a0 H11). assumption.
+        pose (P := H (S j) H17 v2 eff''). rewrite concatn_app, concatn_app in P. simpl in P.
+        pose (P1 := P _ H16). assumption.
       + intros. inversion H6. assert (S j < Datatypes.length (x :: x0)). { simpl. omega. }
-        pose (H0 (S j) H11). rewrite concatn_app, concatn_app in e0. simpl in e0. assumption.
+        pose (P := H0 (S j) H16). rewrite concatn_app, concatn_app in P. simpl in P. assumption.
       + intuition.
       + inversion H6. auto.
       + rewrite <- H6 in H5. simpl in H5. omega.
-      + omega.
+      + rewrite <- H6 in Helper. auto.
+      + simpl in *. rewrite <- H6 in H9. omega.
+      + rewrite <- last_element_equal in H10. simpl in H10. rewrite concatn_app in H10. 
+        inversion H6. rewrite H16. exact H10.
 Qed.
 
 (** Based on determinsim, using lists with exceptions, these are equal *)
 Lemma exception_equality {env : Environment} {exps : list Expression} (vals vals0 : list Value) 
    (ex : Exception) (eff1 : SideEffectList) (eff eff6 : list SideEffectList) (i i0 : nat) 
-   (eff3 : SideEffectList) (ex0 : Exception) (eff4 : SideEffectList) :
+   (eff3 : SideEffectList) (ex0 : Exception) (eff4 : SideEffectList) (ids ids0 : list nat) (id id' : nat) :
 (forall j : nat,
      j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j exps ErrorExp, concatn eff1 eff j | -e> | v2, eff'' | ->
-     inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id j, nth j exps ErrorExp, concatn eff1 eff j | -e> | id'', v2, eff'' | ->
+     inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'' /\ nth_id ids id (S j) = id'')
 ->
-| env, nth i0 exps ErrorExp, concatn eff1 eff6 i0 | -e> | inr ex0, concatn eff1 eff6 i0 ++ eff4 |
+| env, last ids0 id, nth i0 exps ErrorExp, concatn eff1 eff6 i0 | -e> | id', inr ex0, concatn eff1 eff6 i0 ++ eff4 |
 ->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList),
-        | env, nth i exps ErrorExp, concatn eff1 eff i | -e> | v2, eff'' | -> inr ex = v2 /\ eff3 = eff'')
+(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+        | env, last ids id, nth i exps ErrorExp, concatn eff1 eff i | -e> | id'', v2, eff'' | -> inr ex = v2 /\ eff3 = eff'' /\ id' = id'')
 ->
 (forall j : nat,
       j < i0 ->
-      | env, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | inl (nth j vals0 ErrorValue),
+      | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
       concatn eff1 eff6 (S j) |)
 ->
 Datatypes.length vals = i ->
@@ -615,226 +692,236 @@ Datatypes.length vals = i ->
  Datatypes.length eff = i ->
  Datatypes.length vals0 = i0 ->
  i0 < Datatypes.length exps ->
- Datatypes.length eff6 = i0
+ Datatypes.length eff6 = i0 ->
+ length ids = i ->
+ length ids0 = i0
 ->
-i = i0 /\ eff = eff6 /\ vals = vals0.
+i = i0 /\ eff = eff6 /\ vals = vals0 /\ ids = ids0.
 Proof.
   intros. destruct (le_gt_dec i i0).
   * case_eq (le_lt_or_eq i i0 l).
-    - intros. pose (P1 := H2 i l0).
-      assert (concatn eff1 eff6 i = concatn eff1 eff i).
-      {
-        apply (con_n_equality exps vals vals0 eff1 eff6 i i0 H H2 H5 H4 H3 H6 H7 H8 l0).
-      }
-      rewrite H10 in P1.
-      pose (P2 := H1 (inl (nth i vals0 ErrorValue)) (concatn eff1 eff6 (S i)) P1). inversion P2. inversion H11.
-    - intros. subst. pose (list_equal_until_i exps vals vals0 eff6 eff1 H H2 e H5 H8 H7). auto.
-  * 
-    assert (concatn eff1 eff6 i0 = concatn eff1 eff i0).
-    {
-      apply (con_n_equality_rev exps vals vals0 eff1 eff6 i i0 H H2 H5 H4 H3 H6 H7 H8 g).
-    }
-    rewrite H9 in H0 at 1.
-    pose (H i0 g (inr ex0) (concatn eff1 eff6 i0 ++ eff4) H0). inversion a. inversion H10.
+    - intros.
+      pose (P1 := con_n_equality exps vals vals0 eff1 eff6 i i0 ids ids0 id _ _ _ H H2 H1 H5 H4 H3 H6 H7 H8 H9 H10 l0). inversion P1.
+    - intros. subst. pose (list_equal_until_i exps vals vals0 eff6 eff1 _ _ _ H H2 e H5 H8 H7 H9 H10). auto.
+  * pose (P := con_n_equality_rev exps vals vals0 eff1 eff6 i i0 id ids ids0 _ _ _ H H2 H5 H4 H3 H6 H7 H8 H9 H10 g H0). inversion P.
 Qed.
 
 (** Map lists are equal *)
 Lemma map_lists_equality {env : Environment} {kl : list Expression} : 
 forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (eff1 : SideEffectList) 
-     (eff eff7 : list SideEffectList),
+     (eff eff7 : list SideEffectList) (ids ids0 : list nat) (id : nat),
 (forall j : nat,
      j < length vl ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | id'', v2, eff'' | ->
+     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\ nth_id ids id (S (2*j)) = id'')
 ->
 (forall j : nat,
      j < length vl ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | id'', v2, eff'' | ->
+     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\ nth_id ids id (S (S (2*j))) = id'')
 ->
 Datatypes.length kl = Datatypes.length vl ->
 length kl = Datatypes.length vvals ->
 length kl = Datatypes.length kvals ->
 ((length kl) * 2)%nat = Datatypes.length eff ->
+((length kl) * 2)%nat = length ids ->
 (forall j : nat,
       j < length vl ->
-      | env, nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | inl (nth j kvals0 ErrorValue),
+      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
       concatn eff1 eff7 (S (2 * j)) |)
 ->
 (forall j : nat,
       j < length vl ->
-      | env, nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
-      | inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
+      | env, nth_id ids0 id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
+      | nth_id ids0 id (S(S(2*j))), inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
 ->
 length kl = Datatypes.length vvals0 ->
 length kl = Datatypes.length kvals0 ->
-((length kl) * 2)%nat = Datatypes.length eff7
+((length kl) * 2)%nat = Datatypes.length eff7 ->
+((length kl) * 2)%nat = length ids0
 ->
-kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7.
+kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7 /\ ids = ids0.
 Proof.
   induction kl.
   * intros. inversion H1. inversion H2. inversion H3. inversion H4.
     repeat unfold_list.
-    inversion H7. inversion H8. inversion H9.
+    inversion H10. inversion H8. inversion H9. inversion H11. inversion H5.
     repeat unfold_list.
     auto.
-  * intros. inversion H1. inversion H2. inversion H3. inversion H4. simpl in H9, H14, H7, H8.
+  * intros. inversion H1. inversion H2. inversion H3. inversion H4. simpl in H9, H14, H7, H8, H10, H5, H11.
     single_unfold_list. single_unfold_list. single_unfold_list. 
     single_unfold_list. single_unfold_list. single_unfold_list.
     single_unfold_list. single_unfold_list. single_unfold_list.
+    single_unfold_list. single_unfold_list. single_unfold_list. single_unfold_list.
     (** FIRST ELEMENTS ARE EQUAL *)
-    pose (F1 := H5 0 (Nat.lt_0_succ (length x7))).
-    pose (F2 := H 0 (Nat.lt_0_succ _) _ _ F1). inversion F2. inversion H31.
-    rewrite concatn_app, concatn_app in H33. simpl_concatn_H H33. apply app_inv_head in H33. subst.
-    pose (F3 := H6 0 (Nat.lt_0_succ (length x7))).
-    pose (F4 := H0 0 (Nat.lt_0_succ _) _ _ F3). inversion F4. inversion H33.
-    rewrite concatn_app, concatn_app in H34. simpl_concatn_H H34. apply app_inv_head in H34. subst. simpl.
+    pose (F1 := H6 0 (Nat.lt_0_succ (length x7))). simpl in F1.
+    pose (F2 := H 0 (Nat.lt_0_succ _) _ _ _ F1). inversion F2. inversion H41.
+    rewrite concatn_app, concatn_app in H43. simpl_concatn_H H43. destruct H43. apply app_inv_head in H43. subst.
+    pose (F3 := H7 0 (Nat.lt_0_succ (length x7))).
+    pose (F4 := H0 0 (Nat.lt_0_succ _) _ _ _ F3). inversion F4. inversion H43.
+    rewrite concatn_app, concatn_app in H44. simpl_concatn_H H44. destruct H44. apply app_inv_head in H44. subst. simpl.
     (** OTHER ELEMETS *)
-    assert (x3 = x12 /\ x5 = x14 /\ x2 = x11).
+    assert (x3 = x15 /\ x5 = x17 /\ x2 = x14 /\ x21 = x11).
     {
       eapply IHkl with (vl := x7); auto.
       * intros. assert (S j < length (x6 :: x7)). { simpl. omega. }
-        pose (P3 := H (S j) H36 v2 eff''). simpl in P3.
+        pose (P3 := H (S j) H46 v2 eff''). simpl in P3.
         rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
-               <- app_assoc in P3. simpl in H35. rewrite Nat.add_0_r in H35.
-        pose (P4 := P3 H35). simpl. rewrite Nat.add_0_r. assumption.
+               <- app_assoc in P3. simpl in H45. rewrite Nat.add_0_r in H45.
+        pose (P4 := P3 _ H45). simpl. rewrite Nat.add_0_r. assumption.
       * intros. assert (S j < length (x6 :: x7)). { simpl. omega. }
-        pose (P3 := H0 (S j) H36 v2 eff''). simpl in P3.
+        pose (P3 := H0 (S j) H46 v2 eff''). simpl in P3.
         rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
-               <- app_assoc in P3. simpl in H35. rewrite Nat.add_0_r in H35.
-        pose (P4 := P3 H35). simpl. rewrite Nat.add_0_r. assumption.
+               <- app_assoc in P3. simpl in H45. rewrite Nat.add_0_r in H45.
+        pose (P4 := P3 _ H45). simpl. rewrite Nat.add_0_r. assumption.
       * intros. assert (S j < length (x6 :: x7)). { simpl. omega. }
-        pose (P3 := H5 (S j) H35). simpl in P3. 
+        pose (P3 := H6 (S j) H45). simpl in P3. 
         rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
                <- app_assoc in P3. simpl. rewrite Nat.add_0_r. assumption.
       * intros. assert (S j < length (x6 :: x7)). { simpl. omega. }
-        pose (P3 := H6 (S j) H35). simpl in P3.
+        pose (P3 := H7 (S j) H45). simpl in P3.
         rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
                <- app_assoc in P3. simpl. rewrite Nat.add_0_r. assumption.
     }
-    inversion H34. inversion H36. subst. auto.
+    destruct H44. destruct H45. destruct H46. subst. auto.
 Qed.
 
 (** Map lists are equal until ith element *)
 Lemma map_lists_equal_until_i {env : Environment} {kl : list Expression} : forall {vl : list Expression}
    (kvals vvals kvals0 vvals0 : list Value) (i0 : nat) (eff1 : SideEffectList)
-   (eff eff7 : list SideEffectList) (ex0 : Exception) (eff5 eff6 : SideEffectList) (val0 : Value),
+   (eff eff7 : list SideEffectList) (ex0 : Exception) (eff5 eff6 : SideEffectList) (val0 : Value)
+   (ids ids0 : list nat) (id id' id'' : nat),
 (forall j : nat,
      j < length vl ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | id'', v2, eff'' | ->
+     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\ nth_id ids id (S (2*j)) = id'')
 ->
 (forall j : nat,
      j < length vl ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | id'', v2, eff'' | ->
+     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\ nth_id ids id (S (S (2*j))) = id'')
 ->
 Datatypes.length kl = Datatypes.length vl ->
 length kl = Datatypes.length vvals ->
 length kl = Datatypes.length kvals ->
-Datatypes.length eff = ((length kl) * 2)%nat ->
+((length kl) * 2)%nat = Datatypes.length eff ->
+((length kl) * 2)%nat = Datatypes.length ids ->
 (forall j : nat,
       j < i0 ->
-      | env, nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | inl (nth j kvals0 ErrorValue),
+      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
       concatn eff1 eff7 (S (2 * j)) |)
 ->
 (forall j : nat,
       j < i0 ->
-      | env, nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
-      | inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
+      | env, nth_id ids0 id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
+      | nth_id ids0 id (S (S (2*j))), inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
 ->
 Datatypes.length vvals0 = i0 ->
 Datatypes.length kvals0 = i0 ->
 i0 <= Datatypes.length kl ->
 Datatypes.length eff7 = (i0 * 2)%nat ->
-(| env, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
+length ids0 = (i0 * 2)%nat ->
+(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
 \/
-(| env, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | inl val0,
+(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id', inl val0,
       concatn eff1 eff7 (2 * i0) ++ eff5 | /\
-| env, nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff5 | -e> | 
-      inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 ++ eff6 |)
+| env, id', nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff5 | -e> | 
+      id'', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 ++ eff6 |)
 )
 ->
-length vl = i0 /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7.
+length vl = i0 /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7 /\ ids = ids0.
 Proof.
   induction kl.
-  * intros. inversion H2. apply eq_sym, length_zero_iff_nil in H13. subst. inversion H1.
-    apply eq_sym, length_zero_iff_nil in H12. subst. inversion H9. apply length_zero_iff_nil in H12.
-    subst. inversion H3. apply eq_sym,  length_zero_iff_nil in H12. subst. inversion H8.
-    apply length_zero_iff_nil in H12. subst. inversion H10. apply length_zero_iff_nil in H12.
-    subst. inversion H4. apply length_zero_iff_nil in H12. subst. auto.
+  * intros. inversion H2. apply eq_sym, length_zero_iff_nil in H15. subst. inversion H1.
+    apply eq_sym, length_zero_iff_nil in H14. subst. inversion H10. apply length_zero_iff_nil in H14.
+    subst. inversion H3. apply eq_sym,  length_zero_iff_nil in H14. subst. inversion H11.
+    apply length_zero_iff_nil in H14. subst. inversion H12. apply length_zero_iff_nil in H14. subst.
+    inversion H4. apply eq_sym, length_zero_iff_nil in H14. subst. apply length_zero_iff_nil in H9.
+    subst. apply eq_sym, length_zero_iff_nil in H5. auto.
   * intros. inversion H1.
-    pose (EE1 := element_exist Expression (length kl) vl H13). inversion EE1 as [ve]. inversion H12 as [ves].
+    pose (EE1 := element_exist Expression (length kl) vl H15). 
+    inversion EE1 as [ve]. inversion H14 as [ves].
     subst.
     case_eq (length vvals0).
-    - intros. apply length_zero_iff_nil in H7. subst.
-      apply length_zero_iff_nil in H8. apply length_zero_iff_nil in H10. subst.
-      simpl_concatn_H H11.
-      inversion H11.
-      + pose (P1 := H 0 (Nat.lt_0_succ _) (inr ex0) (eff1 ++ eff5)).
-        simpl_concatn_H P1. pose (P2 := P1 H7). inversion P2. inversion H8.
-      + inversion H7. pose (P1 := H 0 (Nat.lt_0_succ _) (inl val0) (eff1 ++ eff5)).
-        simpl_concatn_H P1. pose (P2 := P1 H8). inversion P2. inversion H14. subst.
-        pose (P3 := H0 0 (Nat.lt_0_succ _) (inr ex0) (eff1 ++ eff5 ++ eff6)).
+    - intros. apply length_zero_iff_nil in H8. subst.
+      apply length_zero_iff_nil in H9. apply length_zero_iff_nil in H12. apply length_zero_iff_nil in H11. subst.
+      rewrite <- H1 in H, H0.
+      simpl_concatn_H H13.
+      inversion H13.
+      + pose (P1 := H 0 (Nat.lt_0_succ _) (inr ex0) (eff1 ++ eff5) id').
+        simpl_concatn_H P1. pose (P2 := P1 H8). inversion P2. inversion H9.
+      + destruct H8. pose (P1 := H 0 (Nat.lt_0_succ _) (inl val0) (eff1 ++ eff5) id').
+        simpl_concatn_H P1. pose (P2 := P1 H8). destruct P2. inversion H11. subst.
+        pose (P3 := H0 0 (Nat.lt_0_succ _) (inr ex0) (eff1 ++ eff5 ++ eff6) id'').
         simpl_concatn_H P3.
-        rewrite <- H15 in H10 at 1.
-        pose (P4 := P3 H10). inversion P4. inversion H16.
+        destruct H12.
+        rewrite <- H12 in H9 at 1. rewrite H16 in P3.
+        pose (P4 := P3 H9). inversion P4. inversion H17.
 
-    - intros. rewrite H7 in *. simpl in H2, H3. simpl in H4, H10.
-      pose (EE2 := element_exist Value _ kvals0 (eq_sym H8)).
-      pose (EE3 := element_exist Value _ vvals0 (eq_sym H7)).
+    - intros. rewrite H8 in *. simpl in H2, H3. simpl in H4, H10.
+      pose (EE2 := element_exist Value _ kvals0 (eq_sym H9)).
+      pose (EE3 := element_exist Value _ vvals0 (eq_sym H8)).
       pose (EE4 := element_exist Value _ kvals H3).
       pose (EE5 := element_exist Value _ vvals H2).
-      pose (EE6 := element_exist SideEffectList _ eff (eq_sym H4)).
-      pose (EE7 := element_exist SideEffectList _ eff7 (eq_sym H10)).
+      pose (EE6 := element_exist SideEffectList _ eff H4).
+      pose (EE7 := element_exist SideEffectList _ eff7 (eq_sym H11)).
+      pose (EE8 := element_exist _ _ _ H5).
+      pose (EE9 := element_exist _ _ _ (eq_sym H12)).
       inversion EE2 as [kv']. inversion EE3 as [vv']. inversion EE4 as [kv]. inversion EE5 as [vv].
-      inversion EE6 as [e1]. inversion EE7 as [e1'].
-      inversion H14. inversion H15. inversion H16. inversion H17. inversion H18. inversion H19. subst.
-      inversion H4. inversion H10.
-      pose (EE8 := element_exist SideEffectList _ x3 (eq_sym H21)).
-      pose (EE9 := element_exist SideEffectList _ x4 (eq_sym H22)).
-      inversion EE8 as [e2]. inversion EE9 as [e2']. inversion H20. inversion H23. subst.
+      inversion EE6 as [e1]. inversion EE7 as [e1']. inversion EE8 as [id1]. inversion EE9 as [id1'].
+      inversion H16. inversion H17. inversion H18. inversion H19.
+      inversion H20. inversion H21. inversion H22. inversion H23. subst.
+      
+      inversion H4. inversion H11. inversion H5. inversion H12.
+      pose (EE10 := element_exist SideEffectList _ x3 (H25)).
+      pose (EE11 := element_exist SideEffectList _ x4 (eq_sym H26)).
+      pose (EE12 := element_exist _ _ x5 (H27)).
+      pose (EE13 := element_exist _ _ x6 (eq_sym H28)).
+      inversion EE10 as [e2]. inversion EE11 as [e2']. inversion EE12 as [id2]. inversion EE13 as [id2']. 
+      inversion H24. inversion H29. inversion H30. inversion H31. subst.
       (** FIRST ELEMENTS ARE EQUAL *)
-      pose (F1 := H5 0 (Nat.lt_0_succ n)).
-      pose (F2 := H 0 (Nat.lt_0_succ _) _ _ F1). inversion F2. inversion H24.
-      rewrite concatn_app, concatn_app in H25. simpl_concatn_H H25. apply app_inv_head in H25. subst.
-      pose (F3 := H6 0 (Nat.lt_0_succ n)).
-      pose (F4 := H0 0 (Nat.lt_0_succ _) _ _ F3). inversion F4. inversion H25.
-      rewrite concatn_app, concatn_app in H26. simpl_concatn_H H26. apply app_inv_head in H26. subst. simpl.
+      pose (F1 := H6 0 (Nat.lt_0_succ n)).
+      pose (F2 := H 0 (Nat.lt_0_succ _) _ _ _ F1). inversion F2. inversion H32. destruct H33.
+      rewrite concatn_app, concatn_app in H33. simpl_concatn_H H33. apply app_inv_head in H33. 
+      simpl in H34. subst.
+      pose (F3 := H7 0 (Nat.lt_0_succ n)).
+      pose (F4 := H0 0 (Nat.lt_0_succ _) _ _ _ F3). inversion F4. inversion H33. destruct H34.
+      rewrite concatn_app, concatn_app in H34. simpl_concatn_H H34. apply app_inv_head in H34. 
+      simpl in H35. subst. simpl.
       (** OTHER ELEMETS *)
-      assert (length ves = n /\ x1 = x /\ x2 = x0 /\ x5 = x6).
+      assert (length ves = n /\ x1 = x /\ x2 = x0 /\ x7 = x8 /\ x9 = x10).
       {
-        apply IHkl with (eff1 := eff1 ++ e1' ++ e2') (ex0 := ex0) (eff5 := eff5) (vl := ves) (eff6 := eff6) (val0 := val0); auto.
+        eapply IHkl with (eff1 := eff1 ++ e1' ++ e2') (ex0 := ex0) (eff5 := eff5) (vl := ves) (eff6 := eff6) (val0 := val0); auto.
         * intros. assert (S j < length (ve :: ves)). { simpl. omega. }
-          pose (P3 := H (S j) H28 v2 eff''). simpl in P3.
+          pose (P3 := H (S j) H36 v2 eff''). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r,
-                <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl in H27. rewrite Nat.add_0_r in H27.
-          pose (P4 := P3 H27). simpl. rewrite Nat.add_0_r. assumption.
+                <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl in H35. rewrite Nat.add_0_r in H35.
+          pose (P4 := P3 _ H35). simpl. rewrite Nat.add_0_r. assumption.
         * intros. assert (S j < length (ve :: ves)). { simpl. omega. }
-          pose (P3 := H0 (S j) H28 v2 eff''). simpl in P3.
+          pose (P3 := H0 (S j) H36 v2 eff''). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r,
-                <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl in H27. rewrite Nat.add_0_r in H27.
-          pose (P4 := P3 H27). simpl. rewrite Nat.add_0_r. assumption.
+                <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl in H35. rewrite Nat.add_0_r in H35.
+          pose (P4 := P3 _ H35). simpl. rewrite Nat.add_0_r. assumption.
         * intros. assert (S j < S n). { omega. }
-          pose (P3 := H5 (S j) H27). simpl in P3.
+          pose (P3 := H6 (S j) H35). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r,
                 <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl. rewrite Nat.add_0_r. assumption.
         * intros. assert (S j < S n). { omega. }
-          pose (P3 := H6 (S j) H27). simpl in P3.
+          pose (P3 := H7 (S j) H35). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r,
                <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl. rewrite Nat.add_0_r. assumption.
         * simpl in H9. omega.
-        * simpl in H11. 
+        * rewrite <- last_element_equal, <- last_element_equal in H13. simpl in H13.
           rewrite concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
-              <- app_assoc in H11. simpl. rewrite Nat.add_0_r. assumption.
+              <- app_assoc in H13. simpl. rewrite Nat.add_0_r. exact H13.
       }
-      inversion H26. inversion H28. inversion H30. subst. auto.
+      destruct H34. destruct H35. destruct H36. destruct H37. subst. auto.
 Qed.
-
+(*
 (** Map lists are equal until ith key *)
 Lemma map_lists_equal_until_i_key {env : Environment} {kl : list Expression} :
   forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (i i0 : nat) 

--- a/Core_Erlang_Determinism_Helpers.v
+++ b/Core_Erlang_Determinism_Helpers.v
@@ -46,7 +46,8 @@ match goal with
    | [H' : exists x l', _ = x::l' |- _] => 
      inversion H';
      match goal with
-     | [H'' : exists l', _ = ?x::l' |- _] => inversion H''; subst; simpl in H; inversion H; unfold_list
+     | [H'' : exists l', _ = ?x::l' |- _] => inversion H''; subst; simpl in H; 
+                                             inversion H; unfold_list
      end
    end
 end
@@ -176,8 +177,10 @@ Proof.
     single_unfold_list. single_unfold_list.
     single_unfold_list. single_unfold_list.
     pose (P1 := H1 0 list_length). simpl_concatn_H P1.
-    pose (P2 := H0 0 list_length (inl x7) (concatn eff1 (x9 :: x10) 1) x). simpl_concatn_H P2.
-    pose (P3 := P2 P1). inversion P3. inversion H25. inversion H27. apply app_inv_head in H28. subst.
+    pose (P2 := H0 0 list_length (inl x7) (concatn eff1 (x9 :: x10) 1) x).
+    simpl_concatn_H P2.
+    pose (P3 := P2 P1). inversion P3. inversion H25. inversion H27. apply app_inv_head in H28.
+    subst.
   (* remaining lists are the same *)
 
   (* These three asserts ensure, that if something states for every element in 
@@ -185,7 +188,8 @@ Proof.
     assert (
       (forall i : nat,
     i < Datatypes.length exps ->
-    | env, nth_id x2 x i, nth i exps ErrorExp, concatn (eff1 ++ x9) x4 i | -e> | nth_id x2 x (S i), inl (nth i x6 ErrorValue),
+    | env, nth_id x2 x i, nth i exps ErrorExp, concatn (eff1 ++ x9) x4 i | -e> 
+    | nth_id x2 x (S i), inl (nth i x6 ErrorValue),
     concatn (eff1 ++ x9) x4 (S i) |)
     ).
     {
@@ -206,7 +210,8 @@ Proof.
     assert (
      (forall i : nat,
     i < Datatypes.length exps ->
-    | env, nth_id x0 x i, nth i exps ErrorExp, concatn (eff1 ++ x9) x10 i | -e> | nth_id x0 x (S i), inl (nth i x8 ErrorValue),
+    | env, nth_id x0 x i, nth i exps ErrorExp, concatn (eff1 ++ x9) x10 i | -e>
+    | nth_id x0 x (S i), inl (nth i x8 ErrorValue),
     concatn (eff1 ++ x9) x10 (S i) |)
     ).
     {
@@ -289,7 +294,8 @@ length ids0 = length vals0
 ->
 (forall j : nat,
      j < Datatypes.length vals0 ->
-     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff5 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
+     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff5 j | -e>
+     | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
      concatn eff1 eff5 (S j) |)
 ->
 | env, last ids0 id, nth (Datatypes.length vals0) exps ErrorExp,
@@ -331,7 +337,8 @@ Proof.
       pose (P2 := P1 _ P0). destruct P2. destruct H18, H19. apply app_inv_head in H18. subst.
     (* other elements *)
       inversion H1.
-      eapply IHeff with (exps := x) (vals := x1) (vals0 := x0) (eff1 := eff1 ++ s) (ids := x2) (ids0 := x3) (id := id0'') (eff5 := eff5); auto.
+      eapply IHeff with (exps := x) (vals := x1) (vals0 := x0) (eff1 := eff1 ++ s)
+                      (ids := x2) (ids0 := x3) (id := id0'') (eff5 := eff5); auto.
         + intuition.
         + intros. assert (S i < Datatypes.length (e :: x)). { simpl. omega. }
           pose (A := H5 (S i) H21 v2 eff''). rewrite concatn_app, concatn_app in A.
@@ -366,7 +373,8 @@ length ids0 = length vals0
 ->
 (forall j : nat,
      j < Datatypes.length vals0 ->
-     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff5 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
+     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff5 j | -e>
+     | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
      concatn eff1 eff5 (S j) |)
 ->
 | env, last ids0 id, nth (Datatypes.length vals0) exps ErrorExp,
@@ -375,7 +383,8 @@ length ids0 = length vals0
 ->
   False.
 Proof.
-  intros. simpl_concatn. pose (P := firstn_eq eff5 exps vals vals0 _ _ _ _ _ _ _ H H0 H1 H2 H3 H4 H5 H6 H7). inversion P.
+  intros. simpl_concatn. pose (P := firstn_eq eff5 exps vals vals0 _ _ _ _ _ _ _
+                                H H0 H1 H2 H3 H4 H5 H6 H7). inversion P.
 Qed.
 
 (** First i elements are equal, but with changed hypotheses *)
@@ -391,7 +400,8 @@ Lemma firstn_eq_rev {env : Environment} {eff : list SideEffectList} :
 ->
 (forall i : nat,
      i < Datatypes.length exps ->
-     | env, nth_id ids0 id i, nth i exps ErrorExp, concatn eff1 eff5 i | -e> | nth_id ids0 id (S i), inl (nth i vals0 ErrorValue),
+     | env, nth_id ids0 id i, nth i exps ErrorExp, concatn eff1 eff5 i | -e>
+     | nth_id ids0 id (S i), inl (nth i vals0 ErrorValue),
      concatn eff1 eff5 (S i) |) ->
 (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
         | env, last ids id, nth (Datatypes.length vals) exps ErrorExp,
@@ -437,13 +447,16 @@ Proof.
       pose (P2 := P1 _ P0). destruct P2. destruct H19. apply app_inv_head in H19. inversion H18. subst.
     (* other elements *)
       inversion H3.
-      apply IHeff with (exps := x) (vals := x0) (eff1 := eff1 ++ s) (vals0 := x1) (ids := x2) (ids0 := x3) (id := id0'') (ex := ex) (eff5 := eff5) (eff2 := eff2) (id' := id'); auto.
+      apply IHeff with (exps := x) (vals := x0) (eff1 := eff1 ++ s) (vals0 := x1)
+                  (ids := x2) (ids0 := x3) (id := id0'') (ex := ex) (eff5 := eff5)
+                  (eff2 := eff2) (id' := id'); auto.
         + intros. assert (S j < Datatypes.length (v' :: x0)). { simpl. omega. } 
           pose (A := H (S j) H22 v2 eff''). rewrite concatn_app, concatn_app in A. simpl in A. 
           pose (B := A _ H21). assumption.
         + intros. assert (S i < Datatypes.length (e :: x)). { simpl. omega. } 
           pose (A := H0 (S i) H21). rewrite concatn_app, concatn_app in A. simpl in A. exact A.
-        + intros. rewrite <- last_element_equal in H1. simpl in H1. rewrite concatn_app in H1. apply H1. assumption.
+        + intros. rewrite <- last_element_equal in H1. simpl in H1. rewrite concatn_app in H1.
+          apply H1. assumption.
         + intuition.
         + inversion H7. omega.
 Qed.
@@ -461,7 +474,8 @@ Lemma eff_until_i_rev {env : Environment} {eff : list SideEffectList} :
 ->
 (forall i : nat,
      i < Datatypes.length exps ->
-     | env, nth_id ids0 id i, nth i exps ErrorExp, concatn eff1 eff5 i | -e> | nth_id ids0 id (S i), inl (nth i vals0 ErrorValue),
+     | env, nth_id ids0 id i, nth i exps ErrorExp, concatn eff1 eff5 i | -e>
+     | nth_id ids0 id (S i), inl (nth i vals0 ErrorValue),
      concatn eff1 eff5 (S i) |) ->
 (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
         | env, last ids id, nth (Datatypes.length vals) exps ErrorExp,
@@ -477,7 +491,8 @@ length ids = length vals
 ->
 False.
 Proof.
-  intros. simpl_concatn. apply (firstn_eq_rev eff5 exps vals vals0 eff1 _ _ _ _ _ _ H H0 H1 H2 H3 H4 H5 H6 H7).
+  intros. simpl_concatn. apply (firstn_eq_rev eff5 exps vals vals0 eff1 _ _ _ _ _ _
+                                   H H0 H1 H2 H3 H4 H5 H6 H7).
 Qed.
 
 Lemma nat_exist {n m : nat} : n < m -> exists x, m = S x.
@@ -498,7 +513,8 @@ Lemma con_n_equality {env : Environment} {eff : list SideEffectList} :
 ->
 (forall j : nat,
      j < i0 ->
-     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
+     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e>
+     | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
      concatn eff1 eff6 (S j) |)
 ->
 (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
@@ -547,8 +563,10 @@ Proof.
       }
       destruct H16. subst.
       
-      eapply IHeff with (exps := x3) (vals := vs) (vals0 := x0) (eff1 := eff1 ++ a) (i0 := length x0) (ids := x4) (ids0 := x5); auto.
-      + intros. assert (S j < S (Datatypes.length eff)). { simpl. omega. } pose (P := H (S j) H18 v2 eff'' id''). 
+      eapply IHeff with (exps := x3) (vals := vs) (vals0 := x0) (eff1 := eff1 ++ a)
+                        (i0 := length x0) (ids := x4) (ids0 := x5); auto.
+      + intros. assert (S j < S (Datatypes.length eff)). { simpl. omega. }
+        pose (P := H (S j) H18 v2 eff'' id''). 
         rewrite concatn_app, concatn_app in P. pose (P H17). assumption.
       + intros. assert (S j < Datatypes.length (x :: x0)). { simpl. omega. }
         pose (P := H0 (S j) H17). rewrite concatn_app, concatn_app in P. simpl in P. exact P.
@@ -563,7 +581,8 @@ Qed.
 
 (** Value lists are equal until ith value *)
 Lemma list_equal_until_i {env : Environment} {eff : list SideEffectList} :
-  forall (exps : list Expression) (vals vals0 : list Value) (eff6 : list SideEffectList) (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat),
+  forall (exps : list Expression) (vals vals0 : list Value) (eff6 : list SideEffectList)
+      (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat),
 (forall j : nat,
     j < Datatypes.length vals ->
     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
@@ -572,7 +591,8 @@ Lemma list_equal_until_i {env : Environment} {eff : list SideEffectList} :
 ->
 (forall j : nat,
      j < Datatypes.length vals0 ->
-     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
+     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e> 
+     | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
      concatn eff1 eff6 (S j) |)
 ->
 Datatypes.length vals = Datatypes.length vals0
@@ -608,7 +628,8 @@ Proof.
     assert (0 < Datatypes.length (v' :: x1)). { simpl. omega. }
     pose (P := H0 0 H14).
     assert (0 < Datatypes.length (v :: x0)). { simpl. omega. }
-    pose (P1 := H 0 H15 (inl (nth 0 (v' :: x1) ErrorValue)) (concatn eff1 (fe :: x2) 1) _ P). inversion P1. destruct H17.
+    pose (P1 := H 0 H15 (inl (nth 0 (v' :: x1) ErrorValue)) (concatn eff1 (fe :: x2) 1) _ P).
+    inversion P1. destruct H17.
     simpl_concatn_H H17. simpl in H18. apply app_inv_head in H17. inversion H16. subst.
     
     assert (eff = x2 /\ x0 = x1 /\ x4 = x5).
@@ -637,7 +658,8 @@ forall (exps : list Expression) (vals vals0 : list Value) (eff1 : SideEffectList
 ->
 (forall j : nat,
      j < i0 ->
-     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
+     | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e> 
+     | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
      concatn eff1 eff6 (S j) |)
 ->
 Datatypes.length eff = i ->
@@ -659,13 +681,15 @@ induction eff.
   * intros. simpl in H1. rewrite <- H1 in H3.
     pose (EE1 := element_exist Value (length eff) vals (eq_sym H3)).
     inversion EE1 as [v]. inversion H11 as [vs]. destruct eff6.
-    - subst. apply eq_sym, length_zero_iff_nil in H6. subst. apply length_zero_iff_nil in H8. subst.
+    - subst. apply eq_sym, length_zero_iff_nil in H6. subst. apply length_zero_iff_nil in H8.
+      subst.
       simpl in H10. pose (P := H 0 (Nat.lt_0_succ _) _ _ _ H10). inversion P. congruence.
     - subst.
       assert (Datatypes.length ids0 = Datatypes.length vals0) as Helper. { auto. }
       pose (EE2 := element_exist Value (length eff6) vals0 H6). inversion EE2. inversion H1.
       pose (NE := nat_exist H2). inversion NE.
-      pose (EE3 := element_exist Expression x1 exps (eq_sym H12)). inversion EE3. inversion H13. subst.
+      pose (EE3 := element_exist Expression x1 exps (eq_sym H12)). inversion EE3.
+      inversion H13. subst.
       pose (EE4 := element_exist _ _ _ (eq_sym H7)).
       pose (EE5 := element_exist _ _ _ (eq_sym H8)).
       inversion EE4 as [id0']. inversion EE5 as [id0'']. inversion H4. inversion H14. subst.
@@ -674,7 +698,8 @@ induction eff.
         assert (0 < Datatypes.length (x :: x0)). {  simpl. omega. }
         pose (P := H0 0 H15).
         assert (0 < S (Datatypes.length eff)). {  simpl. omega. }
-        pose (P1 := H 0 H16 (inl (nth 0 (x :: x0) ErrorValue)) (concatn eff1 (s :: eff6) 1) _ P). destruct P1. destruct H18.
+        pose (P1 := H 0 H16 (inl (nth 0 (x :: x0) ErrorValue)) (concatn eff1 (s :: eff6) 1) _ P).
+        destruct P1. destruct H18.
         simpl_concatn_H H18. apply app_inv_head in H18. simpl in H19. auto.
       }
       destruct H15. subst.
@@ -697,21 +722,25 @@ Qed.
 (** Based on determinsim, using lists with exceptions, these are equal *)
 Lemma exception_equality {env : Environment} {exps : list Expression} (vals vals0 : list Value) 
    (ex : Exception) (eff1 : SideEffectList) (eff eff6 : list SideEffectList) (i i0 : nat) 
-   (eff3 : SideEffectList) (ex0 : Exception) (eff4 : SideEffectList) (ids ids0 : list nat) (id id' id'' : nat) :
+   (eff3 : SideEffectList) (ex0 : Exception) (eff4 : SideEffectList) (ids ids0 : list nat)
+   (id id' id'' : nat) :
 (forall j : nat,
      j < i ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
      | env, nth_id ids id j, nth j exps ErrorExp, concatn eff1 eff j | -e> | id'', v2, eff'' | ->
      inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'' /\ nth_id ids id (S j) = id'')
 ->
-| env, last ids0 id, nth i0 exps ErrorExp, concatn eff1 eff6 i0 | -e> | id'', inr ex0, concatn eff1 eff6 i0 ++ eff4 |
+| env, last ids0 id, nth i0 exps ErrorExp, concatn eff1 eff6 i0 | -e>
+| id'', inr ex0, concatn eff1 eff6 i0 ++ eff4 |
 ->
 (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-        | env, last ids id, nth i exps ErrorExp, concatn eff1 eff i | -e> | id'', v2, eff'' | -> inr ex = v2 /\ eff3 = eff'' /\ id' = id'')
+        | env, last ids id, nth i exps ErrorExp, concatn eff1 eff i | -e>
+        | id'', v2, eff'' | -> inr ex = v2 /\ eff3 = eff'' /\ id' = id'')
 ->
 (forall j : nat,
       j < i0 ->
-      | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e> | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
+      | env, nth_id ids0 id j, nth j exps ErrorExp, concatn eff1 eff6 j | -e>
+      | nth_id ids0 id (S j), inl (nth j vals0 ErrorValue),
       concatn eff1 eff6 (S j) |)
 ->
 Datatypes.length vals = i ->
@@ -728,9 +757,12 @@ Proof.
   intros. destruct (le_gt_dec i i0).
   * case_eq (le_lt_or_eq i i0 l).
     - intros.
-      pose (P1 := con_n_equality exps vals vals0 eff1 eff6 i i0 ids ids0 id _ _ _ H H2 H1 H5 H4 H3 H6 H7 H8 H9 H10 l0). inversion P1.
-    - intros. subst. pose (list_equal_until_i exps vals vals0 eff6 eff1 _ _ _ H H2 e H5 H8 H7 H9 H10). auto.
-  * pose (P := con_n_equality_rev exps vals vals0 eff1 eff6 i i0 id ids ids0 _ _ _ H H2 H5 H4 H3 H6 H7 H8 H9 H10 g H0). inversion P.
+      pose (P1 := con_n_equality exps vals vals0 eff1 eff6 i i0 ids ids0 id _ _ _
+                 H H2 H1 H5 H4 H3 H6 H7 H8 H9 H10 l0). inversion P1.
+    - intros. subst. pose (list_equal_until_i exps vals vals0 eff6 eff1 _ _ _
+                            H H2 e H5 H8 H7 H9 H10). auto.
+  * pose (P := con_n_equality_rev exps vals vals0 eff1 eff6 i i0 id ids ids0 _ _ _
+               H H2 H5 H4 H3 H6 H7 H8 H9 H10 g H0). inversion P.
 Qed.
 
 (** Map lists are equal *)
@@ -740,14 +772,18 @@ forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (eff1 : S
 (forall j : nat,
      j < length vl ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | id'', v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\ nth_id ids id (S (2*j)) = id'')
+     | env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> 
+     | id'', v2, eff'' | ->
+     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' 
+     /\ nth_id ids id (S (2*j)) = id'')
 ->
 (forall j : nat,
      j < length vl ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | id'', v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\ nth_id ids id (S (S (2*j))) = id'')
+     | env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> 
+     | id'', v2, eff'' | ->
+     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\ 
+     nth_id ids id (S (S (2*j))) = id'')
 ->
 Datatypes.length kl = Datatypes.length vl ->
 length kl = Datatypes.length vvals ->
@@ -756,7 +792,8 @@ length kl = Datatypes.length kvals ->
 ((length kl) * 2)%nat = length ids ->
 (forall j : nat,
       j < length vl ->
-      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
+      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> 
+      | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
       concatn eff1 eff7 (S (2 * j)) |)
 ->
 (forall j : nat,
@@ -777,7 +814,8 @@ Proof.
     inversion H10. inversion H8. inversion H9. inversion H11. inversion H5.
     repeat unfold_list.
     auto.
-  * intros. inversion H1. inversion H2. inversion H3. inversion H4. simpl in H9, H14, H7, H8, H10, H5, H11.
+  * intros. inversion H1. inversion H2. inversion H3. inversion H4.
+    simpl in H9, H14, H7, H8, H10, H5, H11.
     single_unfold_list. single_unfold_list. single_unfold_list. 
     single_unfold_list. single_unfold_list. single_unfold_list.
     single_unfold_list. single_unfold_list. single_unfold_list.
@@ -785,10 +823,12 @@ Proof.
     (** FIRST ELEMENTS ARE EQUAL *)
     pose (F1 := H6 0 (Nat.lt_0_succ (length x7))). simpl in F1.
     pose (F2 := H 0 (Nat.lt_0_succ _) _ _ _ F1). inversion F2. inversion H41.
-    rewrite concatn_app, concatn_app in H43. simpl_concatn_H H43. destruct H43. apply app_inv_head in H43. subst.
+    rewrite concatn_app, concatn_app in H43. simpl_concatn_H H43. destruct H43.
+    apply app_inv_head in H43. subst.
     pose (F3 := H7 0 (Nat.lt_0_succ (length x7))).
     pose (F4 := H0 0 (Nat.lt_0_succ _) _ _ _ F3). inversion F4. inversion H43.
-    rewrite concatn_app, concatn_app in H44. simpl_concatn_H H44. destruct H44. apply app_inv_head in H44. subst. simpl.
+    rewrite concatn_app, concatn_app in H44. simpl_concatn_H H44. destruct H44.
+    apply app_inv_head in H44. subst. simpl.
     (** OTHER ELEMETS *)
     assert (x3 = x15 /\ x5 = x17 /\ x2 = x14 /\ x21 = x11).
     {
@@ -823,14 +863,18 @@ Lemma map_lists_equal_until_i {env : Environment} {kl : list Expression} : foral
 (forall j : nat,
      j < length vl ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | id'', v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\ nth_id ids id (S (2*j)) = id'')
+     | env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e>
+     | id'', v2, eff'' | ->
+     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\
+     nth_id ids id (S (2*j)) = id'')
 ->
 (forall j : nat,
      j < length vl ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | id'', v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\ nth_id ids id (S (S (2*j))) = id'')
+     | env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e>
+     | id'', v2, eff'' | ->
+     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\
+     nth_id ids id (S (S (2*j))) = id'')
 ->
 Datatypes.length kl = Datatypes.length vl ->
 length kl = Datatypes.length vvals ->
@@ -839,7 +883,8 @@ length kl = Datatypes.length kvals ->
 ((length kl) * 2)%nat = Datatypes.length ids ->
 (forall j : nat,
       j < i0 ->
-      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
+      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e>
+      | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
       concatn eff1 eff7 (S (2 * j)) |)
 ->
 (forall j : nat,
@@ -852,7 +897,8 @@ Datatypes.length kvals0 = i0 ->
 i0 <= Datatypes.length kl ->
 Datatypes.length eff7 = (i0 * 2)%nat ->
 length ids0 = (i0 * 2)%nat ->
-(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
+(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e>
+| id', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
 \/
 (| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id', inl val0,
       concatn eff1 eff7 (2 * i0) ++ eff5 | /\
@@ -875,7 +921,8 @@ Proof.
     subst.
     case_eq (length vvals0).
     - intros. apply length_zero_iff_nil in H8. subst.
-      apply length_zero_iff_nil in H9. apply length_zero_iff_nil in H12. apply length_zero_iff_nil in H11. subst.
+      apply length_zero_iff_nil in H9. apply length_zero_iff_nil in H12.
+      apply length_zero_iff_nil in H11. subst.
       rewrite <- H1 in H, H0.
       simpl_concatn_H H13.
       inversion H13.
@@ -922,7 +969,8 @@ Proof.
       (** OTHER ELEMETS *)
       assert (length ves = n /\ x1 = x /\ x2 = x0 /\ x7 = x8 /\ x9 = x10).
       {
-        eapply IHkl with (eff1 := eff1 ++ e1' ++ e2') (ex0 := ex0) (eff5 := eff5) (vl := ves) (eff6 := eff6) (val0 := val0); auto.
+        eapply IHkl with (eff1 := eff1 ++ e1' ++ e2') (ex0 := ex0) (eff5 := eff5) (vl := ves)
+                         (eff6 := eff6) (val0 := val0); auto.
         * intros. assert (S j < length (ve :: ves)). { simpl. omega. }
           pose (P3 := H (S j) H36 v2 eff''). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r,
@@ -953,18 +1001,22 @@ Qed.
 Lemma map_lists_equal_until_i_key {env : Environment} {kl : list Expression} :
   forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (i i0 : nat) 
      (eff1 : SideEffectList) (eff eff7 : list SideEffectList) (ex0 : Exception) 
-     (eff5 eff2 eff6 : SideEffectList) (val0 : Value) (ex : Exception) (id id1 id1' id2' : nat) (ids ids0 : list nat) ,
+     (eff5 eff2 eff6 : SideEffectList) (val0 : Value) (ex : Exception) (id id1 id1' id2' : nat)
+     (ids ids0 : list nat) ,
 (forall j : nat,
      j < i ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
      | env, nth_id ids id (2 * j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | id'', v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\ nth_id ids id (S (2 * j)) = id'')
+     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\
+     nth_id ids id (S (2 * j)) = id'')
 ->
 (forall j : nat,
      j < i ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_id ids id (S (2 * j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | id'', v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\ nth_id ids id (S (S (2 * j))) = id'')
+     | env, nth_id ids id (S (2 * j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e>
+     | id'', v2, eff'' | ->
+     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\
+     nth_id ids id (S (S (2 * j))) = id'')
 ->
 (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
          | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | id'', v2, eff'' | ->
@@ -978,22 +1030,25 @@ Datatypes.length eff = (i * 2)%nat ->
 length ids = (i*2)%nat ->
 (forall j : nat,
       j < i0 ->
-      | env, nth_id ids0 id (2 * j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | nth_id ids0 id (S (2 * j)), inl (nth j kvals0 ErrorValue),
+      | env, nth_id ids0 id (2 * j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e>
+      | nth_id ids0 id (S (2 * j)), inl (nth j kvals0 ErrorValue),
       concatn eff1 eff7 (S (2 * j)) |)
 ->
 (forall j : nat,
-      j < i0 ->
-      | env, nth_id ids0 id (S (2 * j)), nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
-      | nth_id ids0 id (S (S (2 * j))), inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
+  j < i0 ->
+  | env, nth_id ids0 id (S (2 * j)), nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
+  | nth_id ids0 id (S (S (2 * j))), inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
 ->
 Datatypes.length vvals0 = i0 ->
 Datatypes.length kvals0 = i0 ->
 i0 <= Datatypes.length kl ->
 Datatypes.length eff7 = (i0 * 2)%nat ->
 length ids0 = (i0*2)%nat ->
-(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id1', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
+(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e>
+| id1', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
 \/
-(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id1', inl val0,
+(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e>
+| id1', inl val0,
       concatn eff1 eff7 (2 * i0) ++ eff5 | /\
 | env, id1', nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff5 | -e> | 
       id2', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 ++ eff6 |)
@@ -1140,18 +1195,21 @@ repeat (rewrite app_assoc in Hyp)
 Lemma map_lists_equal_until_i_val {env : Environment} {kl : list Expression} : 
    forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (i i0 : nat) 
    (eff1 : SideEffectList) (eff eff7 : list SideEffectList) (ex0 : Exception) 
-   (eff5 eff2 eff4 eff6 : SideEffectList) (val val0 : Value) (ex : Exception) (id id1 id2 id1' id2' : nat) (ids ids0 : list nat),
+   (eff5 eff2 eff4 eff6 : SideEffectList) (val val0 : Value) (ex : Exception)
+   (id id1 id2 id1' id2' : nat) (ids ids0 : list nat),
 (forall j : nat,
      j < i ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
      | env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | id'', v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\ nth_id ids id (S (2*j)) = id'')
+     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\
+     nth_id ids id (S (2*j)) = id'')
 ->
 (forall j : nat,
      j < i ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
      | env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | id'', v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\ nth_id ids id (S (S (2*j))) = id'')
+     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\
+     nth_id ids id (S (S (2*j))) = id'')
 ->
 (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
          | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | id'', v2, eff'' | ->
@@ -1169,20 +1227,22 @@ Datatypes.length eff = (i * 2)%nat ->
 Datatypes.length ids = (i * 2)%nat ->
 (forall j : nat,
       j < i0 ->
-      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
+      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e>
+      | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
       concatn eff1 eff7 (S (2 * j)) |)
 ->
 (forall j : nat,
-      j < i0 ->
-      | env, nth_id ids0 id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
-      | nth_id ids0 id (S (S (2*j))), inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
+  j < i0 ->
+  | env, nth_id ids0 id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
+  | nth_id ids0 id (S (S (2*j))), inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
 ->
 Datatypes.length vvals0 = i0 ->
 Datatypes.length kvals0 = i0->
 i0 <= Datatypes.length kl ->
 Datatypes.length eff7 = (i0 * 2)%nat ->
 Datatypes.length ids0 = (i0 * 2)%nat ->
-(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id1', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
+(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e>
+| id1', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
 \/
 (| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id1', inl val0,
       concatn eff1 eff7 (2 * i0) ++ eff5 | /\
@@ -1230,7 +1290,8 @@ Proof.
       pose (P2 := H10 0 (Nat.lt_0_succ n)). simpl in P1, P2.
       apply length_zero_iff_nil in H8. subst.
       pose (P3 := H1 _ _ _ P1). inversion P3.
-      inversion H8. destruct H21. rewrite concatn_app in H21. simpl_concatn_H H21. apply app_inv_head in H21. simpl in H22. subst.
+      inversion H8. destruct H21. rewrite concatn_app in H21. simpl_concatn_H H21.
+      apply app_inv_head in H21. simpl in H22. subst.
       simpl_concatn_H H2. simpl_concatn_H P2.
       pose (P4 := H2 _ _ _ P2). inversion P4. inversion H21.
     - intros. rewrite H4, H11 in *. simpl_concatn_H H16.
@@ -1249,7 +1310,8 @@ Proof.
           simpl in P4.
           assert (concatn eff1 eff 1 = eff1 ++ eff5).
           { simpl_concatn. exact H21. }
-          rewrite H22 in P4. rewrite <- app_assoc in H19. pose (P5 := P4 _ H19). inversion P5. inversion H23.
+          rewrite H22 in P4. rewrite <- app_assoc in H19. pose (P5 := P4 _ H19).
+          inversion P5. inversion H23.
 
     - intros. rewrite H4, H11 in *.
       pose (EE2 := element_exist Value n kvals0 (eq_sym H12)).
@@ -1324,30 +1386,38 @@ Qed.
 (** Map generalised until i-th element equality *)
 Lemma map_lists_equal_until_i_key_or_val {env : Environment} {kl : list Expression} : 
 forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (i : nat) (eff1 : SideEffectList) 
-      (eff eff7 : list SideEffectList) (eff2 eff4 : SideEffectList) (val : Value) (ex : Exception) (ids ids0 : list nat) (id id1 id2: nat),
+      (eff eff7 : list SideEffectList) (eff2 eff4 : SideEffectList) (val : Value) (ex : Exception)
+      (ids ids0 : list nat) (id id1 id2: nat),
 (forall j : nat,
      j < i ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | id'', v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\ nth_id ids id (S (2*j)) = id'')
+     | env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e>
+     | id'', v2, eff'' | ->
+     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\
+     nth_id ids id (S (2*j)) = id'')
 ->
 (forall j : nat,
      j < i ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | id'', v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\ nth_id ids id (S (S (2*j))) = id'')
+     | env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e>
+     | id'', v2, eff'' | ->
+     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\
+     nth_id ids id (S (S (2*j))) = id'')
 ->
 (
 (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-         | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | id'', v2, eff'' | ->
+         | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e>
+         | id'', v2, eff'' | ->
          inr ex = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'' /\ id1 = id'')
 \/
 (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-         | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | id'', v2, eff'' | ->
+         | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e>
+         | id'', v2, eff'' | ->
          inl val = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'' /\ id1 = id'')
 /\
 (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-         | env, id1, nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2 | -e> | id'', v2, eff'' | ->
+         | env, id1, nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2 | -e>
+         | id'', v2, eff'' | ->
          inr ex = v2 /\ eff4 = eff'' /\ id2 = id''))
 ->
 Datatypes.length kl = Datatypes.length vl ->
@@ -1358,13 +1428,14 @@ Datatypes.length eff = (i * 2)%nat ->
 Datatypes.length ids = (i * 2)%nat ->
 (forall j : nat,
       j < length vl ->
-      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
+      | env, nth_id ids0 id (2*j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e>
+      | nth_id ids0 id (S (2*j)), inl (nth j kvals0 ErrorValue),
       concatn eff1 eff7 (S (2 * j)) |)
 ->
 (forall j : nat,
-      j < length vl ->
-      | env, nth_id ids0 id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
-      | nth_id ids0 id (S (S (2*j))), inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
+  j < length vl ->
+  | env, nth_id ids0 id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
+  | nth_id ids0 id (S (S (2*j))), inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
 ->
 length kl = Datatypes.length vvals0 ->
 length kl = Datatypes.length kvals0 ->
@@ -1424,7 +1495,8 @@ Proof.
       pose (EE11 := element_exist SideEffectList _ _ (eq_sym H26)).
       pose (EE12 := element_exist _ _ _ (eq_sym H27)).
       pose (EE13 := element_exist _ _ _ (eq_sym H28)).
-      inversion EE10 as [e2]. inversion EE11 as [e2']. inversion EE12 as [id02]. inversion EE13 as [id02'].
+      inversion EE10 as [e2]. inversion EE11 as [e2']. inversion EE12 as [id02].
+      inversion EE13 as [id02'].
       inversion H24. inversion H29. inversion H30. inversion H31. subst.
       (** FIRST ELEMENTS ARE EQUAL *)
       pose (F1 := H8 0 (Nat.lt_0_succ (length ves))).
@@ -1453,11 +1525,16 @@ Proof.
               <- app_assoc in P3. simpl in H35. rewrite Nat.add_0_r in H35.
           pose (P4 := P3 _ H35). simpl. rewrite Nat.add_0_r. assumption.
         * intros. destruct H1 as [Def| Def'].
-          - left. intros. simpl mult in Def, H1. simpl mult. rewrite concatn_app, Nat.add_0_r, Nat.add_succ_r, concatn_app, <- app_assoc in Def. rewrite Nat.add_0_r. rewrite Nat.add_0_r in H1. apply Def.
+          - left. intros. simpl mult in Def, H1. simpl mult.
+          rewrite concatn_app, Nat.add_0_r, Nat.add_succ_r, concatn_app, <- app_assoc in Def.
+          rewrite Nat.add_0_r. rewrite Nat.add_0_r in H1. apply Def.
             rewrite <- last_element_equal, <- last_element_equal. simpl. assumption.
-          - right. simpl mult in Def'. rewrite concatn_app, Nat.add_0_r, Nat.add_succ_r, concatn_app, <- app_assoc, <- last_element_equal, <- last_element_equal in Def'. simpl in Def'. inversion Def'.
+          - right. simpl mult in Def'.
+            rewrite concatn_app, Nat.add_0_r, Nat.add_succ_r, concatn_app, <- app_assoc, 
+                  <- last_element_equal, <- last_element_equal in Def'. simpl in Def'. inversion Def'.
             split.
-            + intros. simpl mult. rewrite Nat.add_0_r. apply H1. simpl mult in H35. rewrite Nat.add_0_r in H35. assumption.
+            + intros. simpl mult. rewrite Nat.add_0_r. apply H1. simpl mult in H35.
+              rewrite Nat.add_0_r in H35. assumption.
             + intros. apply H34. simpl mult in H35. rewrite Nat.add_0_r in H35. assumption.
 
         * simpl in H5. omega.

--- a/Core_Erlang_Determinism_Helpers.v
+++ b/Core_Erlang_Determinism_Helpers.v
@@ -930,148 +930,185 @@ Proof.
       }
       destruct H34. destruct H35. destruct H36. destruct H37. subst. auto.
 Qed.
-(*
+
 (** Map lists are equal until ith key *)
 Lemma map_lists_equal_until_i_key {env : Environment} {kl : list Expression} :
   forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (i i0 : nat) 
      (eff1 : SideEffectList) (eff eff7 : list SideEffectList) (ex0 : Exception) 
-     (eff5 eff2 eff6 : SideEffectList) (val0 : Value) (ex : Exception),
+     (eff5 eff2 eff6 : SideEffectList) (val0 : Value) (ex : Exception) (id id1 id1' id2' : nat) (ids ids0 : list nat) ,
 (forall j : nat,
      j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id (2 * j), nth j kl ErrorExp, concatn eff1 eff (2 * j) | -e> | id'', v2, eff'' | ->
+     inl (nth j kvals ErrorValue) = v2 /\ concatn eff1 eff (S (2 * j)) = eff'' /\ nth_id ids id (S (2 * j)) = id'')
 ->
 (forall j : nat,
      j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList),
-     | env, nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'')
+     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_id ids id (S (2 * j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j)) | -e> | id'', v2, eff'' | ->
+     inl (nth j vvals ErrorValue) = v2 /\ concatn eff1 eff (S (S (2 * j))) = eff'' /\ nth_id ids id (S (S (2 * j))) = id'')
 ->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList),
-         | env, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | v2, eff'' | ->
-         inr ex = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'')
+(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+         | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | id'', v2, eff'' | ->
+         inr ex = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'' /\ id1 = id'')
 ->
 Datatypes.length kl = Datatypes.length vl ->
 Datatypes.length vvals = i ->
 Datatypes.length kvals = i ->
 i <= Datatypes.length kl ->
 Datatypes.length eff = (i * 2)%nat ->
+length ids = (i*2)%nat ->
 (forall j : nat,
       j < i0 ->
-      | env, nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | inl (nth j kvals0 ErrorValue),
+      | env, nth_id ids0 id (2 * j), nth j kl ErrorExp, concatn eff1 eff7 (2 * j) | -e> | nth_id ids0 id (S (2 * j)), inl (nth j kvals0 ErrorValue),
       concatn eff1 eff7 (S (2 * j)) |)
 ->
 (forall j : nat,
       j < i0 ->
-      | env, nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
-      | inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
+      | env, nth_id ids0 id (S (2 * j)), nth j vl ErrorExp, concatn eff1 eff7 (S (2 * j)) | -e>
+      | nth_id ids0 id (S (S (2 * j))), inl (nth j vvals0 ErrorValue), concatn eff1 eff7 (S (S (2 * j))) |)
 ->
 Datatypes.length vvals0 = i0 ->
 Datatypes.length kvals0 = i0 ->
 i0 <= Datatypes.length kl ->
 Datatypes.length eff7 = (i0 * 2)%nat ->
-(| env, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
+length ids0 = (i0*2)%nat ->
+(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id1', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 |
 \/
-(| env, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | inl val0,
+(| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id1', inl val0,
       concatn eff1 eff7 (2 * i0) ++ eff5 | /\
-| env, nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff5 | -e> | 
-      inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 ++ eff6 |)
+| env, id1', nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff5 | -e> | 
+      id2', inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 ++ eff6 |)
 )
 ->
-i = i0 /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7.
+i = i0 /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7 /\ ids = ids0.
 Proof.
   induction kl.
-  * intros. inversion H2. apply eq_sym, length_zero_iff_nil in H15. subst. inversion H11.
-    apply length_zero_iff_nil in H9. subst. inversion H5. apply length_zero_iff_nil in H9.
-    subst. inversion H4. apply length_zero_iff_nil in H9. subst. inversion H6.
-    apply length_zero_iff_nil in H9. subst. inversion H10. apply length_zero_iff_nil in H9. subst.
-    inversion H12. apply length_zero_iff_nil in H9. subst. auto.
-  * intros. inversion H2. simpl in H2. 
-    pose (EE1 := element_exist Expression (length kl) vl H15). inversion EE1 as [ve]. inversion H14 as [ves].
-    subst.
+  * intros. inversion H2. apply eq_sym, length_zero_iff_nil in H17. subst.
+    inversion H12. apply length_zero_iff_nil in H10. subst.
+    inversion H5. apply length_zero_iff_nil in H10. subst.
+    inversion H6. apply length_zero_iff_nil in H10. subst.
+    inversion H7. apply length_zero_iff_nil in H10. subst.
+    inversion H11. apply length_zero_iff_nil in H10. subst.
+    inversion H4. apply length_zero_iff_nil in H10. subst. 
+    inversion H13. apply length_zero_iff_nil in H10. subst.
+    inversion H14. apply length_zero_iff_nil in H10. subst. 
+    auto.
+  * intros. inversion H2.
+    pose (EE1 := element_exist Expression (length kl) vl H17).
+    inversion EE1 as [ve]. inversion H16 as [ves]. subst.
     case_eq (length vvals); case_eq (length vvals0).
-    - intros. apply length_zero_iff_nil in H3. apply length_zero_iff_nil in H9. subst.
-      apply length_zero_iff_nil in H4. apply length_zero_iff_nil in H10.
-      apply length_zero_iff_nil in H12. apply length_zero_iff_nil in H6. subst. auto.
-    - intros. rewrite H3, H9 in *.
+    - intros.
+      apply length_zero_iff_nil in H3.
+      apply length_zero_iff_nil in H10. subst.
+      apply length_zero_iff_nil in H4.
       apply length_zero_iff_nil in H6.
-      pose (EE2 := element_exist SideEffectList _ eff7 (eq_sym H12)). inversion EE2. inversion H16.
-      subst. inversion H12. 
-      pose (EE3 := element_exist SideEffectList _ x0 (eq_sym H17)).
-      inversion EE3. inversion H6. subst.
-      pose (P1 := H7 0 (Nat.lt_0_succ n)). pose (P2 := H8 0 (Nat.lt_0_succ n)). simpl in P1, P2.
-      pose (P3 := H1 _ _ P1). inversion P3.
-      inversion H18.
-    - intros. rewrite H3, H9 in *. simpl_concatn_H H13.
-      inversion H13. 2: inversion H16.
+      apply length_zero_iff_nil in H7.
+      apply length_zero_iff_nil in H11.
+      apply length_zero_iff_nil in H13.
+      apply length_zero_iff_nil in H14.
+      subst. auto.
+    - intros. rewrite H3, H10 in *.
+      apply length_zero_iff_nil in H6.
+      pose (EE2 := element_exist SideEffectList _ eff7 (eq_sym H13)).
+      inversion EE2. inversion H18.
+      subst. inversion H13. 
+      pose (EE3 := element_exist SideEffectList _ x0 (eq_sym H19)).
+      inversion EE3. inversion H6.
+      apply length_zero_iff_nil in H7. subst.
+      pose (P1 := H8 0 (Nat.lt_0_succ n)). pose (P2 := H9 0 (Nat.lt_0_succ n)). simpl in P1, P2.
+      pose (P3 := H1 _ _ _ P1). inversion P3.
+      inversion H7.
+    - intros. rewrite H3, H10 in *. simpl_concatn_H H15.
+      inversion H15.
       (** KEY EXCEPTION *)
         + pose (P2 := H 0 (Nat.lt_0_succ n) (inr ex0) (eff1 ++ eff5)).
-          simpl_concatn_H P2. pose (P3 := P2 H16). inversion P3. inversion H17.
+          apply length_zero_iff_nil in H14. subst.
+          simpl_concatn_H P2. pose (P3 := P2 _ H18). inversion P3. inversion H14.
       (** VALUE EXCEPTION *)
-        + pose (P2 := H 0 (Nat.lt_0_succ n) (inl val0) (eff1 ++ eff5)).
-          simpl_concatn_H P2. inversion H16. pose (P3 := P2 H17).
+        + destruct H18.
+          pose (P2 := H 0 (Nat.lt_0_succ n) (inl val0) (eff1 ++ eff5)).
+          simpl_concatn_H P2.
+          apply length_zero_iff_nil in H14. subst.
+          pose (P3 := P2 _ H18).
           inversion P3.
           pose (P4 := H0 0 (Nat.lt_0_succ n) (inr ex0) (eff1 ++ eff5 ++ eff6)). simpl in P4.
-          assert (concatn eff1 eff 1 = eff1 ++ eff5). { simpl_concatn. exact H22. }
-          rewrite H23 in P4 at 1. rewrite <- app_assoc in H20. pose (P5 := P4 H20).
-          inversion P5. inversion H24.
+          destruct H20. subst.
+          assert (concatn eff1 eff 1 = eff1 ++ eff5). { simpl_concatn. exact H20. }
+          rewrite H21 in P4. rewrite <- app_assoc in H19.
+          pose (P5 := P4 _ H19).
+          inversion P5. inversion H22.
 
-    - intros. rewrite H3, H9 in *. simpl in H6, H12.
-      pose (EE2 := element_exist Value _ kvals0 (eq_sym H10)).
-      pose (EE3 := element_exist Value _ vvals0 (eq_sym H3)).
-      pose (EE4 := element_exist Value _ kvals (eq_sym H4)).
-      pose (EE5 := element_exist Value _ vvals (eq_sym H9)).
+    - intros. rewrite H3, H10 in *.
+      pose (EE2 := element_exist Value n kvals0 (eq_sym H11)).
+      pose (EE3 := element_exist Value n vvals0 (eq_sym H3)).
+      pose (EE4 := element_exist Value n0 kvals (eq_sym H4)).
+      pose (EE5 := element_exist Value n0 vvals (eq_sym H10)).
       pose (EE6 := element_exist SideEffectList _ eff (eq_sym H6)).
-      pose (EE7 := element_exist SideEffectList _ eff7 (eq_sym H12)).
-      inversion EE2 as [kv']. inversion EE3 as [vv']. inversion EE4 as [kv]. inversion EE5 as [vv].
-      inversion EE6 as [e1]. inversion EE7 as [e1']. inversion H17. inversion H18. 
-      inversion H19. inversion H20. inversion H21. inversion H16. subst.
-      inversion H6. inversion H12.
-      pose (EE8 := element_exist SideEffectList _ x2 (eq_sym H23)).
-      pose (EE9 := element_exist SideEffectList _ x3 (eq_sym H24)).
-      inversion EE8 as [e2]. inversion EE9 as [e2']. inversion H22. inversion H25. subst.
+      pose (EE7 := element_exist SideEffectList _ eff7 (eq_sym H13)).
+      pose (EE8 := element_exist _ _ _ (eq_sym H7)).
+      pose (EE9 := element_exist _ _ _ (eq_sym H14)).
+      inversion EE2 as [kv']. inversion EE3 as [vv']. inversion EE4 as [kv]. 
+      inversion EE5 as [vv]. inversion EE6 as [e1]. inversion EE7 as [e1'].
+      inversion EE8 as [id01]. inversion EE9 as [id01'].
+      inversion H18. inversion H19. inversion H20. inversion H21.
+      inversion H22. inversion H23. inversion H24. inversion H25. subst.
+      inversion H6. inversion H13. inversion H7. inversion H14.
+      pose (EE10 := element_exist SideEffectList _ x3 (eq_sym H27)).
+      pose (EE11 := element_exist SideEffectList _ x4 (eq_sym H28)).
+      pose (EE12 := element_exist _ _ x5 (eq_sym H29)).
+      pose (EE13 := element_exist _ _ x6 (eq_sym H30)).
+      inversion EE10 as [e2]. inversion EE11 as [e2'].
+      inversion EE12 as [id02]. inversion EE13 as [id02'].
+      inversion H26. inversion H31. inversion H32. inversion H33. subst.
+      clear EE10. clear EE11. clear EE12. clear EE13.
+      clear EE6. clear EE7. clear EE8. clear EE9.
       (** FIRST ELEMENTS ARE EQUAL *)
-      pose (F1 := H7 0 (Nat.lt_0_succ n)).
-      pose (F2 := H 0 (Nat.lt_0_succ n0) _ _ F1). inversion F2. inversion H26.
-      rewrite concatn_app, concatn_app in H27. simpl_concatn_H H27. apply app_inv_head in H27. subst.
-      pose (F3 := H8 0 (Nat.lt_0_succ n)).
-      pose (F4 := H0 0 (Nat.lt_0_succ n0) _ _ F3). inversion F4. inversion H27.
-      rewrite concatn_app, concatn_app in H28. simpl_concatn_H H28. apply app_inv_head in H28. subst.
+      pose (F1 := H8 0 (Nat.lt_0_succ n)).
+      pose (F2 := H 0 (Nat.lt_0_succ n0) _ _ _ F1). inversion F2. inversion H34.
+      destruct H35. simpl in H36.
+      rewrite concatn_app, concatn_app in H35. simpl_concatn_H H35. apply app_inv_head in H35. subst.
+      pose (F3 := H9 0 (Nat.lt_0_succ n)).
+      pose (F4 := H0 0 (Nat.lt_0_succ n0) _ _ _ F3). inversion F4. inversion H35.
+      destruct H36. simpl in H37.
+      rewrite concatn_app, concatn_app in H36. simpl_concatn_H H36. apply app_inv_head in H36. subst.
       (** OTHER ELEMETS *)
-      assert (n0 = n /\ x0 = x4 /\ x1 = x /\ x5 = x6).
+      assert (n0 = n /\ x1 = x /\ x2 = x0 /\ x7 = x8 /\ x9 = x10).
       {
-        apply IHkl with (eff1 := eff1 ++ e1' ++ e2') (ex0 := ex0) (eff5 := eff5) (eff2 := eff2) 
+        eapply IHkl with (eff1 := eff1 ++ e1' ++ e2') (ex0 := ex0) (eff5 := eff5) (eff2 := eff2) 
                         (ex := ex) (vl := ves) (eff6 := eff6) (val0 := val0); auto.
-        * intros. assert (S j < S n0). { omega. } pose (P3 := H (S j) H30 v2 eff'').
+        * intros. assert (S j < S n0). { omega. } pose (P3 := H (S j) H38 v2 eff'').
           simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r,
-               <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl in H29. rewrite Nat.add_0_r in H29.
-          pose (P4 := P3 H29). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. assert (S j < S n0). { omega. } 
-          pose (P3 := H0 (S j) H30 v2 eff''). simpl in P3.
+               <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl in H37. rewrite Nat.add_0_r in H37.
+          pose (P4 := P3 _ H37). simpl. rewrite Nat.add_0_r. assumption.
+        * intros. assert (S j < S n0). { omega. }
+          pose (P3 := H0 (S j) H38 v2 eff''). simpl in P3.
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r,
-               <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl in H29. rewrite Nat.add_0_r in H29.
-          pose (P4 := P3 H29). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. pose (P3 := H1 v2 eff''). simpl in P3. simpl in P3.
-           rewrite concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app, <- app_assoc in P3.
-           simpl. rewrite Nat.add_0_r. simpl in H28. rewrite Nat.add_0_r in H28. apply (P3 H28).
+               <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl in H37. rewrite Nat.add_0_r in H37.
+          pose (P4 := P3 _ H37). simpl. rewrite Nat.add_0_r. assumption.
+        * intros. pose (P3 := H1 v2 eff'').
+          rewrite <- last_element_equal, <- last_element_equal in P3. simpl in P3.
+          rewrite concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app, <- app_assoc in P3.
+          simpl. rewrite Nat.add_0_r. simpl in H36. rewrite Nat.add_0_r in H36. apply (P3 _ H36).
         * simpl in H5. omega.
         * intros. assert (S j < S n). { omega. }
-          pose (P3 := H7 (S j) H29). simpl in P3.
+          pose (P3 := H8 (S j) H37). simpl in P3.
           rewrite Nat.add_0_r, concatn_app, concatn_app, concatn_app,
                <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl. rewrite Nat.add_0_r. assumption.
         * intros. assert (S j < S n). { omega. }
-        pose (P3 := H8 (S j) H29).
+        pose (P3 := H9 (S j) H37).
           simpl in P3. 
           rewrite concatn_app, concatn_app, concatn_app, Nat.add_0_r,
                <- plus_n_Sm, concatn_app, <- app_assoc in P3. simpl. rewrite Nat.add_0_r. assumption.
         * simpl in H11. omega.
-        * simpl in H13. 
+        * rewrite <- last_element_equal, <- last_element_equal in H15.
+          simpl in H15. 
           rewrite concatn_app, Nat.add_0_r, <- plus_n_Sm, concatn_app,
-               <- app_assoc in H13. simpl. rewrite Nat.add_0_r. assumption.
+               <- app_assoc in H15. simpl. rewrite Nat.add_0_r.
+          exact H15.
       }
-      inversion H28. inversion H30. inversion H32. subst. auto.
+      destruct H36. destruct H37. destruct H38. destruct H39. subst. auto.
 Qed.
 
 Ltac simpl_concatn_app Hyp :=
@@ -1085,7 +1122,7 @@ repeat (rewrite app_assoc in Hyp)
 Lemma map_lists_equal_until_i_val {env : Environment} {kl : list Expression} : 
    forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (i i0 : nat) 
    (eff1 : SideEffectList) (eff eff7 : list SideEffectList) (ex0 : Exception) 
-   (eff5 eff2 eff4 eff6 : SideEffectList) (val val0 : Value) (ex : Exception),
+   (eff5 eff2 eff4 eff6 : SideEffectList) (val val0 : Value) (ex : Exception) (id ),
 (forall j : nat,
      j < i ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList),

--- a/Core_Erlang_Determinism_Helpers.v
+++ b/Core_Erlang_Determinism_Helpers.v
@@ -381,7 +381,8 @@ Qed.
 (** First i elements are equal, but with changed hypotheses *)
 Lemma firstn_eq_rev {env : Environment} {eff : list SideEffectList} : 
    forall (eff5 : list SideEffectList) (exps : list Expression) (vals vals0 : list Value) 
-          (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat),
+          (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat) (eff2 : SideEffectList) 
+          (id' : nat) (ex : Exception),
 (forall j : nat,
      j < Datatypes.length vals ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
@@ -391,7 +392,11 @@ Lemma firstn_eq_rev {env : Environment} {eff : list SideEffectList} :
 (forall i : nat,
      i < Datatypes.length exps ->
      | env, nth_id ids0 id i, nth i exps ErrorExp, concatn eff1 eff5 i | -e> | nth_id ids0 id (S i), inl (nth i vals0 ErrorValue),
-     concatn eff1 eff5 (S i) |)
+     concatn eff1 eff5 (S i) |) ->
+(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+        | env, last ids id, nth (Datatypes.length vals) exps ErrorExp,
+        concatn eff1 eff (Datatypes.length vals) | -e> | id'', v2, eff'' | ->
+        inr ex = v2 /\ concatn eff1 eff (Datatypes.length vals) ++ eff2 = eff'' /\ id' = id'')
 ->
 Datatypes.length vals < Datatypes.length exps ->
 Datatypes.length eff = Datatypes.length vals ->
@@ -400,54 +405,54 @@ Datatypes.length exps = Datatypes.length eff5 ->
 length exps = length ids0 ->
 length ids = length vals
 ->
-firstn (Datatypes.length vals) eff5 = firstn (Datatypes.length vals) eff.
+False.
 Proof.
   induction eff.
-  * intros. inversion H2. simpl. reflexivity.
+  * intros. apply eq_sym, length_zero_iff_nil in H3. subst.
+    apply length_zero_iff_nil in H7. subst.
+    pose (P := H0 0 H2).
+    pose (P2 := H1 _ _ _ P). inversion P2. congruence.
   * intros. destruct eff5.
-    - inversion H4. rewrite H4 in H1. inversion H1.
-    - inversion H2. inversion H4. simpl.
+    - inversion H5. rewrite H5 in H2. inversion H2.
+    - inversion H3. inversion H5.
     (* first elements *)
-      assert (0 < length exps). { omega. } assert (0 < length vals). { omega. } simpl in H0, H1.
-      assert (S (Datatypes.length eff5) = Datatypes.length exps).
-      { auto. }
+      assert (0 < length exps). { omega. } assert (0 < length vals). { omega. }
+      assert (S (Datatypes.length eff5) = Datatypes.length exps). { auto. }
       assert (Datatypes.length exps = Datatypes.length vals0) as LENGTH. { auto. }
       assert (S (Datatypes.length eff) = Datatypes.length vals) as Helper1. { auto. }
       assert (Datatypes.length exps = Datatypes.length ids0) as Helper2. { auto. }
       (* single_unfold_list H9. *)
-      pose (EE1 := element_exist Expression (length eff5) exps (eq_sym H4)).
-      pose (EE2 := element_exist Value (length eff) vals H8).
-      rewrite H4 in H3, H5. rewrite <- H8 in H6.
-      pose (EE3 := element_exist Value (length eff5) vals0 H3).
-      pose (EE4 := element_exist _ _ _ (eq_sym H6)).
-      pose (EE5 := element_exist _ _ _ H5).
+      pose (EE1 := element_exist Expression (length eff5) exps (eq_sym H5)).
+      pose (EE2 := element_exist Value (length eff) vals H9).
+      rewrite H5 in H4, H6. rewrite <- H9 in H7.
+      pose (EE3 := element_exist Value (length eff5) vals0 H4).
+      pose (EE4 := element_exist _ _ _ (eq_sym H7)).
+      pose (EE5 := element_exist _ _ _ H6).
 
       inversion EE1 as [e]. inversion EE2 as [v]. inversion EE3 as [v'].
-      inversion EE4 as [id']. inversion EE5 as [id'']. 
-      inversion H12. inversion H13. inversion H14. inversion H15. inversion H16. subst.
-      pose (P0 := H0 0 H7). simpl_concatn_H P0.
-      pose (P1 := H 0 H10 (inl v') (eff1 ++ s ++ [])). simpl_concatn_H P1.
-      pose (P2 := P1 _ P0). destruct P2. destruct H18. apply app_inv_head in H18. inversion H17. subst.
+      inversion EE4 as [id0']. inversion EE5 as [id0'']. 
+      inversion H13. inversion H14. inversion H15. inversion H16. inversion H17. subst.
+      pose (P0 := H0 0 H8). simpl_concatn_H P0.
+      pose (P1 := H 0 H11 (inl v') (eff1 ++ s ++ [])). simpl_concatn_H P1.
+      pose (P2 := P1 _ P0). destruct P2. destruct H19. apply app_inv_head in H19. inversion H18. subst.
     (* other elements *)
-      inversion H2.
-      assert (firstn (Datatypes.length x0) eff5 = firstn (Datatypes.length x0) eff).
-      {
-        apply IHeff with (exps := x) (vals := x0) (eff1 := eff1 ++ s) (vals0 := x1) (ids := x2) (ids0 := x3) (id := id''); auto.
-        - intros. assert (S j < Datatypes.length (v' :: x0)). { simpl. omega. } 
-          pose (A := H (S j) H21 v2 eff''). rewrite concatn_app, concatn_app in A. simpl in A. 
-          pose (B := A _ H20). assumption.
-        - intros. assert (S i < Datatypes.length (e :: x)). { simpl. omega. } 
-          pose (A := H0 (S i) H20). rewrite concatn_app, concatn_app in A. simpl in A. exact A.
-        - intuition.
-        - inversion H6. omega.
-      }
-      rewrite <- H19 in H18. rewrite H18. reflexivity.
+      inversion H3.
+      apply IHeff with (exps := x) (vals := x0) (eff1 := eff1 ++ s) (vals0 := x1) (ids := x2) (ids0 := x3) (id := id0'') (ex := ex) (eff5 := eff5) (eff2 := eff2) (id' := id'); auto.
+        + intros. assert (S j < Datatypes.length (v' :: x0)). { simpl. omega. } 
+          pose (A := H (S j) H22 v2 eff''). rewrite concatn_app, concatn_app in A. simpl in A. 
+          pose (B := A _ H21). assumption.
+        + intros. assert (S i < Datatypes.length (e :: x)). { simpl. omega. } 
+          pose (A := H0 (S i) H21). rewrite concatn_app, concatn_app in A. simpl in A. exact A.
+        + intros. rewrite <- last_element_equal in H1. simpl in H1. rewrite concatn_app in H1. apply H1. assumption.
+        + intuition.
+        + inversion H7. omega.
 Qed.
 
 (** First i (length vals) element are equal with concatn *)
 Lemma eff_until_i_rev {env : Environment} {eff : list SideEffectList} : 
    forall (eff5 : list SideEffectList) (exps : list Expression) (vals vals0 : list Value) 
-          (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat),
+          (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat) (eff2 : SideEffectList) 
+          (id' : nat) (ex : Exception),
 (forall j : nat,
      j < Datatypes.length vals ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
@@ -457,7 +462,11 @@ Lemma eff_until_i_rev {env : Environment} {eff : list SideEffectList} :
 (forall i : nat,
      i < Datatypes.length exps ->
      | env, nth_id ids0 id i, nth i exps ErrorExp, concatn eff1 eff5 i | -e> | nth_id ids0 id (S i), inl (nth i vals0 ErrorValue),
-     concatn eff1 eff5 (S i) |)
+     concatn eff1 eff5 (S i) |) ->
+(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+        | env, last ids id, nth (Datatypes.length vals) exps ErrorExp,
+        concatn eff1 eff (Datatypes.length vals) | -e> | id'', v2, eff'' | ->
+        inr ex = v2 /\ concatn eff1 eff (Datatypes.length vals) ++ eff2 = eff'' /\ id' = id'')
 ->
 Datatypes.length vals < Datatypes.length exps ->
 Datatypes.length eff = Datatypes.length vals ->
@@ -466,10 +475,9 @@ Datatypes.length exps = Datatypes.length eff5 ->
 length exps = length ids0 ->
 length ids = length vals
 ->
-concatn eff1 eff5 (Datatypes.length vals) = concatn eff1 eff (Datatypes.length vals).
+False.
 Proof.
-  intros. simpl_concatn. rewrite (firstn_eq_rev eff5 exps vals vals0 eff1 _ _ _ H H0 H1 H2 H3 H4 H5 H6). 
-  reflexivity.
+  intros. simpl_concatn. apply (firstn_eq_rev eff5 exps vals vals0 eff1 _ _ _ _ _ _ H H0 H1 H2 H3 H4 H5 H6 H7).
 Qed.
 
 Lemma nat_exist {n m : nat} : n < m -> exists x, m = S x.
@@ -689,14 +697,14 @@ Qed.
 (** Based on determinsim, using lists with exceptions, these are equal *)
 Lemma exception_equality {env : Environment} {exps : list Expression} (vals vals0 : list Value) 
    (ex : Exception) (eff1 : SideEffectList) (eff eff6 : list SideEffectList) (i i0 : nat) 
-   (eff3 : SideEffectList) (ex0 : Exception) (eff4 : SideEffectList) (ids ids0 : list nat) (id id' : nat) :
+   (eff3 : SideEffectList) (ex0 : Exception) (eff4 : SideEffectList) (ids ids0 : list nat) (id id' id'' : nat) :
 (forall j : nat,
      j < i ->
      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
      | env, nth_id ids id j, nth j exps ErrorExp, concatn eff1 eff j | -e> | id'', v2, eff'' | ->
      inl (nth j vals ErrorValue) = v2 /\ concatn eff1 eff (S j) = eff'' /\ nth_id ids id (S j) = id'')
 ->
-| env, last ids0 id, nth i0 exps ErrorExp, concatn eff1 eff6 i0 | -e> | id', inr ex0, concatn eff1 eff6 i0 ++ eff4 |
+| env, last ids0 id, nth i0 exps ErrorExp, concatn eff1 eff6 i0 | -e> | id'', inr ex0, concatn eff1 eff6 i0 ++ eff4 |
 ->
 (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
         | env, last ids id, nth i exps ErrorExp, concatn eff1 eff i | -e> | id'', v2, eff'' | -> inr ex = v2 /\ eff3 = eff'' /\ id' = id'')

--- a/Core_Erlang_Environment.v
+++ b/Core_Erlang_Environment.v
@@ -21,52 +21,19 @@ match env with
 end.
 
 (** Get *)
-Fixpoint get_value (env : Environment) (key : (Var + FunctionIdentifier)) : (Value + Exception) :=
+Fixpoint get_value (env : Environment) (key : (Var + FunctionIdentifier)) 
+   : (Value + Exception) :=
 match env with
 | [ ] => inr novar
 | (k,v)::xs => if uequal key k then inl v else get_value xs key
 end.
 
-Fixpoint insert_value (env : Environment) (key : (Var + FunctionIdentifier)) (value : Value) :=
+Fixpoint insert_value (env : Environment) (key : (Var + FunctionIdentifier)) 
+   (value : Value) : Environment :=
 match env with
   | [] => [(key, value)]
   | (k,v)::xs => if uequal k key then (key,value)::xs else (k,v)::(insert_value xs key value)
 end.
-
-(** Set with overwrite *)
-(* Fixpoint insert_closure (env : Environment) (key : (Var + FunctionIdentifier)) (value : Value) (count : nat) : Environment :=
-match value with
-| VClosure def ext n ps b =>
-  match env with
-  | [] => [(key, VClosure def ext count ps b)]
-  | (k,v)::xs => if uequal k key 
-                 then match v with
-                      | VClosure _ _ n _ _ => (key, VClosure def ext n ps b)::xs
-                      | _ => (key, VClosure def ext count ps b)::xs
-                      end
-                 else (k,v)::(insert_value xs key value count)
-  end
-| _ =>
-  match env with
-  | [] => [(key, value)]
-  | (k,v)::xs => if uequal k key then (key,value)::xs else (k,v)::(insert_value xs key value count)
-  end
-end. *)
-
-(** Set without overwrite *)
-(* Fixpoint insert_value_no_overwrite (env : Environment) (key : (Var + FunctionIdentifier)) (value : Value) : Environment :=
-match env with
-| [] => [(key, value)]
-| (k,v)::xs => if uequal k key then env else (k,v)::(insert_value xs key value)
-end.
- *)
-
-(* Merge environments *)
-(* Fixpoint env_fold (e1 e2: Environment) : Environment :=
-match e1 with
-| [] => e2
-| (k,v)::xs => env_fold xs (insert_value e2 k v)
-end. *)
 
 (** Add additional bindings *)
 (** We used here: when binding, variables must be unique *)
@@ -77,7 +44,8 @@ match bindings with
 end.
 
 (** Add bindings with two lists *)
-Fixpoint append_vars_to_env (vl : list Var) (el : list Value) (d : Environment) : Environment :=
+Fixpoint append_vars_to_env (vl : list Var) (el : list Value) (d : Environment) 
+   : Environment :=
 match vl, el with
 | [], [] => d
 | v::vs, e::es => append_vars_to_env vs es (insert_value d (inl v) e)
@@ -87,43 +55,44 @@ end.
 (** Not Overwriting insert *)
 (** Overwriting does not fit with this recursion *)
 Fixpoint insert_function (id : nat) (v : FunctionIdentifier) (p : list Var) (b : Expression) 
- (l : list (nat * FunctionIdentifier * FunctionExpression)) : list (nat * FunctionIdentifier * FunctionExpression) :=
+   (l : list (nat * FunctionIdentifier * FunctionExpression)) 
+    : list (nat * FunctionIdentifier * FunctionExpression) :=
 match l with
 | [] => [(id, v, (p, b))]
-| (id', k, v0)::xs => if equal k v then (id', k, v0)::xs else (id', k, v0)::(insert_function id v p b xs)
+| (id', k, v0)::xs => if equal k v then (id', k, v0)::xs 
+                                   else (id', k, v0)::(insert_function id v p b xs)
 end.
 
 (** Lists represented functions *)
 Fixpoint list_functions (vl : list FunctionIdentifier) (paramss : list (list Var)) 
-      (bodies : list Expression) (last_id : nat) : list (nat * FunctionIdentifier * FunctionExpression) :=
+      (bodies : list Expression) (last_id : nat) 
+      : list (nat * FunctionIdentifier * FunctionExpression) :=
 match vl, paramss, bodies with
 | [], [], [] => []
-| v::vs, varl::ps, e::bs => insert_function last_id v varl e (list_functions vs ps bs (S last_id))
+| v::vs, varl::ps, e::bs => insert_function last_id v varl e 
+                                 (list_functions vs ps bs (S last_id))
 | _, _, _ => []
 end.
-
-(* (** Inserting closures *)
-Fixpoint insert_closure (name : FunctionIdentifier) (env def : Environment) (deffuns : list (FunctionIdentifier * FunctionExpression)) (params : list Var) (count : nat)
-      (body :  Expression) : Environment :=
-match env with
-| [] => [(inr name, VClosure def deffuns count varl e)]
-| (k,v)::xs => if uequal k (inr name) then (key,value)::xs else (k,v)::(insert_value xs key value)
-end. *)
 
 (** Add functions *)
 Fixpoint append_funs_to_env_base (vl : list FunctionIdentifier) (paramss : list (list Var)) 
       (bodies : list Expression) (d : Environment) (def : Environment) 
-      (deffuns : list (nat * FunctionIdentifier * FunctionExpression)) (last_id : nat) : Environment :=
+      (deffuns : list (nat * FunctionIdentifier * FunctionExpression)) (last_id : nat) 
+      : Environment :=
 match vl, paramss, bodies with
 | [], [], [] => d
 | v::vs, varl::ps, e::bs => append_funs_to_env_base vs ps bs 
-                              (insert_value d (inr v) (VClosure def deffuns last_id varl e)) def deffuns (S last_id)
+                              (insert_value d (inr v) 
+                                           (VClosure def deffuns last_id varl e)) 
+                                           def deffuns (S last_id)
 | _, _, _ => []
 end.
 
 Definition append_funs_to_env (vl : list FunctionIdentifier) (paramss : list (list Var)) 
       (bodies : list Expression) (d : Environment) (last_id : nat) : Environment :=
-append_funs_to_env_base vl paramss bodies d d (list_functions vl paramss bodies last_id) last_id
+append_funs_to_env_base vl paramss bodies d d 
+                       (list_functions vl paramss bodies last_id)
+                       last_id
 .
 
 (** Examples *)
@@ -142,14 +111,16 @@ Compute insert_function 2 ("f1"%string, 0) [] ErrorExp (list_functions
                               [ErrorExp; ErrorExp; ErrorExp] 0).
 
 (** Environment construction from the extension and the reference *)
-Fixpoint get_env_base (env def : Environment) (ext defext : list (nat * FunctionIdentifier * FunctionExpression))
+Fixpoint get_env_base (env def : Environment) 
+   (ext defext : list (nat * FunctionIdentifier * FunctionExpression))
    : Environment :=
 match ext with
 | [] => env
 | (id, f1, (pl, b))::xs => get_env_base (insert_value env (inr f1) (VClosure def defext id pl b)) def xs defext
 end.
 
-Definition get_env (env : Environment) (ext : list (nat * FunctionIdentifier * FunctionExpression))
+Definition get_env (env : Environment) 
+   (ext : list (nat * FunctionIdentifier * FunctionExpression))
    : Environment :=
   get_env_base env env ext ext
 .

--- a/Core_Erlang_Environment.v
+++ b/Core_Erlang_Environment.v
@@ -28,6 +28,7 @@ match env with
 | (k,v)::xs => if uequal key k then inl v else get_value xs key
 end.
 
+(** Insert *)
 Fixpoint insert_value (env : Environment) (key : (Var + FunctionIdentifier)) 
    (value : Value) : Environment :=
 match env with

--- a/Core_Erlang_Environment.v
+++ b/Core_Erlang_Environment.v
@@ -16,7 +16,7 @@ Definition Environment : Type := list ((Var + FunctionIdentifier) * Value).
 Fixpoint count_closures (env : Environment) : nat :=
 match env with
 | [] => 0
-| (_, VClosure _ _ _ _ _)::xs => S (count_closures xs)
+| (_, VClos _ _ _ _ _)::xs => S (count_closures xs)
 | _::xs => count_closures xs
 end.
 
@@ -83,7 +83,7 @@ match vl, paramss, bodies with
 | [], [], [] => d
 | v::vs, varl::ps, e::bs => append_funs_to_env_base vs ps bs 
                               (insert_value d (inr v) 
-                                           (VClosure def deffuns last_id varl e)) 
+                                           (VClos def deffuns last_id varl e)) 
                                            def deffuns (S last_id)
 | _, _, _ => []
 end.
@@ -116,7 +116,7 @@ Fixpoint get_env_base (env def : Environment)
    : Environment :=
 match ext with
 | [] => env
-| (id, f1, (pl, b))::xs => get_env_base (insert_value env (inr f1) (VClosure def defext id pl b)) def xs defext
+| (id, f1, (pl, b))::xs => get_env_base (insert_value env (inr f1) (VClos def defext id pl b)) def xs defext
 end.
 
 Definition get_env (env : Environment) 

--- a/Core_Erlang_Equalities.v
+++ b/Core_Erlang_Equalities.v
@@ -23,14 +23,14 @@ Proof.
   set (eq1 := A_eq_dec).
   set (eq2 := B_eq_dec).
   decide equality.
-Qed.
+Defined.
 
 Proposition sum_eq_dec : forall p1 p2 : A + B, {p1 = p2} + {p1 <> p2}.
 Proof.
   set (eq1 := A_eq_dec).
   set (eq2 := B_eq_dec).
   decide equality.
-Qed.
+Defined.
 
 End Basic_Eq_Dec.
 

--- a/Core_Erlang_Equalities.v
+++ b/Core_Erlang_Equalities.v
@@ -61,7 +61,7 @@ Section Equalities.
     set (patlist_eq_dec := list_eq_dec pattern_eq_dec).
     (* for letrec *)
     set (listvarexp_eq_dec := list_eq_dec (prod_eq_dec (list Var) Expression
-                                                      (list_eq_dec string_dec) Expression_eq_dec)).
+                                    (list_eq_dec string_dec) Expression_eq_dec)).
     (* for fids *)
     set (listfunid_eq_dec := list_eq_dec funid_eq_dec).
     set (listlistvar_eq_dec := list_eq_dec (list_eq_dec string_dec)).
@@ -99,7 +99,8 @@ Section Equalities.
    | PList hd tl, PList hd' tl' => bPattern_eq_dec hd hd' && bPattern_eq_dec tl tl'
    | PTuple l, PTuple l' => (fix blist_eq l l' := match l, l' with
                                          | [], [] => true
-                                         | x::xs, x'::xs' => andb (bPattern_eq_dec x x') (blist_eq xs xs')
+                                         | x::xs, x'::xs' => andb (bPattern_eq_dec x x') 
+                                                                  (blist_eq xs xs')
                                          | _, _ => false
                                          end) l l'
    | PEmptyList, PEmptyList => true
@@ -128,7 +129,8 @@ Section Equalities.
    | ECall f l, ECall f' l' => 
      eqb f f' && (fix blist l l' := match l, l' with
                                     | [], [] => true
-                                    | x::xs, x'::xs' => andb (bExpression_eq_dec x x') (blist xs xs')
+                                    | x::xs, x'::xs' => andb (bExpression_eq_dec x x')
+                                                             (blist xs xs')
                                     | _, _ => false
                                     end) l l'
    | EApply exp l, EApply exp' l' => 
@@ -247,14 +249,16 @@ Section Equalities.
       * inversion H. apply eqb_eq in H1. subst. reflexivity.
       * inversion H.
       * inversion H.
-      * inversion H. destruct f, f0. inversion H1. apply Bool.andb_true_iff in H2. inversion H2.
+      * inversion H. destruct f, f0. inversion H1. apply Bool.andb_true_iff in H2. 
+        inversion H2.
         apply eqb_eq in H0. apply Nat.eqb_eq in H3. subst. reflexivity.
     }
     { destruct v, v0.
       * inversion H. subst. simpl. apply eqb_refl.
       * inversion H.
       * inversion H.
-      * inversion H. simpl. destruct f. simpl. rewrite eqb_refl, Nat.eqb_refl. simpl. reflexivity.
+      * inversion H. simpl. destruct f. simpl. rewrite eqb_refl, Nat.eqb_refl. simpl.
+        reflexivity.
     }
   Qed.
 
@@ -263,12 +267,14 @@ Section Equalities.
   Proof.
     split; intros.
     { destruct v0, v.
-      * simpl in *. apply eqb_neq in H. unfold not in *. intros. apply H. inversion H0. reflexivity.
+      * simpl in *. apply eqb_neq in H. unfold not in *. intros. apply H. inversion H0. 
+        reflexivity.
       * unfold not. intro. inversion H0.
       * unfold not. intro. inversion H0.
       * destruct f, f0. simpl in H. Search andb. apply Bool.andb_false_iff in H. inversion H.
         - apply eqb_neq in H0. unfold not in *. intro. apply H0. inversion H1. reflexivity.
-        - apply Nat.eqb_neq in H0. unfold not in *. intro. apply H0. inversion H1. reflexivity.
+        - apply Nat.eqb_neq in H0. unfold not in *. intro. apply H0. inversion H1.
+          reflexivity.
     }
     { destruct v0, v.
       * simpl in *. apply eqb_neq. unfold not in *. intro. apply H. subst. reflexivity.
@@ -276,7 +282,8 @@ Section Equalities.
       * simpl. reflexivity.
       * simpl. destruct f, f0. simpl. apply Bool.andb_false_iff.
         unfold not in H. case_eq ((s =? s0)%string); intros.
-        - right. apply eqb_eq in H0. apply Nat.eqb_neq. unfold not. intro. apply H. subst. reflexivity.
+        - right. apply eqb_eq in H0. apply Nat.eqb_neq. unfold not. intro. apply H. subst.
+          reflexivity.
         - left. reflexivity.
     }
   Qed.
@@ -318,7 +325,8 @@ Section Comparisons.
 
   Lemma lt_str : lt_Literal (Atom "aaaa") (Atom "aaaa2").
   Proof.
-    apply lt_atom_atom. apply lts_tail. apply lts_tail. apply lts_tail. apply lts_tail. apply lts_empty.
+    apply lt_atom_atom. apply lts_tail. apply lts_tail. apply lts_tail. apply lts_tail.
+    apply lts_empty.
   Qed.
 
   Inductive lt_Value : Value -> Value -> Prop :=
@@ -334,7 +342,8 @@ Section Comparisons.
   ->
     lt_Value (VClosure ref ext n params body) (v)
   | lt_tuple_tuple_nil exps' : exps' <> [] -> lt_Value (VTuple [])  (VTuple exps')
-  | lt_tuple_length exps exps' : length exps < length exps' -> lt_Value (VTuple exps) (VTuple exps')
+  | lt_tuple_length exps exps' : length exps < length exps' -> 
+      lt_Value (VTuple exps) (VTuple exps')
   | lt_tuple_tuple_hd exps exps' hd hd' : 
      length exps = length exps' ->
      lt_Value hd hd' 
@@ -350,7 +359,8 @@ Section Comparisons.
   | lt_tuple_list l hd tl: lt_Value (VTuple l) (VList hd tl)
   | lt_tuple_emptylist l: lt_Value (VTuple l) (VEmptyList)
   | lt_map_map_nil kl' vl': length kl' = length vl' -> lt_Value (VMap [] []) (VMap kl' vl')
-  | lt_map_length kl kl' vl vl' : length kl < length kl' -> lt_Value (VMap kl vl) (VMap kl' vl')
+  | lt_map_length kl kl' vl vl' : length kl < length kl' ->
+      lt_Value (VMap kl vl) (VMap kl' vl')
   | lt_map_map_hd (kl kl' vl vl' : list Value) hd hd' hdv hdv':
     length kl = length kl' -> 
     lt_Value hd hd' 
@@ -382,7 +392,8 @@ Section Comparisons.
     apply lt_tuple_tuple_nil. congruence.
   Qed.
 
-  Example e3 : lt_Value (VMap [VLiteral (Integer 5)] [VEmptyList]) (VMap [VEmptyList] [VEmptyList]).
+  Example e3 : lt_Value (VMap [VLiteral (Integer 5)] [VEmptyList])
+                        (VMap [VEmptyList] [VEmptyList]).
   Proof.
     apply lt_map_map_hd; auto. apply lt_lit_other. intros. congruence.
   Qed.
@@ -448,13 +459,14 @@ Section Comparisons.
   | VTuple l, VList _ _ => true
   | VMap kl vl, VMap kl' vl' => orb (Nat.ltb (length kl) (length kl')) 
                                     (andb (Nat.eqb (length kl) (length kl'))
-                                          (orb (list_less Value value_less bValue_eq_dec kl kl')
-                                               (andb (list_equal Value bValue_eq_dec kl kl')
-                                                 (list_less Value value_less bValue_eq_dec vl vl')) ))
+                                       (orb (list_less Value value_less bValue_eq_dec kl kl')
+                                          (andb (list_equal Value bValue_eq_dec kl kl')
+                                            (list_less Value value_less bValue_eq_dec vl vl')) ))
   | VMap _ _, VEmptyList => true
   | VMap _ _, VList _ _ => true
   | VEmptyList, VList _ _ => true
-  | VList hd tl, VList hd' tl' => if bValue_eq_dec hd hd' then value_less tl tl' else value_less hd hd'
+  | VList hd tl, VList hd' tl' => if bValue_eq_dec hd hd' then value_less tl tl' 
+                                                          else value_less hd hd'
   | _, _ => false
   end.
 

--- a/Core_Erlang_Equalities.v
+++ b/Core_Erlang_Equalities.v
@@ -271,7 +271,7 @@ Section Equalities.
         reflexivity.
       * unfold not. intro. inversion H0.
       * unfold not. intro. inversion H0.
-      * destruct f, f0. simpl in H. Search andb. apply Bool.andb_false_iff in H. inversion H.
+      * destruct f, f0. simpl in H. apply Bool.andb_false_iff in H. inversion H.
         - apply eqb_neq in H0. unfold not in *. intro. apply H0. inversion H1. reflexivity.
         - apply Nat.eqb_neq in H0. unfold not in *. intro. apply H0. inversion H1.
           reflexivity.

--- a/Core_Erlang_Equivalence_Proofs.v
+++ b/Core_Erlang_Equivalence_Proofs.v
@@ -774,204 +774,250 @@ Proof.
 Qed.
 
 Example let_1_binding_swap_2_list (env: Environment) (e1 e2 : Expression) (t t' v1 v2 : Value) 
-   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B)
-(Hypo1 : |env, e1, eff| -e> |inl v1, eff ++ eff1|)
-(Hypo2 : |env, e1, eff ++ eff2| -e> |inl v1, eff ++ eff2 ++ eff1|)
-(Hypo1' : |env, e2, eff| -e> |inl v2, eff ++ eff2|)
-(Hypo2' : |env, e2, eff ++ eff1| -e> |inl v2, eff ++ eff1 ++ eff2|) :
-|env, ELet [A; B] [e1 ; e2]
-     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> |inl t, eff ++ eff1 ++ eff2|
+   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B) (id id1 id2 : nat)
+(Hypo1 : |env, id, e1, eff| -e> | id + id1, inl v1, eff ++ eff1|)
+(Hypo2 : |env, id + id2, e1, eff ++ eff2| -e> | id + id1 + id2, inl v1, eff ++ eff2 ++ eff1|)
+(Hypo1' : |env, id, e2, eff| -e> | id + id2, inl v2, eff ++ eff2|)
+(Hypo2' : |env, id + id1, e2, eff ++ eff1| -e> | id + id2 + id1, inl v2, eff ++ eff1 ++ eff2|) :
+|env, id, ELet [A; B] [e1 ; e2]
+     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> | id + id1 + id2, inl t, eff ++ eff1 ++ eff2|
 ->
-|env, ELet [B; A] [e2 ; e1]
-     (ECall "plus"%string [EVar B ; EVar A]), eff| -e> |inl t', eff ++ eff2 ++ eff1|
+|env, id, ELet [B; A] [e2 ; e1]
+     (ECall "plus"%string [EVar B ; EVar A]), eff| -e> |id + id2 + id1, inl t', eff ++ eff2 ++ eff1|
 ->
 t = t'.
 Proof.
   intros.
   (* FROM LET HYPO1 *)
-  inversion H. subst. simpl in H4. simpl in H5.
-  pose (EE1 := element_exist Value 1 vals H4). inversion EE1 as [v1']. inversion H1. subst. inversion H4.
-  pose (EE2 := element_exist Value 0 x H3). inversion EE2 as [v2']. inversion H2. subst. inversion H4. 
+  inversion H. subst. simpl in H4, H5, H6.
+  pose (EE1 := element_exist Value 1 vals H4).
+  inversion EE1 as [v1']. inversion H1. subst. inversion H4.
+  pose (EE2 := element_exist Value 0 x H3).
+  inversion EE2 as [v2']. inversion H2. subst. inversion H4. 
   apply eq_sym, length_zero_iff_nil in H8. subst.
-  pose (EE3 := element_exist _ _ _ H5). inversion EE3 as [eff1']. inversion H6. subst. inversion H5.
-  pose (EE4 := element_exist _ _ _ H9). inversion EE4 as [eff2']. inversion H8. subst. inversion H5.
-  apply eq_sym, length_zero_iff_nil in H13. subst.
+  pose (EE3 := element_exist _ _ _ H5). inversion EE3 as [eff1']. inversion H7. subst. inversion H5.
+  pose (EE4 := element_exist _ _ _ H10). inversion EE4 as [eff2']. inversion H8. subst. inversion H5.
+  apply eq_sym, length_zero_iff_nil in H12. subst.
+  pose (EE5 := element_exist nat _ _ H6). inversion EE5 as [id1']. inversion H11. subst. inversion H6.
+  pose (EE6 := element_exist _ _ _ H13). inversion EE6 as [id2']. inversion H12. subst. inversion H6.
+  apply eq_sym, length_zero_iff_nil in H17. subst.
   (* FROM LET HYPO2 *)
-  inversion H0. subst. simpl in H15, H16.
-  pose (EE1' := element_exist _ _ _ H15). inversion EE1' as [v2'']. inversion H10. subst. inversion H15.
-  pose (EE2' := element_exist _ _ _ H14). inversion EE2' as [v1'']. inversion H13. subst. inversion H15.
-  apply eq_sym, length_zero_iff_nil in H19. subst.
-  pose (EE3' := element_exist _ _ _ H16). inversion EE3' as [eff2'']. inversion H17. subst. inversion H16.
-  pose (EE4' := element_exist _ _ _ H20). inversion EE4' as [eff1'']. inversion H19. subst. inversion H16.
-  apply eq_sym, length_zero_iff_nil in H24. subst.
+  inversion H0. subst. simpl in H19, H20, H21.
+  pose (EE1' := element_exist _ _ _ H19). inversion EE1' as [v2'']. inversion H16. subst. inversion H19.
+  pose (EE2' := element_exist _ _ _ H18). inversion EE2' as [v1'']. inversion H17. subst. inversion H19.
+  apply eq_sym, length_zero_iff_nil in H23. subst.
+  pose (EE3' := element_exist _ _ _ H20). inversion EE3' as [eff2'']. inversion H22. subst. inversion H20.
+  pose (EE4' := element_exist _ _ _ H25). inversion EE4' as [eff1'']. inversion H23. subst. inversion H25.
+  apply eq_sym, length_zero_iff_nil in H27. subst.
 
-  assert (v1' = v1 /\ eff1' = eff1).
-  {
-    pose (P1 := H7 0 Nat.lt_0_2).
+  pose (EE5' := element_exist _ _ _ H21). inversion EE5' as [id2'']. inversion H26. subst. inversion H21.
+  pose (EE6' := element_exist _ _ _ H28). inversion EE6' as [id1'']. inversion H27. subst. inversion H21.
+  apply eq_sym, length_zero_iff_nil in H32. subst.
+
+  (* assert (v1' = v1 /\ eff1' = eff1).
+  { *)
+    pose (P1 := H9 0 Nat.lt_0_2).
     unfold concatn in P1. simpl in P1. rewrite app_nil_r, app_nil_r in P1.
-    pose (WD1 := determinism _ Hypo1).
-    pose (PC1 := WD1 _ _ P1).
-    inversion PC1. inversion H21. apply app_inv_head in H24. subst. auto.
-  }
-  inversion H21. subst.
+    pose (WD1 := determinism Hypo1).
+    pose (PC1 := WD1 _ _ _ P1).
+    destruct PC1. destruct H32. apply app_inv_head in H32. inversion H31. subst.
+  (* } *)
   
-  assert (v2'' = v2 /\ eff2'' = eff2).
-  {
-    pose (P1 := H18 0 Nat.lt_0_2).
-    unfold concatn in P1. simpl in P1. rewrite app_nil_r, app_nil_r in P1.
-    pose (WD1 := determinism _ Hypo1').
-    pose (PC1 := WD1 _ _ P1).
-    inversion PC1. inversion H24. apply app_inv_head in H25. subst. auto.
-  }
-  inversion H24. subst.
-  assert (v1'' = v1 /\ v2' = v2 /\ eff1'' = eff1 /\ eff2' = eff2).
-  {
-    pose (P1 := H18 1 Nat.lt_1_2).
-    unfold concatn in P1. simpl in P1. rewrite app_nil_r, app_nil_r in P1.
-    pose (WD1 := determinism _ Hypo2).
-    pose (PC1 := WD1 _ _ P1).
-    inversion PC1. inversion H25. apply app_inv_head, app_inv_head in H26. subst.
-    pose (P2 := H7 1 Nat.lt_1_2).
+  (* assert (v2'' = v2 /\ eff2'' = eff2).
+  { *)
+    pose (P2 := H24 0 Nat.lt_0_2).
     unfold concatn in P2. simpl in P2. rewrite app_nil_r, app_nil_r in P2.
-    pose (WD2 := determinism _ Hypo2').
-    pose (PC2 := WD2 _ _ P2).
-    inversion PC2. inversion H26. apply app_inv_head, app_inv_head in H27. subst. auto.
-  }
-  inversion H25. inversion H27. inversion H29. subst.
+    pose (WD2 := determinism Hypo1').
+    pose (PC2 := WD2 _ _ _ P2).
+    destruct PC2. destruct H33. inversion H32. apply app_inv_head in H33. subst. auto.
+  (* } *)
+
+  (* assert (v1'' = v1 /\ v2' = v2 /\ eff1'' = eff1 /\ eff2' = eff2).
+  { *)
+    pose (P3 := H24 1 Nat.lt_1_2).
+    unfold concatn in P3. simpl in P3. rewrite app_nil_r, app_nil_r in P3.
+    pose (WD3 := determinism Hypo2).
+    pose (PC3 := WD3 _ _ _ P3).
+    inversion PC3. inversion H34. inversion H33. apply app_inv_head, app_inv_head in H35. subst.
+    pose (P4 := H9 1 Nat.lt_1_2).
+    unfold concatn in P4. simpl in P4. rewrite app_nil_r, app_nil_r in P4.
+    pose (WD4 := determinism Hypo2').
+    pose (PC4 := WD4 _ _ _ P4).
+    inversion PC4. inversion H36. inversion H35. apply app_inv_head, app_inv_head in H37. subst.
+    clear EE1. clear EE2. clear EE3. clear EE4. clear EE5. clear EE6.
+  (* } *)
+
   (* FROM CALL HYPOS *)
  (* FROM CALL HYPO1 *)
-  inversion H12. subst. simpl in H30. simpl in H31.
-  pose (EC1 := element_exist _ _ _ H30). inversion EC1 as [v1']. inversion H26. subst. inversion H30.
-  pose (EC2 := element_exist _ _ _ H32). inversion EC2 as [v2']. inversion H28. subst. inversion H30.
-  apply eq_sym, length_zero_iff_nil in H35. subst.
-  pose (EC3 := element_exist _ _ _ H31). inversion EC3 as [eff1']. inversion H34. subst. inversion H31.
-  pose (EC4 := element_exist _ _ _ H36). inversion EC4 as [eff2']. inversion H35. subst. inversion H36.
-  apply eq_sym, length_zero_iff_nil in H39. subst.
-  (* FROM CALL HYPO2 *)
-  inversion H23. subst. simpl in H40, H41.
-  pose (EC1' := element_exist _ _ _ H40). inversion EC1' as [v2'']. inversion H38. subst. inversion H40.
-  pose (EC2' := element_exist _ _ _ H42). inversion EC2' as [v1'']. inversion H39. subst. inversion H40.
-  apply eq_sym, length_zero_iff_nil in H45. subst.
-  pose (EC3' := element_exist _ _ _ H41). inversion EC3' as [eff2'']. inversion H44. subst. inversion H41.
-  pose (EC4' := element_exist _ _ _ H46). inversion EC4' as [eff1'']. inversion H45. subst. inversion H41.
+  inversion H15. subst. simpl in H39, H40, H41.
+  pose (EC1 := element_exist _ _ _ H39). inversion EC1 as [v10]. inversion H37. subst. 
+  inversion H39.
+  pose (EC2 := element_exist _ _ _ H43). inversion EC2 as [v20]. inversion H38. subst. 
+  inversion H39.
+  apply eq_sym, length_zero_iff_nil in H46. subst.
+  pose (EC3 := element_exist _ _ _ H40). inversion EC3 as [eff10]. inversion H44. subst.
+  inversion H40.
+  pose (EC4 := element_exist _ _ _ H47). inversion EC4 as [eff20]. inversion H46. subst.
+  inversion H40.
   apply eq_sym, length_zero_iff_nil in H49. subst.
+  pose (EC5 := element_exist _ _ _ H41). inversion EC5 as [id10]. inversion H48. subst.
+  inversion H41.
+  pose (EC6 := element_exist _ _ _ H51). inversion EC6 as [id20]. inversion H49. subst.
+  inversion H41.
+  apply eq_sym, length_zero_iff_nil in H53. subst.
+  (* FROM CALL HYPO2 *)
+  inversion H30. subst. simpl in H54, H55, H56.
+  pose (EC1' := element_exist _ _ _ H54). inversion EC1' as [v20']. inversion H52. subst.
+  inversion H54.
+  pose (EC2' := element_exist _ _ _ H58). inversion EC2' as [v10']. inversion H53. subst.
+  inversion H54.
+  apply eq_sym, length_zero_iff_nil in H61. subst.
+  pose (EC3' := element_exist _ _ _ H55). inversion EC3' as [eff20']. inversion H59. subst.
+  inversion H55.
+  pose (EC4' := element_exist _ _ _ H62). inversion EC4' as [eff10']. inversion H61. subst.
+  inversion H55.
+  apply eq_sym, length_zero_iff_nil in H64. subst.
+  pose (EC5' := element_exist _ _ _ H56). inversion EC5' as [id20']. inversion H63. subst.
+  inversion H56.
+  pose (EC6' := element_exist _ _ _ H66). inversion EC6' as [id10']. inversion H64. subst.
+  inversion H56.
+  apply eq_sym, length_zero_iff_nil in H68. subst.
 
-  unfold concatn in H47, H37. simpl app in H47, H37.
-  pose (PUM1 := plus_effect_unmodified _ _ _ H37).
-  pose (PUM2 := plus_effect_unmodified _ _ _ H47).
+  unfold concatn in H45, H60. simpl app in H45, H60.
+  pose (PUM1 := plus_effect_unmodified _ _ _ H45).
+  pose (PUM2 := plus_effect_unmodified _ _ _ H60).
   rewrite app_nil_r, app_nil_r, <- app_nil_r in PUM1, PUM2.
   apply app_inv_head in PUM1. apply app_inv_head in PUM2.
   apply app_eq_nil in PUM1. apply app_eq_nil in PUM2.
   inversion PUM1. inversion PUM2. subst.
   (* EVERYTHING IS EQUAL *)
-  assert (v1' = v1 /\ v1'' = v1 /\ v2' = v2 /\ v2'' = v2).
-  {
-    pose (P1 := H33 0 Nat.lt_0_2).
-    pose (P2 := H33 1 Nat.lt_1_2).
-    pose (P1' := H43 1 Nat.lt_1_2).
-    pose (P2' := H43 0 Nat.lt_0_2).
+  (* assert (v1' = v1 /\ v1'' = v1 /\ v2' = v2 /\ v2'' = v2).
+  { *)
+    clear P1. clear P2.
+    pose (P1 := H42 0 Nat.lt_0_2).
+    pose (P2 := H42 1 Nat.lt_1_2).
+    pose (P1' := H57 1 Nat.lt_1_2).
+    pose (P2' := H57 0 Nat.lt_0_2).
     unfold concatn in P1, P2, P1', P2'. simpl in P1, P2, P1', P2'.
     rewrite app_nil_r, app_nil_r in P1, P1', P2, P2'.
     inversion P1. inversion P2. inversion P1'. inversion P2'. subst.
-    rewrite get_value_there in H52, H64.
+    rewrite get_value_there in H73, H91.
     2-3 : congruence.
-    rewrite get_value_here in H52, H56, H60, H64.
-    inversion H52. inversion H56. inversion H60. inversion H64. subst. auto.
-  }
-  inversion H48. inversion H50. inversion H52. subst.
-  rewrite app_nil_r, app_nil_r in H37, H47.
+    rewrite get_value_here in H73, H79, H85, H91.
+    inversion H73. inversion H79. inversion H85. inversion H91. subst.
+(* } *)
+  rewrite app_nil_r, app_nil_r in H45, H60.
   
-  apply (plus_comm_basic_value _ (eff ++ eff2 ++ eff1)) in H37.
-  rewrite H37 in H47. inversion H47.
+  apply (plus_comm_basic_value _ (eff ++ eff2' ++ eff1'')) in H45.
+  rewrite H45 in H60. inversion H60.
   reflexivity.
 Qed.
 
 Example let_1_comm_2_list_alt (env: Environment) (e1 e2 : Expression) (t v1 v2 : Value) 
-   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B)
-(Hypo1 : |env, e1, eff| -e> |inl v1, eff ++ eff1|)
-(Hypo2 : |env, e1, eff ++ eff2| -e> |inl v1, eff ++ eff2 ++ eff1|)
-(Hypo1' : |env, e2, eff| -e> |inl v2, eff ++ eff2|)
-(Hypo2' : |env, e2, eff ++ eff1| -e> |inl v2, eff ++ eff1 ++ eff2|) :
-|env, ELet [A; B] [e1 ; e2]
-     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> |inl t, eff ++ eff1 ++ eff2|
+   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B) (id id1 id2 : nat)
+(Hypo1 : |env, id, e1, eff| -e> | id + id1, inl v1, eff ++ eff1|)
+(Hypo2 : |env, id + id2, e1, eff ++ eff2| -e> | id + id1 + id2, inl v1, eff ++ eff2 ++ eff1|)
+(Hypo1' : |env, id, e2, eff| -e> | id + id2, inl v2, eff ++ eff2|)
+(Hypo2' : |env, id + id1, e2, eff ++ eff1| -e> | id + id2 + id1, inl v2, eff ++ eff1 ++ eff2|) :
+|env, id, ELet [A; B] [e1 ; e2]
+     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> | id + id1 + id2, inl t, eff ++ eff1 ++ eff2|
 ->
-|env, ELet [A; B] [e2 ; e1]
-     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> |inl t, eff ++ eff2 ++ eff1|.
+|env, id, ELet [A; B] [e2 ; e1]
+     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> | id + id2 + id1, inl t, eff ++ eff2 ++ eff1|.
 Proof.
   intros.
   (* FROM LET HYPO *)
-  inversion H. subst. simpl in H4. simpl in H3.
+  inversion H. subst. simpl in H3, H4, H5.
   pose (EE1 := element_exist Value 1 vals H3). inversion EE1 as [v1']. inversion H0. subst. inversion H3.
   pose (EE2 := element_exist Value 0 x H2). inversion EE2 as [v2']. inversion H1. subst. inversion H3.
   apply eq_sym, length_zero_iff_nil in H7. subst.
-  pose (EE3 := element_exist _ _ _ H4). inversion EE3 as [eff1']. inversion H5. subst. inversion H4.
-  pose (EE4 := element_exist _ _ _ H8). inversion EE4 as [eff2']. inversion H7. subst. inversion H8.
-  apply eq_sym, length_zero_iff_nil in H12. subst.
-  assert (v1' = v1 /\ v2' = v2 /\ eff1' = eff1 /\ eff2' = eff2).
-  {
-    pose (P1 := H6 0 Nat.lt_0_2).
-    pose (P2 := H6 1 Nat.lt_1_2).
+  pose (EE3 := element_exist _ _ _ H4). inversion EE3 as [eff1']. inversion H6. subst. inversion H4.
+  pose (EE4 := element_exist _ _ _ H9). inversion EE4 as [eff2']. inversion H7. subst. inversion H9.
+  apply eq_sym, length_zero_iff_nil in H11. subst.
+  pose (EE5 := element_exist _ _ _ H5). inversion EE5 as [id1']. inversion H10. subst. inversion H5.
+  pose (EE6 := element_exist _ _ _ H12). inversion EE6 as [id2']. inversion H11. subst. inversion H12.
+  apply eq_sym, length_zero_iff_nil in H16. subst.
+  clear dependent H5. clear dependent H4. clear dependent H3.
+  clear dependent H12. clear dependent H2.
+  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = eff1 /\ eff2' = eff2).
+  { *)
+    pose (P1 := H8 0 Nat.lt_0_2).
+    pose (P2 := H8 1 Nat.lt_1_2).
     simpl_concatn_H P1. simpl_concatn_H P2. rewrite <- app_assoc in P2.
-    pose (D1 := determinism _ Hypo1 _ _ P1). inversion D1. inversion H9. apply app_inv_head in H12. subst.
-    pose (D2 := determinism _ Hypo2' _ _ P2). inversion D2. inversion H12. apply app_inv_head, app_inv_head in H13. subst. auto.
-  }
-  inversion H9. inversion H13. inversion H15. subst.
+    pose (D1 := determinism Hypo1 _ _ _ P1).
+    destruct D1. destruct H3. inversion H2. apply app_inv_head in H3. subst.
+    pose (D2 := determinism Hypo2' _ _ _ P2).
+    destruct D2. destruct H4. inversion H3. apply app_inv_head, app_inv_head in H4. subst.
+  (* } *)
 
   (* Deconstruct call *)
 
-  inversion H11. subst.
-  pose (EE1' := element_exist Value 1 vals H16). inversion EE1' as [v1']. inversion H12. subst. inversion H16.
-  pose (EE2' := element_exist Value 0 x H18). inversion EE2' as [v2']. inversion H14. subst. inversion H18.
+  inversion H14. subst.
+  pose (EE1' := element_exist Value 1 vals H12). inversion EE1' as [v1''].
+  inversion H4. subst. inversion H12.
+  pose (EE2' := element_exist Value 0 x H18). inversion EE2' as [v2''].
+  inversion H5. subst. inversion H12.
   apply eq_sym, length_zero_iff_nil in H21. subst.
-  pose (EE3' := element_exist _ _ _ H17). inversion EE3' as [eff1']. inversion H20. subst. inversion H17.
-  pose (EE4' := element_exist _ _ _ H22). inversion EE4' as [eff2']. inversion H21. subst. inversion H22.
-  apply eq_sym, length_zero_iff_nil in H25. subst.
-  assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
-  {
-    pose (P1 := H19 0 Nat.lt_0_2).
-    pose (P2 := H19 1 Nat.lt_1_2).
+  pose (EE3' := element_exist _ _ _ H15). inversion EE3' as [eff1'']. inversion H19. subst. inversion H15.
+  pose (EE4' := element_exist _ _ _ H22). inversion EE4' as [eff2'']. inversion H21. subst. inversion H15.
+  apply eq_sym, length_zero_iff_nil in H24. subst.
+  pose (EE5' := element_exist _ _ _ H16). inversion EE5' as [id1'']. inversion H23. subst. inversion H16.
+  pose (EE6' := element_exist _ _ _ H26). inversion EE6' as [id2'']. inversion H24. subst. inversion H16.
+  apply eq_sym, length_zero_iff_nil in H28. subst.
+  clear dependent H15. clear dependent H12. clear dependent H21.
+  clear dependent H16. clear dependent H18. clear dependent H22.
+  clear dependent H26. clear P1. clear dependent P2.
+  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
+  { *)
+    pose (P1 := H17 0 Nat.lt_0_2).
+    pose (P2 := H17 1 Nat.lt_1_2).
     simpl_concatn_H P1. simpl_concatn_H P2. repeat (rewrite <- app_assoc in P2, P1).
     inversion P1.
     inversion P2. subst.
-    rewrite <- app_nil_r in H29 at 1, H34 at 1.
-    repeat (rewrite <- app_assoc in H29). repeat (rewrite <- app_assoc in H34).
-    repeat (apply app_inv_head in H29). repeat (apply app_inv_head in H34). subst.
+    rewrite <- app_nil_r in H27 at 1, H34 at 1.
+    repeat (rewrite <- app_assoc in H27). repeat (rewrite <- app_assoc in H34).
+    repeat (apply app_inv_head in H27). repeat (apply app_inv_head in H34). subst.
+    simpl in H25.
     rewrite get_value_here in H33. inversion H33.
-    rewrite get_value_there in H28. rewrite get_value_here in H28. inversion H28.
-    subst. auto.
-    - congruence.
-  }
+    rewrite get_value_there in H26. rewrite get_value_here in H26. inversion H26.
+    subst.
+    2: congruence.
+  (* } *)
 
   (* construct derivation tree *)
-  apply eval_let with (vals := [v2; v1]) (eff := [eff2; eff1]) (eff2 := []); auto.
-  * intros. inversion H25. 2: inversion H27.
-    1-2: simpl_concatn; try(rewrite <- app_assoc); assumption.
-    - inversion H29.
+  apply eval_let with (vals := [v2''; v1'']) (eff := [eff2'; eff1']) (eff2 := []) 
+                      (ids := [(id + id2)%nat; (id + id2 + id1)%nat]); auto.
+  * intros. inversion H12. 2: inversion H16.
+    1-2: simpl_concatn; try(rewrite <- app_assoc).
+    - rewrite <- H25. exact Hypo2.
+    - assumption.
+    - inversion H21.
   * simpl_concatn. auto.
-  * simpl_concatn. apply eval_call with (vals := [v2; v1]) (eff := [[];[]]); auto.
-    - intros. inversion H25. 2: inversion H27.
-      + simpl_concatn. replace (inl v1) with (get_value (insert_original_value (insert_original_value env (inl A) v2) (inl B) v1) (inl B)). apply eval_var.
+  * simpl_concatn. apply eval_call with (vals := [v2''; v1'']) (eff := [[];[]])
+                             (ids := [(id + id2 + id1)%nat; (id + id2 + id1)%nat]); auto.
+    - intros. inversion H12. 2: inversion H16.
+      + simpl_concatn. replace (inl v1'') with (get_value (insert_value (insert_value env (inl A) v2'') (inl B) v1'') (inl B)). apply eval_var.
         apply get_value_here.
-      + simpl_concatn. replace (inl v2) with (get_value (insert_original_value (insert_original_value env (inl A) v2) (inl B) v1) (inl A)). apply eval_var.
+      + simpl_concatn. replace (inl v2'') with (get_value (insert_value (insert_value env (inl A) v2'') (inl B) v1'') (inl A)). apply eval_var.
         rewrite get_value_there. apply get_value_here. congruence.
-      + inversion H29.
-    - inversion H24. inversion H26. inversion H28. subst.
-      unfold concatn in *. simpl concat. repeat (rewrite <- app_assoc).
-      simpl concat in H23. repeat (rewrite <- app_assoc in H23). repeat (rewrite app_nil_r in *).
-      apply (plus_comm_basic_value _ _ H23).
+      + inversion H21.
+    - unfold concatn in *. simpl concat. repeat (rewrite <- app_assoc).
+      simpl concat in H20. repeat (rewrite <- app_assoc in H20).
+      repeat (rewrite app_nil_r in *).
+      apply (plus_comm_basic_value _ _ H20).
 Qed.
 
 Example let_1_comm_2_list_alt_eq (env: Environment) (e1 e2 : Expression) (t v1 v2 : Value) 
-   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B)
-(Hypo1 : |env, e1, eff| -e> |inl v1, eff ++ eff1|)
-(Hypo2 : |env, e1, eff ++ eff2| -e> |inl v1, eff ++ eff2 ++ eff1|)
-(Hypo1' : |env, e2, eff| -e> |inl v2, eff ++ eff2|)
-(Hypo2' : |env, e2, eff ++ eff1| -e> |inl v2, eff ++ eff1 ++ eff2|) :
-|env, ELet [A; B] [e1 ; e2]
-     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> |inl t, eff ++ eff1 ++ eff2|
+   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B) (id id1 id2 : nat)
+(Hypo1 : |env, id, e1, eff| -e> | id + id1, inl v1, eff ++ eff1|)
+(Hypo2 : |env, id + id2, e1, eff ++ eff2| -e> | id + id1 + id2, inl v1, eff ++ eff2 ++ eff1|)
+(Hypo1' : |env, id, e2, eff| -e> | id + id2, inl v2, eff ++ eff2|)
+(Hypo2' : |env, id + id1, e2, eff ++ eff1| -e> | id + id2 + id1, inl v2, eff ++ eff1 ++ eff2|) :
+|env, id, ELet [A; B] [e1 ; e2]
+     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> | id + id1 + id2, inl t, eff ++ eff1 ++ eff2|
 <->
-|env, ELet [A; B] [e2 ; e1]
-     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> |inl t, eff ++ eff2 ++ eff1|.
+|env, id, ELet [A; B] [e2 ; e1]
+     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> | id + id2 + id1, inl t, eff ++ eff2 ++ eff1|.
 Proof.
   split.
   * apply let_1_comm_2_list_alt with (v1 := v1) (v2 := v2); assumption.
@@ -979,134 +1025,178 @@ Proof.
 Qed.
 
 Example let_1_binding_swap_2_list_alt (env: Environment) (e1 e2 : Expression) (t v1 v2 : Value) 
-   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B)
-(Hypo1 : |env, e1, eff| -e> |inl v1, eff ++ eff1|)
-(Hypo2 : |env, e1, eff ++ eff2| -e> |inl v1, eff ++ eff2 ++ eff1|)
-(Hypo1' : |env, e2, eff| -e> |inl v2, eff ++ eff2|)
-(Hypo2' : |env, e2, eff ++ eff1| -e> |inl v2, eff ++ eff1 ++ eff2|) :
-|env, ELet [A; B] [e1; e2]
-     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> |inl t, eff ++ eff1 ++ eff2|
+   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B) (id id1 id2 : nat)
+(Hypo1 : |env, id, e1, eff| -e> | id + id1, inl v1, eff ++ eff1|)
+(Hypo2 : |env, id + id2, e1, eff ++ eff2| -e> | id + id1 + id2, inl v1, eff ++ eff2 ++ eff1|)
+(Hypo1' : |env, id, e2, eff| -e> | id + id2, inl v2, eff ++ eff2|)
+(Hypo2' : |env, id + id1, e2, eff ++ eff1| -e> | id + id2 + id1, inl v2, eff ++ eff1 ++ eff2|) :
+|env, id, ELet [A; B] [e1; e2]
+     (ECall "plus"%string [EVar A ; EVar B]), eff| -e> | id + id1 + id2, inl t, eff ++ eff1 ++ eff2|
 <->
-|env, ELet [B; A] [e2; e1]
-     (ECall "plus"%string [EVar B ; EVar A]), eff| -e> |inl t, eff ++ eff2 ++ eff1|.
+|env, id, ELet [B; A] [e2; e1]
+     (ECall "plus"%string [EVar B ; EVar A]), eff| -e> | id + id2 + id1, inl t, eff ++ eff2 ++ eff1|.
 Proof.
   split.
-  * intro. inversion H. subst.
-    pose (EE1 := element_exist Value 1 vals H3). inversion EE1 as [v1']. inversion H0. subst. inversion H3.
-    pose (EE2 := element_exist Value 0 x H2). inversion EE2 as [v2']. inversion H1. subst. inversion H2.
-    apply eq_sym, length_zero_iff_nil in H7. subst.
-    pose (EE3 := element_exist _ _ _ H4). inversion EE3 as [eff1']. inversion H5. subst. inversion H4.
-    pose (EE4 := element_exist _ _ _ H8). inversion EE4 as [eff2']. inversion H7. subst. inversion H8.
-    apply eq_sym, length_zero_iff_nil in H12. subst.
-    assert (v1' = v1 /\ v2' = v2 /\ eff1' = eff1 /\ eff2' = eff2).
-    {
-      pose (P1 := H6 0 Nat.lt_0_2).
-      pose (P2 := H6 1 Nat.lt_1_2).
-      simpl_concatn_H P1. simpl_concatn_H P2. rewrite <- app_assoc in P2.
-      pose (D1 := determinism _ Hypo1 _ _ P1). inversion D1. inversion H9. apply app_inv_head in H12. subst.
-      pose (D2 := determinism _ Hypo2' _ _ P2). inversion D2. inversion H12. apply app_inv_head, app_inv_head in H13. subst. auto.
-    }
-    inversion H9. inversion H13. inversion H15. subst.
+  * intros.
+  (* FROM LET HYPO *)
+  inversion H. subst. simpl in H3, H4, H5.
+  pose (EE1 := element_exist Value 1 vals H3). inversion EE1 as [v1']. inversion H0. subst. inversion H3.
+  pose (EE2 := element_exist Value 0 x H2). inversion EE2 as [v2']. inversion H1. subst. inversion H3.
+  apply eq_sym, length_zero_iff_nil in H7. subst.
+  pose (EE3 := element_exist _ _ _ H4). inversion EE3 as [eff1']. inversion H6. subst. inversion H4.
+  pose (EE4 := element_exist _ _ _ H9). inversion EE4 as [eff2']. inversion H7. subst. inversion H9.
+  apply eq_sym, length_zero_iff_nil in H11. subst.
+  pose (EE5 := element_exist _ _ _ H5). inversion EE5 as [id1']. inversion H10. subst. inversion H5.
+  pose (EE6 := element_exist _ _ _ H12). inversion EE6 as [id2']. inversion H11. subst. inversion H12.
+  apply eq_sym, length_zero_iff_nil in H16. subst.
+  clear dependent H5. clear dependent H4. clear dependent H3.
+  clear dependent H12. clear dependent H2.
+  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = eff1 /\ eff2' = eff2).
+  { *)
+    pose (P1 := H8 0 Nat.lt_0_2).
+    pose (P2 := H8 1 Nat.lt_1_2).
+    simpl_concatn_H P1. simpl_concatn_H P2. rewrite <- app_assoc in P2.
+    pose (D1 := determinism Hypo1 _ _ _ P1).
+    destruct D1. destruct H3. inversion H2. apply app_inv_head in H3. subst.
+    pose (D2 := determinism Hypo2' _ _ _ P2).
+    destruct D2. destruct H4. inversion H3. apply app_inv_head, app_inv_head in H4. subst.
+  (* } *)
 
-    (* Deconstruct call *)
+  (* Deconstruct call *)
 
-    inversion H11. subst.
-    pose (EE1' := element_exist Value 1 vals H16). inversion EE1' as [v1']. inversion H12. subst. inversion H16.
-    pose (EE2' := element_exist Value 0 x H18). inversion EE2' as [v2']. inversion H14. subst. inversion H18.
-    apply eq_sym, length_zero_iff_nil in H21. subst.
-    pose (EE3' := element_exist _ _ _ H17). inversion EE3' as [eff1']. inversion H20. subst. inversion H17.
-    pose (EE4' := element_exist _ _ _ H22). inversion EE4' as [eff2']. inversion H21. subst. inversion H22.
-    apply eq_sym, length_zero_iff_nil in H25. subst.
-    assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
-    {
-      pose (P1 := H19 0 Nat.lt_0_2).
-      pose (P2 := H19 1 Nat.lt_1_2).
-      simpl_concatn_H P1. simpl_concatn_H P2. repeat (rewrite <- app_assoc in P2, P1).
-      inversion P1.
-      inversion P2. subst.
-      rewrite <- app_nil_r in H29 at 1, H34 at 1.
-      repeat (rewrite <- app_assoc in H29). repeat (rewrite <- app_assoc in H34).
-      repeat (apply app_inv_head in H29). repeat (apply app_inv_head in H34). subst.
-      rewrite get_value_here in H33. inversion H33.
-      rewrite get_value_there in H28. rewrite get_value_here in H28. inversion H28.
-      subst. auto.
-      - congruence.
-    }
-    (* construct derivation tree *)
-    apply eval_let with (vals := [v2; v1]) (eff := [eff2; eff1]) (eff2 := []); auto.
-    - intros. inversion H25. 2: inversion H27.
-      1-2: simpl_concatn; try(rewrite <- app_assoc); assumption.
-      + inversion H29.
-    - simpl_concatn. auto.
-    - simpl_concatn. apply eval_call with (vals := [v2; v1]) (eff := [[];[]]); auto.
-      + intros. inversion H25. 2: inversion H27.
-        ** simpl_concatn. replace (inl v1) with (get_value (insert_original_value (insert_original_value env (inl B) v2) (inl A) v1) (inl A)). apply eval_var.
-           apply get_value_here.
-        ** simpl_concatn. replace (inl v2) with (get_value (insert_original_value (insert_original_value env (inl B) v2) (inl A) v1) (inl B)). apply eval_var.
-           rewrite get_value_there. apply get_value_here. congruence.
-        ** inversion H29.
-      + inversion H24. inversion H26. inversion H28. subst.
-        unfold concatn in *. simpl concat. repeat (rewrite <- app_assoc).
-        simpl concat in H23. repeat (rewrite <- app_assoc in H23). repeat (rewrite app_nil_r in *).
-        apply (plus_comm_basic_value _ _ H23).
-  * intro. inversion H. subst.
-    pose (EE1 := element_exist Value 1 vals H3). inversion EE1 as [v2']. inversion H0. subst. inversion H3.
-    pose (EE2 := element_exist Value 0 x H2). inversion EE2 as [v1']. inversion H1. subst. inversion H2.
-    apply eq_sym, length_zero_iff_nil in H7. subst.
-    pose (EE3 := element_exist _ _ _ H4). inversion EE3 as [eff2']. inversion H5. subst. inversion H4.
-    pose (EE4 := element_exist _ _ _ H8). inversion EE4 as [eff1']. inversion H7. subst. inversion H8.
-    apply eq_sym, length_zero_iff_nil in H12. subst.
-    assert (v1' = v1 /\ v2' = v2 /\ eff1' = eff1 /\ eff2' = eff2).
-    {
-      pose (P1 := H6 0 Nat.lt_0_2).
-      pose (P2 := H6 1 Nat.lt_1_2).
-      simpl_concatn_H P1. simpl_concatn_H P2. rewrite <- app_assoc in P2.
-      pose (D1 := determinism _ Hypo1' _ _ P1). inversion D1. inversion H9. apply app_inv_head in H12. subst.
-      pose (D2 := determinism _ Hypo2 _ _ P2). inversion D2. inversion H12. apply app_inv_head, app_inv_head in H13. subst. auto.
-    }
-    inversion H9. inversion H13. inversion H15. subst.
+  inversion H14. subst.
+  pose (EE1' := element_exist Value 1 vals H12). inversion EE1' as [v1''].
+  inversion H4. subst. inversion H12.
+  pose (EE2' := element_exist Value 0 x H18). inversion EE2' as [v2''].
+  inversion H5. subst. inversion H12.
+  apply eq_sym, length_zero_iff_nil in H21. subst.
+  pose (EE3' := element_exist _ _ _ H15). inversion EE3' as [eff1'']. inversion H19. subst. inversion H15.
+  pose (EE4' := element_exist _ _ _ H22). inversion EE4' as [eff2'']. inversion H21. subst. inversion H15.
+  apply eq_sym, length_zero_iff_nil in H24. subst.
+  pose (EE5' := element_exist _ _ _ H16). inversion EE5' as [id1'']. inversion H23. subst. inversion H16.
+  pose (EE6' := element_exist _ _ _ H26). inversion EE6' as [id2'']. inversion H24. subst. inversion H16.
+  apply eq_sym, length_zero_iff_nil in H28. subst.
+  clear dependent H15. clear dependent H12. clear dependent H21.
+  clear dependent H16. clear dependent H18. clear dependent H22.
+  clear dependent H26. clear P1. clear dependent P2.
+  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
+  { *)
+    pose (P1 := H17 0 Nat.lt_0_2).
+    pose (P2 := H17 1 Nat.lt_1_2).
+    simpl_concatn_H P1. simpl_concatn_H P2. repeat (rewrite <- app_assoc in P2, P1).
+    inversion P1.
+    inversion P2. subst.
+    rewrite <- app_nil_r in H27 at 1, H34 at 1.
+    repeat (rewrite <- app_assoc in H27). repeat (rewrite <- app_assoc in H34).
+    repeat (apply app_inv_head in H27). repeat (apply app_inv_head in H34). subst.
+    simpl in H25.
+    rewrite get_value_here in H33. inversion H33.
+    rewrite get_value_there in H26. rewrite get_value_here in H26. inversion H26.
+    subst.
+    2: congruence.
+  (* } *)
 
-    (* Deconstruct call *)
+  (* construct derivation tree *)
+  apply eval_let with (vals := [v2''; v1'']) (eff := [eff2'; eff1']) (eff2 := []) 
+                      (ids := [(id + id2)%nat; (id + id2 + id1)%nat]); auto.
+  - intros. inversion H12. 2: inversion H16.
+    1-2: simpl_concatn; try(rewrite <- app_assoc).
+    + rewrite <- H25. exact Hypo2.
+    + assumption.
+    + inversion H21.
+  - simpl_concatn. auto.
+  - simpl_concatn. apply eval_call with (vals := [v2''; v1'']) (eff := [[];[]])
+                             (ids := [(id + id2 + id1)%nat; (id + id2 + id1)%nat]); auto.
+    + intros. inversion H12. 2: inversion H16.
+      ** simpl_concatn. replace (inl v1'') with (get_value (insert_value (insert_value env (inl B) v2'') (inl A) v1'') (inl A)). apply eval_var.
+        apply get_value_here.
+      ** simpl_concatn. replace (inl v2'') with (get_value (insert_value (insert_value env (inl B) v2'') (inl A) v1'') (inl B)). apply eval_var.
+        rewrite get_value_there. apply get_value_here. congruence.
+      ** inversion H21.
+    + unfold concatn in *. simpl concat. repeat (rewrite <- app_assoc).
+      simpl concat in H20. repeat (rewrite <- app_assoc in H20).
+      repeat (rewrite app_nil_r in *).
+      pose (plus_comm_basic_value _ (eff ++ eff2' ++ eff1') H20). assumption.
+  * intros.
+  (* FROM LET HYPO *)
+  inversion H. subst. simpl in H3, H4, H5.
+  pose (EE1 := element_exist Value 1 vals H3). inversion EE1 as [v2']. inversion H0. subst. inversion H3.
+  pose (EE2 := element_exist Value 0 x H2). inversion EE2 as [v1']. inversion H1. subst. inversion H3.
+  apply eq_sym, length_zero_iff_nil in H7. subst.
+  pose (EE3 := element_exist _ _ _ H4). inversion EE3 as [eff2']. inversion H6. subst. inversion H4.
+  pose (EE4 := element_exist _ _ _ H9). inversion EE4 as [eff1']. inversion H7. subst. inversion H9.
+  apply eq_sym, length_zero_iff_nil in H11. subst.
+  pose (EE5 := element_exist _ _ _ H5). inversion EE5 as [id2']. inversion H10. subst. inversion H5.
+  pose (EE6 := element_exist _ _ _ H12). inversion EE6 as [id1']. inversion H11. subst. inversion H12.
+  apply eq_sym, length_zero_iff_nil in H16. subst.
+  clear dependent H5. clear dependent H4. clear dependent H3.
+  clear dependent H12. clear dependent H2.
+  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = eff1 /\ eff2' = eff2).
+  { *)
+    pose (P1 := H8 0 Nat.lt_0_2).
+    pose (P2 := H8 1 Nat.lt_1_2).
+    simpl_concatn_H P1. simpl_concatn_H P2. rewrite <- app_assoc in P2.
+    pose (D1 := determinism Hypo1' _ _ _ P1).
+    destruct D1. destruct H3. inversion H2. apply app_inv_head in H3. subst.
+    pose (D2 := determinism Hypo2 _ _ _ P2).
+    destruct D2. destruct H4. inversion H3. apply app_inv_head, app_inv_head in H4. subst.
+  (* } *)
 
-    inversion H11. subst.
-    pose (EE1' := element_exist Value 1 vals H16). inversion EE1' as [v2']. inversion H12. subst. inversion H16.
-    pose (EE2' := element_exist Value 0 x H18). inversion EE2' as [v1']. inversion H14. subst. inversion H18.
-    apply eq_sym, length_zero_iff_nil in H21. subst.
-    pose (EE3' := element_exist _ _ _ H17). inversion EE3' as [eff2']. inversion H20. subst. inversion H17.
-    pose (EE4' := element_exist _ _ _ H22). inversion EE4' as [eff1']. inversion H21. subst. inversion H22.
-    apply eq_sym, length_zero_iff_nil in H25. subst.
-    assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
-    {
-      pose (P1 := H19 0 Nat.lt_0_2).
-      pose (P2 := H19 1 Nat.lt_1_2).
-      simpl_concatn_H P1. simpl_concatn_H P2. repeat (rewrite <- app_assoc in P2, P1).
-      inversion P1.
-      inversion P2. subst.
-      rewrite <- app_nil_r in H29 at 1, H34 at 1.
-      repeat (rewrite <- app_assoc in H29). repeat (rewrite <- app_assoc in H34).
-      repeat (apply app_inv_head in H29). repeat (apply app_inv_head in H34). subst.
-      rewrite get_value_here in H33. inversion H33.
-      rewrite get_value_there in H28. rewrite get_value_here in H28. inversion H28.
-      subst. auto.
-      - congruence.
-    }
-    (* construct derivation tree *)
-    apply eval_let with (vals := [v1; v2]) (eff := [eff1; eff2]) (eff2 := []); auto.
-    - intros. inversion H25. 2: inversion H27.
-      1-2: simpl_concatn; try(rewrite <- app_assoc); assumption.
-      + inversion H29.
-    - simpl_concatn. auto.
-    - simpl_concatn. apply eval_call with (vals := [v1; v2]) (eff := [[];[]]); auto.
-      + intros. inversion H25. 2: inversion H27.
-        ** simpl_concatn. replace (inl v2) with (get_value (insert_original_value (insert_original_value env (inl A) v1) (inl B) v2) (inl B)). apply eval_var.
-           apply get_value_here.
-        ** simpl_concatn. replace (inl v1) with (get_value (insert_original_value (insert_original_value env (inl A) v1) (inl B) v2) (inl A)). apply eval_var.
-           rewrite get_value_there. apply get_value_here. congruence.
-        ** inversion H29.
-      + inversion H24. inversion H26. inversion H28. subst.
-        unfold concatn in *. simpl concat. repeat (rewrite <- app_assoc).
-        simpl concat in H23. repeat (rewrite <- app_assoc in H23). repeat (rewrite app_nil_r in *).
-        apply (plus_comm_basic_value _ _ H23).
+  (* Deconstruct call *)
+
+  inversion H14. subst.
+  pose (EE1' := element_exist Value 1 vals H12). inversion EE1' as [v2''].
+  inversion H4. subst. inversion H12.
+  pose (EE2' := element_exist Value 0 x H18). inversion EE2' as [v1''].
+  inversion H5. subst. inversion H12.
+  apply eq_sym, length_zero_iff_nil in H21. subst.
+  pose (EE3' := element_exist _ _ _ H15). inversion EE3' as [eff2'']. inversion H19. subst. inversion H15.
+  pose (EE4' := element_exist _ _ _ H22). inversion EE4' as [eff1'']. inversion H21. subst. inversion H15.
+  apply eq_sym, length_zero_iff_nil in H24. subst.
+  pose (EE5' := element_exist _ _ _ H16). inversion EE5' as [id2'']. inversion H23. subst. inversion H16.
+  pose (EE6' := element_exist _ _ _ H26). inversion EE6' as [id1'']. inversion H24. subst. inversion H16.
+  apply eq_sym, length_zero_iff_nil in H28. subst.
+  clear dependent H15. clear dependent H12. clear dependent H21.
+  clear dependent H16. clear dependent H18. clear dependent H22.
+  clear dependent H26. clear P1. clear dependent P2.
+  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
+  { *)
+    pose (P1 := H17 0 Nat.lt_0_2).
+    pose (P2 := H17 1 Nat.lt_1_2).
+    simpl_concatn_H P1. simpl_concatn_H P2. repeat (rewrite <- app_assoc in P2, P1).
+    inversion P1.
+    inversion P2. subst.
+    rewrite <- app_nil_r in H27 at 1, H34 at 1.
+    repeat (rewrite <- app_assoc in H27). repeat (rewrite <- app_assoc in H34).
+    repeat (apply app_inv_head in H27). repeat (apply app_inv_head in H34). subst.
+    simpl in H25.
+    rewrite get_value_here in H33. inversion H33.
+    rewrite get_value_there in H26. rewrite get_value_here in H26. inversion H26.
+    subst.
+    2: congruence.
+  (* } *)
+
+  (* construct derivation tree *)
+  apply eval_let with (vals := [v1''; v2'']) (eff := [eff1'; eff2']) (eff2 := []) 
+                      (ids := [(id + id1)%nat; (id + id1 + id2)%nat]); auto.
+  - intros. inversion H12. 2: inversion H16.
+    1-2: simpl_concatn; try(rewrite <- app_assoc).
+    + rewrite <- H25. exact Hypo2'.
+    + assumption.
+    + inversion H21.
+  - simpl_concatn. auto.
+  - simpl_concatn. apply eval_call with (vals := [v1''; v2'']) (eff := [[];[]])
+                             (ids := [(id + id1 + id2)%nat; (id + id1 + id2)%nat]); auto.
+    + intros. inversion H12. 2: inversion H16.
+      ** simpl_concatn. replace (inl v2'') with (get_value (insert_value (insert_value env (inl A) v1'') (inl B) v2'') (inl B)). apply eval_var.
+        apply get_value_here.
+      ** simpl_concatn. replace (inl v1'') with (get_value (insert_value (insert_value env (inl A) v1'') (inl B) v2'') (inl A)). apply eval_var.
+        rewrite get_value_there. apply get_value_here. congruence.
+      ** inversion H21.
+    + unfold concatn in *. simpl concat. repeat (rewrite <- app_assoc).
+      simpl concat in H20. repeat (rewrite <- app_assoc in H20).
+      repeat (rewrite app_nil_r in *).
+      pose (plus_comm_basic_value _ (eff ++ eff1' ++ eff2') H20). assumption.
 Qed.
 
 
@@ -1194,197 +1284,311 @@ Proof.
           -- unfold concatn in H32. simpl in H32. 
 Abort. *)
 
-Example let_2_apply_effect_free (env: Environment)(e1 e2 exp : Expression) (v1 v2 : Value) (v0 t : Value + Exception) (A B : Var) (VarHyp : A <> B) 
-(E1 : | append_vars_to_env [A] [v1] (append_vars_to_env [B] [v2] env), exp, [] | -e> |v0, []|)
-(E2 : | append_vars_to_env [B] [v2] (append_vars_to_env [A] [v1] env), exp, [] | -e> |v0, []|)
+Example let_2_apply_effect_free (env: Environment)(e1 e2 exp : Expression) (v1 v2 : Value) (v0 t : Value + Exception) (A B : Var) (VarHyp : A <> B) (id : nat)
+(E1 : | append_vars_to_env [A] [v1] (append_vars_to_env [B] [v2] env), id, exp, [] | -e> |id, v0, []|)
+(E2 : | append_vars_to_env [B] [v2] (append_vars_to_env [A] [v1] env), id, exp, [] | -e> |id, v0, []|)
     :
-  |env, e2, []| -e> |inl v2, []| -> 
-  |append_vars_to_env [A] [v1] env, e2, []| -e> |inl v2, []| ->
-  |env, e1, []| -e> |inl v1, []| -> 
-  |append_vars_to_env [B] [v2] env, e1, []| -e> |inl v1, []| ->
-  |env, ELet [A] [e1] (ELet [B] [e2] 
-        (EApp exp [EVar A ; EVar B])), []| -e> |t, []|
-<->
-|env, ELet [B] [e2] (ELet [A] [e1]
-        (EApp exp [EVar A ; EVar B])), []| -e> |t, []|
+  |env, id, e2, []| -e> |id, inl v2, []| -> 
+  |append_vars_to_env [A] [v1] env, id, e2, []| -e> | id, inl v2, []| ->
+  |env, id, e1, []| -e> | id, inl v1, []| -> 
+  |append_vars_to_env [B] [v2] env, id, e1, []| -e> | id, inl v1, []|
+->
+  |env, id, ELet [A] [e1] (ELet [B] [e2] 
+        (EApp exp [EVar A ; EVar B])), []| -e> |id, t, []|
+  <->
+  |env, id, ELet [B] [e2] (ELet [A] [e1]
+        (EApp exp [EVar A ; EVar B])), []| -e> |id, t, []|
 .
 Proof.
   split;intros. 
    (** Deconstruct ELet-s *)
-  * inversion H3. subst. simpl in H8. pose (EE1 := element_exist Value 0 vals H7). inversion EE1 as [v1']. inversion H4. subst. inversion H7. apply eq_sym, length_zero_iff_nil in H6. subst.
-  pose (EE2 := element_exist _ 0 _ H8). inversion EE2 as [eff1']. inversion H5. subst. inversion H8. apply eq_sym, length_zero_iff_nil in H9. subst.
-  assert (v1' = v1 /\ eff1' = []).
-  {
-    pose (P := H10 0 Nat.lt_0_1). unfold concatn in P. simpl in P. rewrite app_nil_r in P.
-    pose (WD := determinism _ H1 _ _ P). inversion WD. inversion H6.
-    subst. auto.
-  }
-  inversion H6. subst.
-  inversion H15. subst. simpl in H13, H16.
-  pose (EE3 := element_exist Value 0 vals H13). inversion EE3 as [v2']. inversion H9.
-  subst. inversion H13. apply eq_sym, length_zero_iff_nil in H12. subst.
-  pose (EE4 := element_exist _ _ _ H16). inversion EE4 as [eff2']. inversion H11. subst.
-  inversion H16. apply eq_sym, length_zero_iff_nil in H17. subst.
-  assert (v2' = v2 /\ eff2' = []). 
-  {
-    pose (P := H18 0 Nat.lt_0_1). unfold concatn in P. simpl in P.
-    rewrite app_nil_r in P.
-    pose (WD := determinism _ H0 _ _ P). inversion WD. inversion H12. subst. auto.
-  }
-  inversion H12. subst.
-  apply eval_let with (vals := [v2]) (eff := [[]]) (eff2 := []); auto.
-   - intros. inversion H17.
-     + unfold concatn. simpl. assumption.
-     + inversion H20.
-   - apply eval_let with (vals := [v1]) (eff := [[]]) (eff2 := []); auto.
-     + intros. inversion H17.
-       ** subst. unfold concatn. simpl concat. simpl nth. assumption.
-       ** inversion H20.
-   (** Destruct application hypothesis *)
-     + inversion H23; subst.
-       ** unfold concatn in H21. simpl in H21. pose (WD3 := determinism _ E2 _ _ H21). inversion WD3. subst.
-          pose (EEA := element_exist _ _ _ H20). inversion EEA as [v1']. inversion H17. subst. inversion H20. 
-          pose (EEA2 := element_exist _ _ _ H27). inversion EEA2 as [v2']. inversion H19. subst. inversion H27. apply eq_sym, length_zero_iff_nil in H30. subst.
-          simpl in H25.
-          pose (EEE := element_exist _ _ _ H25). inversion EEE as [eff1']. inversion H29. subst. inversion H25.
-          pose (EEE2 := element_exist _ _ _ H31). inversion EEE2 as [eff2']. inversion H30. subst. inversion H31. apply eq_sym, length_zero_iff_nil in H34. subst.
-          assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
-          {
-            pose (P := H26 0 Nat.lt_0_2). unfold concatn in P. simpl in P.
-            inversion P. rewrite get_value_there in H37. rewrite get_value_here in H37. inversion H37.
-            rewrite app_nil_r in H38. subst.
+  * inversion H3. subst. simpl in H8.
+    pose (EE1 := element_exist Value 0 vals H7). inversion EE1 as [v1'].
+    inversion H4. subst. inversion H7.
+    apply eq_sym, length_zero_iff_nil in H6. subst.
+    pose (EE2 := element_exist _ 0 _ H8). inversion EE2 as [eff1'].
+    inversion H5. subst. inversion H8.
+    apply eq_sym, length_zero_iff_nil in H10. subst.
+    pose (EE3 := element_exist _ 0 _ H9). inversion EE3 as [id1'].
+    inversion H6. subst. inversion H9.
+    apply eq_sym, length_zero_iff_nil in H11. subst.
+    (* assert (v1' = v1 /\ eff1' = []).
+    { *)
+      pose (P := H12 0 Nat.lt_0_1).
+      unfold concatn in P. simpl in P. rewrite app_nil_r in P.
+      pose (WD := determinism H1 _ _ _ P). destruct WD. destruct H11. inversion H10.
+      subst.
+    (* } *)
+    inversion H18. subst. simpl in H15, H16, H19.
+    pose (EE4 := element_exist Value 0 vals H15).
+    inversion EE4 as [v2']. inversion H11. subst. inversion H15.
+    apply eq_sym, length_zero_iff_nil in H14. subst.
+    pose (EE5 := element_exist _ _ _ H16).
+    inversion EE5 as [eff2']. inversion H13. subst.
+    inversion H16. apply eq_sym, length_zero_iff_nil in H20. subst.
+    pose (EE6 := element_exist _ _ _ H19). inversion EE6 as [id2']. inversion H14. subst.
+    inversion H19. apply eq_sym, length_zero_iff_nil in H21. subst.
+    clear dependent H15. clear dependent H16. clear dependent H19.
+    clear dependent H7. clear dependent H8. clear dependent H9.
+    clear dependent P.
+    (* assert (v2' = v2 /\ eff2' = []). 
+    { *)
+      pose (P := H22 0 Nat.lt_0_1). unfold concatn in P. simpl in P.
+      rewrite app_nil_r in P.
+      pose (WD := determinism H0 _ _ _ P). destruct WD. destruct H8.
+      inversion H7.
+      subst.
+    (* } *)
+    apply eval_let with (vals := [v2']) (eff := [[]]) (eff2 := []) (ids := [id2']); auto.
+     - intros. inversion H8.
+       + unfold concatn. simpl. assumption.
+       + inversion H15.
+     - apply eval_let with (vals := [v1']) (eff := [[]]) (eff2 := []) (ids := [id2']); auto.
+       + intros. inversion H8.
+         ** subst. unfold concatn. simpl concat. simpl nth. assumption.
+         ** inversion H15.
+     (** Destruct application hypothesis *)
+       + inversion H28; subst.
+         ** pose (WD3 := determinism E2 _ _ _ H16). destruct WD3.
+            inversion H8. destruct H9. subst.
+            pose (EEA := element_exist _ _ _ H15).
+            inversion EEA as [v1'']. inversion H8. subst. inversion H15. 
+            pose (EEA2 := element_exist _ _ _ H29).
+            inversion EEA2 as [v2'']. inversion H25. subst. inversion H15.
+            apply eq_sym, length_zero_iff_nil in H31. subst.
+            pose (EEE := element_exist _ _ _ H20).
+            inversion EEE as [eff1'']. inversion H30. subst. inversion H20.
+            pose (EEE2 := element_exist _ _ _ H32).
+            inversion EEE2 as [eff2'']. inversion H31. subst. inversion H20.
+            apply eq_sym, length_zero_iff_nil in H35. subst.
+            pose (EEI := element_exist _ _ _ H21).
+            inversion EEI as [id1'']. inversion H34. subst. inversion H21.
+            pose (EEI2 := element_exist _ _ _ H36).
+            inversion EEI2 as [id2'']. inversion H35. subst. inversion H21.
+            apply eq_sym, length_zero_iff_nil in H38. subst.
+            clear dependent H15. clear dependent H29. clear dependent H20.
+            clear dependent H32. clear dependent H21. clear dependent H36.
+            clear dependent P.
+            (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
+            { *)
+              pose (P := H23 0 Nat.lt_0_2). unfold concatn in P. simpl in P.
+              inversion P.
+              rewrite get_value_there in H37. 2: congruence. 
+              rewrite get_value_here in H37.
+              inversion H37.
+              apply app_inv_head in H38.
+              rewrite app_nil_r in H38. subst.
 
-            pose (P2 := H26 1 Nat.lt_1_2). unfold concatn in P2. simpl in P2.
-            inversion P2. rewrite get_value_here in H38. inversion H38.
-            rewrite app_nil_r in H39. subst. auto.
-            congruence.
-          }
-          inversion H33. inversion H35. inversion H37. subst.
-          eapply eval_apply with (vals := [v1; v2]) (eff := [[]; []]); auto.
-          -- unfold concatn. simpl concat. exact E1.
-          -- auto.
-          -- intros. inversion H34. 2: inversion H38.
-            ++ simpl_concatn. replace (inl v2) with (get_value (insert_original_value (insert_original_value env (inl B) v2) (inl A) v1) (inl B)). apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
-            ++ simpl_concatn. replace (inl v1) with (get_value (insert_original_value (insert_original_value env (inl B) v2) (inl A) v1) (inl A)). apply eval_var. rewrite get_value_here. auto.
-            ++ inversion H40.
-          -- unfold concatn. simpl. repeat (rewrite <- app_assoc, app_nil_r). reflexivity.
-          -- simpl_concatn_H H32. simpl_concatn. exact H32.
-       ** eapply eval_apply_ex_closure_ex; try(reflexivity).
-          pose (WD := determinism _ E2 _ _ H27). inversion WD. subst. assumption.
-       ** inversion H21.
-          -- pose (EEA := element_exist _ _ _  (eq_sym H19)). inversion EEA as [v1']. inversion H17. subst. inversion H19. apply length_zero_iff_nil in H27. subst. simpl in H32. inversion H32.
-             rewrite get_value_here in H31. congruence.
-          -- inversion H19.
-            ++ rewrite H27 in *. simpl in H32. inversion H32.
-             rewrite get_value_there, get_value_here in H33; congruence.
-            ++ inversion H27.
-       ** simpl_concatn_H H24. pose (WD := determinism _ E2 _ _ H24). inversion WD. subst. eapply eval_apply_ex_closure with (vals := [v1; v2]) (eff := [[];[]]); auto.
-         -- simpl_concatn. simpl in E1. exact E1.
-         -- intros. inversion H17. 2: inversion H26.
-            ++ simpl_concatn. replace (inl v2) with (get_value (insert_original_value (insert_original_value env (inl B) v2) (inl A) v1) (inl B)). apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
-            ++ simpl_concatn. replace (inl v1) with (get_value (insert_original_value (insert_original_value env (inl B) v2) (inl A) v1) (inl A)). apply eval_var. rewrite get_value_here. auto.
-            ++ inversion H29.
-         -- reflexivity.
-       ** simpl_concatn_H H24. pose (WD := determinism _ E2 _ _ H24). inversion WD. subst.
-          eapply eval_apply_ex_param_count with (vals := [v1; v2]) (eff := [[];[]]); auto.
-         -- simpl_concatn. simpl in E1. exact E1.
-         -- intros. inversion H17. 2: inversion H26.
-            ++ simpl_concatn. replace (inl v2) with (get_value (insert_original_value (insert_original_value env (inl B) v2) (inl A) v1) (inl B)). apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
-            ++ simpl_concatn. replace (inl v1) with (get_value (insert_original_value (insert_original_value env (inl B) v2) (inl A) v1) (inl A)). apply eval_var. rewrite get_value_here. auto.
-            ++ inversion H29.
-         -- rewrite <- H20 in H27. auto.
-         -- reflexivity.
-    - inversion H16. simpl_concatn_H H24. subst. rewrite H26 in H24. pose (WD := determinism _ H0 _ _ H24). inversion WD. inversion H9. 
-      inversion H26.
-    - inversion H8. subst. simpl in H16. rewrite H18 in H16. pose (WD := determinism _ H1 _ _ H16). inversion WD. inversion H4.
-      inversion H18.
-  * inversion H3. subst. simpl in H8. pose (EE1 := element_exist Value 0 vals H7). inversion EE1 as [v2']. inversion H4. subst. inversion H7. apply eq_sym, length_zero_iff_nil in H6. subst.
-  pose (EE2 := element_exist _ 0 _ H8). inversion EE2 as [eff2']. inversion H5. subst. inversion H8. apply eq_sym, length_zero_iff_nil in H9. subst.
-  assert (v2' = v2 /\ eff2' = []).
-  {
-    pose (P := H10 0 Nat.lt_0_1). unfold concatn in P. simpl in P. rewrite app_nil_r in P.
-    pose (WD := determinism _ H _ _ P). inversion WD. inversion H6.
-    subst. auto.
-  }
-  inversion H6. subst.
-  inversion H15. subst. simpl in H13, H16.
-  pose (EE3 := element_exist Value 0 vals H13). inversion EE3 as [v1']. inversion H9.
-  subst. inversion H13. apply eq_sym, length_zero_iff_nil in H12. subst.
-  pose (EE4 := element_exist _ _ _ H16). inversion EE4 as [eff1']. inversion H11. subst.
-  inversion H16. apply eq_sym, length_zero_iff_nil in H17. subst.
-  assert (v1' = v1 /\ eff1' = []). 
-  {
-    pose (P := H18 0 Nat.lt_0_1). unfold concatn in P. simpl in P.
-    rewrite app_nil_r in P.
-    pose (WD := determinism _ H2 _ _ P). inversion WD. inversion H12. subst. auto.
-  }
-  inversion H12. subst.
-  apply eval_let with (vals := [v1]) (eff := [[]]) (eff2 := []); auto.
-   - intros. inversion H17.
-     + unfold concatn. simpl. assumption.
-     + inversion H20.
-   - apply eval_let with (vals := [v2]) (eff := [[]]) (eff2 := []); auto.
-     + intros. inversion H17.
-       ** subst. unfold concatn. simpl concat. simpl nth. assumption.
-       ** inversion H20.
-   (** Destruct application hypothesis *)
-     + inversion H23; subst.
-       ** unfold concatn in H21. simpl in H21. pose (WD3 := determinism _ E1 _ _ H21). inversion WD3. subst.
-          pose (EEA := element_exist _ _ _ H20). inversion EEA as [v1']. inversion H17. subst. inversion H20. 
-          pose (EEA2 := element_exist _ _ _ H27). inversion EEA2 as [v2']. inversion H19. subst. inversion H27. apply eq_sym, length_zero_iff_nil in H30. subst.
-          simpl in H25.
-          pose (EEE := element_exist _ _ _ H25). inversion EEE as [eff1']. inversion H29. subst. inversion H25.
-          pose (EEE2 := element_exist _ _ _ H31). inversion EEE2 as [eff2']. inversion H30. subst. inversion H31. apply eq_sym, length_zero_iff_nil in H34. subst.
-          assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
-          {
-            pose (P := H26 0 Nat.lt_0_2). unfold concatn in P. simpl in P.
-            inversion P. rewrite get_value_here in H37. inversion H37.
-            rewrite app_nil_r in H38. subst.
+              pose (P2 := H23 1 Nat.lt_1_2). unfold concatn in P2. simpl in P2.
+              inversion P2. rewrite get_value_here in H38. inversion H38.
+              apply app_inv_head in H39.
+              rewrite app_nil_r in H39. subst.
+              simpl_concatn_H H9. subst.
+            (* } *)
+            eapply eval_apply with (vals := [v1''; v2'']) (eff := [[]; []])
+                                   (ids := [id2'';id2'']); auto.
+            -- unfold concatn. simpl concat. exact E1.
+            -- auto.
+            -- intros. inversion H9. 2: inversion H20.
+              ++ simpl_concatn. replace (inl v2'') with (get_value (insert_value (insert_value env (inl B) v2'') (inl A) v1'') (inl B)). apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+              ++ simpl_concatn. replace (inl v1'') with (get_value (insert_value (insert_value env (inl B) v2'') (inl A) v1'') (inl A)). apply eval_var. rewrite get_value_here. auto.
+              ++ inversion H29.
+            -- unfold concatn. simpl. repeat (rewrite <- app_assoc, app_nil_r). reflexivity.
+            -- simpl_concatn_H H33. simpl_concatn. exact H33.
+         ** eapply eval_apply_ex_closure_ex; try(reflexivity).
+            pose (WD := determinism E2 _ _ _ H25). destruct WD. destruct H9.
+            subst. assumption.
+         ** inversion H16.
+            -- pose (EEA := element_exist _ _ _  (eq_sym H9)). inversion EEA as [v1''].
+               inversion H8. subst.
+               inversion H9. apply length_zero_iff_nil in H24. subst. 
+               simpl in H33. inversion H33.
+               rewrite get_value_here in H32. congruence.
+            -- inversion H9.
+              ++ rewrite H24 in *. simpl in H33. inversion H33.
+               rewrite get_value_there, get_value_here in H34; congruence.
+              ++ inversion H24.
+         ** simpl_concatn_H H20.
+            pose (WD := determinism E2 _ _ _ H20).
+            destruct WD. destruct H9. subst.
+            eapply eval_apply_ex_closure with (vals := [v1'; v2']) (eff := [[];[]])
+                                              (ids := [id';id']); auto.
+           -- simpl_concatn. simpl in E1. exact E1.
+           -- intros. inversion H8. 2: inversion H25.
+              ++ simpl_concatn. replace (inl v2') with (get_value (insert_value (insert_value env (inl B) v2') (inl A) v1') (inl B)). apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+              ++ simpl_concatn. replace (inl v1') with (get_value (insert_value (insert_value env (inl B) v2') (inl A) v1') (inl A)). rewrite H24.
+              apply eval_var. rewrite get_value_here. auto.
+              ++ inversion H30.
+           -- reflexivity.
+         ** simpl_concatn_H H20. pose (WD := determinism E2 _ _ _ H20).
+            inversion WD. destruct H9. subst.
+            eapply eval_apply_ex_param_count with (vals := [v1'; v2']) (eff := [[];[]])
+                                   (ids := [id'; id']); auto.
+           -- simpl_concatn. simpl in E1. exact E1.
+           -- intros. inversion H8. 2: inversion H25.
+              ++ simpl_concatn. replace (inl v2') with (get_value (insert_value (insert_value env (inl B) v2') (inl A) v1') (inl B)). apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+              ++ simpl_concatn. replace (inl v1') with (get_value (insert_value (insert_value env (inl B) v2') (inl A) v1') (inl A)).
+              rewrite H24.
+              apply eval_var. rewrite get_value_here. auto.
+              ++ inversion H30.
+           -- rewrite <- H15 in H23. auto.
+           -- reflexivity.
+      - simpl_concatn_H H24. subst. inversion H16.
+        rewrite H13 in *.
+        apply length_zero_iff_nil in H20. subst.
+        pose (WD := determinism H0 _ _ _ H29).
+        destruct WD. destruct H14. inversion H11.
+        inversion H13.
+      - subst. inversion H8. rewrite H5 in *.
+        apply length_zero_iff_nil in H10. subst.
+        pose (WD := determinism H1 _ _ _ H19).
+        destruct WD. inversion H4.
+        inversion H5.
+    * inversion H3. subst. simpl in H8.
+    pose (EE1 := element_exist Value 0 vals H7). inversion EE1 as [v2'].
+    inversion H4. subst. inversion H7.
+    apply eq_sym, length_zero_iff_nil in H6. subst.
+    pose (EE2 := element_exist _ 0 _ H8). inversion EE2 as [eff2'].
+    inversion H5. subst. inversion H8.
+    apply eq_sym, length_zero_iff_nil in H10. subst.
+    pose (EE3 := element_exist _ 0 _ H9). inversion EE3 as [id2'].
+    inversion H6. subst. inversion H9.
+    apply eq_sym, length_zero_iff_nil in H11. subst.
+    (* assert (v1' = v1 /\ eff1' = []).
+    { *)
+      pose (P := H12 0 Nat.lt_0_1).
+      unfold concatn in P. simpl in P. rewrite app_nil_r in P.
+      pose (WD := determinism H _ _ _ P). destruct WD. destruct H11. inversion H10.
+      subst.
+    (* } *)
+    inversion H18. subst. simpl in H15, H16, H19.
+    pose (EE4 := element_exist Value 0 vals H15).
+    inversion EE4 as [v1']. inversion H11. subst. inversion H15.
+    apply eq_sym, length_zero_iff_nil in H14. subst.
+    pose (EE5 := element_exist _ _ _ H16).
+    inversion EE5 as [eff1']. inversion H13. subst.
+    inversion H16. apply eq_sym, length_zero_iff_nil in H20. subst.
+    pose (EE6 := element_exist _ _ _ H19). inversion EE6 as [id1']. inversion H14. subst.
+    inversion H19. apply eq_sym, length_zero_iff_nil in H21. subst.
+    clear dependent H15. clear dependent H16. clear dependent H19.
+    clear dependent H7. clear dependent H8. clear dependent H9.
+    clear dependent P.
+    (* assert (v2' = v2 /\ eff2' = []). 
+    { *)
+      pose (P := H22 0 Nat.lt_0_1). unfold concatn in P. simpl in P.
+      rewrite app_nil_r in P.
+      pose (WD := determinism H2 _ _ _ P). destruct WD. destruct H8.
+      inversion H7.
+      subst.
+    (* } *)
+    apply eval_let with (vals := [v1']) (eff := [[]]) (eff2 := []) (ids := [id1']); auto.
+     - intros. inversion H8.
+       + unfold concatn. simpl. assumption.
+       + inversion H15.
+     - apply eval_let with (vals := [v2']) (eff := [[]]) (eff2 := []) (ids := [id1']); auto.
+       + intros. inversion H8.
+         ** subst. unfold concatn. simpl concat. simpl nth. assumption.
+         ** inversion H15.
+     (** Destruct application hypothesis *)
+       + inversion H28; subst.
+         ** pose (WD3 := determinism E1 _ _ _ H16). destruct WD3.
+            inversion H8. destruct H9. subst.
+            pose (EEA := element_exist _ _ _ H15).
+            inversion EEA as [v1'']. inversion H8. subst. inversion H15. 
+            pose (EEA2 := element_exist _ _ _ H29).
+            inversion EEA2 as [v2'']. inversion H25. subst. inversion H15.
+            apply eq_sym, length_zero_iff_nil in H31. subst.
+            pose (EEE := element_exist _ _ _ H20).
+            inversion EEE as [eff1'']. inversion H30. subst. inversion H20.
+            pose (EEE2 := element_exist _ _ _ H32).
+            inversion EEE2 as [eff2'']. inversion H31. subst. inversion H20.
+            apply eq_sym, length_zero_iff_nil in H35. subst.
+            pose (EEI := element_exist _ _ _ H21).
+            inversion EEI as [id1'']. inversion H34. subst. inversion H21.
+            pose (EEI2 := element_exist _ _ _ H36).
+            inversion EEI2 as [id2'']. inversion H35. subst. inversion H21.
+            apply eq_sym, length_zero_iff_nil in H38. subst.
+            clear dependent H15. clear dependent H29. clear dependent H20.
+            clear dependent H32. clear dependent H21. clear dependent H36.
+            clear dependent P.
+            (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
+            { *)
+              pose (P := H23 0 Nat.lt_0_2). unfold concatn in P. simpl in P.
+              inversion P.
+              rewrite get_value_here in H37.
+              inversion H37.
+              apply app_inv_head in H38.
+              rewrite app_nil_r in H38. subst.
 
-            pose (P2 := H26 1 Nat.lt_1_2). unfold concatn in P2. simpl in P2.
-            inversion P2. rewrite get_value_there in H38. rewrite get_value_here in H38. inversion H38.
-            rewrite app_nil_r in H39. subst. auto.
-            congruence.
-          }
-          inversion H33. inversion H35. inversion H37. subst.
-          eapply eval_apply with (vals := [v1; v2]) (eff := [[]; []]); auto.
-          -- unfold concatn. simpl concat. exact E2.
-          -- auto.
-          -- intros. inversion H34. 2: inversion H38.
-            ++ simpl_concatn. replace (inl v2) with (get_value (insert_original_value (insert_original_value env (inl A) v1) (inl B) v2) (inl B)). apply eval_var. rewrite get_value_here. auto.
-            ++ simpl_concatn. replace (inl v1) with (get_value (insert_original_value (insert_original_value env (inl A) v1) (inl B) v2) (inl A)). apply eval_var. rewrite get_value_there. rewrite get_value_here. auto. congruence.
-            ++ inversion H40.
-          -- unfold concatn. simpl. repeat (rewrite <- app_assoc, app_nil_r). reflexivity.
-          -- simpl_concatn_H H32. simpl_concatn. exact H32.
-       ** eapply eval_apply_ex_closure_ex; try(reflexivity).
-          pose (WD := determinism _ E1 _ _ H27). inversion WD. subst. assumption.
-       ** inversion H21.
-          -- pose (EEA := element_exist _ _ _  (eq_sym H19)). inversion EEA as [v1']. inversion H17. subst. inversion H19. apply length_zero_iff_nil in H27. subst. simpl in H32. inversion H32.
-             rewrite get_value_there, get_value_here in H31; congruence.
-          -- inversion H19.
-            ++ rewrite H27 in *. simpl in H32. inversion H32.
-             rewrite get_value_here in H33. congruence.
-            ++ inversion H27.
-       ** simpl_concatn_H H24. pose (WD := determinism _ E1 _ _ H24). inversion WD. subst. eapply eval_apply_ex_closure with (vals := [v1; v2]) (eff := [[];[]]); auto.
-         -- simpl_concatn. simpl in E1. exact E2.
-         -- intros. inversion H17. 2: inversion H26.
-            ++ simpl_concatn. replace (inl v2) with (get_value (insert_original_value (insert_original_value env (inl A) v1) (inl B) v2) (inl B)). apply eval_var. rewrite get_value_here. auto.
-            ++ simpl_concatn. replace (inl v1) with (get_value (insert_original_value (insert_original_value env (inl A) v1) (inl B) v2) (inl A)). apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
-            ++ inversion H29.
-         -- reflexivity.
-       ** simpl_concatn_H H24. pose (WD := determinism _ E1 _ _ H24). inversion WD. subst.
-          eapply eval_apply_ex_param_count with (vals := [v1; v2]) (eff := [[];[]]); auto.
-         -- simpl_concatn. simpl in E1. exact E2.
-         -- intros. inversion H17. 2: inversion H26.
-            ++ simpl_concatn. replace (inl v2) with (get_value (insert_original_value (insert_original_value env (inl A) v1) (inl B) v2) (inl B)). apply eval_var. rewrite get_value_here. auto.
-            ++ simpl_concatn. replace (inl v1) with (get_value (insert_original_value (insert_original_value env (inl A) v1) (inl B) v2) (inl A)). apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
-            ++ inversion H29.
-         -- rewrite <- H20 in H27. auto.
-         -- reflexivity.
-    - inversion H16. simpl_concatn_H H24. subst. rewrite H26 in H24. pose (WD := determinism _ H2 _ _ H24). inversion WD. inversion H9. 
-      inversion H26.
-    - inversion H8. subst. simpl in H16. rewrite H18 in H16. pose (WD := determinism _ H _ _ H16). inversion WD. inversion H4.
-      inversion H18.
+              pose (P2 := H23 1 Nat.lt_1_2). unfold concatn in P2. simpl in P2.
+              inversion P2.
+              rewrite get_value_there in H38. 2: congruence.
+              rewrite get_value_here in H38.
+              inversion H38.
+              apply app_inv_head in H39.
+              rewrite app_nil_r in H39. subst.
+              simpl_concatn_H H9. subst.
+            (* } *)
+            eapply eval_apply with (vals := [v1''; v2'']) (eff := [[]; []])
+                                   (ids := [id2'';id2'']); auto.
+            -- unfold concatn. simpl concat. exact E2.
+            -- auto.
+            -- intros. inversion H9. 2: inversion H20.
+              ++ simpl_concatn. replace (inl v2'') with (get_value (insert_value (insert_value env (inl A) v1'') (inl B) v2'') (inl B)). apply eval_var. rewrite get_value_here. auto.
+              ++ simpl_concatn. replace (inl v1'') with (get_value (insert_value (insert_value env (inl A) v1'') (inl B) v2'') (inl A)). apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+              ++ inversion H29.
+            -- unfold concatn. simpl. repeat (rewrite <- app_assoc, app_nil_r). reflexivity.
+            -- simpl_concatn_H H33. simpl_concatn. exact H33.
+         ** eapply eval_apply_ex_closure_ex; try(reflexivity).
+            pose (WD := determinism E1 _ _ _ H25). destruct WD. destruct H9.
+            subst. assumption.
+         ** inversion H16.
+            -- pose (EEA := element_exist _ _ _  (eq_sym H9)). inversion EEA as [v1''].
+               inversion H8. subst.
+               inversion H9. apply length_zero_iff_nil in H24. subst. 
+               simpl in H33. inversion H33.
+               rewrite get_value_there, get_value_here in H32. 
+               congruence. congruence.
+            -- inversion H9.
+              ++ rewrite H24 in *. simpl in H33. inversion H33.
+               rewrite get_value_here in H34. congruence.
+              ++ inversion H24.
+         ** simpl_concatn_H H20.
+            pose (WD := determinism E1 _ _ _ H20).
+            destruct WD. destruct H9. subst.
+            eapply eval_apply_ex_closure with (vals := [v1'; v2']) (eff := [[];[]])
+                                              (ids := [id';id']); auto.
+           -- simpl_concatn. simpl in E1. exact E2.
+           -- intros. inversion H8. 2: inversion H25.
+              ++ simpl_concatn. replace (inl v2') with (get_value (insert_value (insert_value env (inl A) v1') (inl B) v2') (inl B)). apply eval_var. rewrite get_value_here. auto.
+              ++ simpl_concatn. replace (inl v1') with (get_value (insert_value (insert_value env (inl A) v1') (inl B) v2') (inl A)). rewrite H24.
+              apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+              ++ inversion H30.
+           -- reflexivity.
+         ** simpl_concatn_H H20. pose (WD := determinism E1 _ _ _ H20).
+            inversion WD. destruct H9. subst.
+            eapply eval_apply_ex_param_count with (vals := [v1'; v2']) (eff := [[];[]])
+                                   (ids := [id'; id']); auto.
+           -- simpl_concatn. simpl in E1. exact E2.
+           -- intros. inversion H8. 2: inversion H25.
+              ++ simpl_concatn. replace (inl v2') with (get_value (insert_value (insert_value env (inl A) v1') (inl B) v2') (inl B)). apply eval_var. rewrite get_value_here. auto.
+              ++ simpl_concatn. replace (inl v1') with (get_value (insert_value (insert_value env (inl A) v1') (inl B) v2') (inl A)).
+              rewrite H24.
+              apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+              ++ inversion H30.
+           -- rewrite <- H15 in H23. auto.
+           -- reflexivity.
+      - simpl_concatn_H H24. subst. inversion H16.
+        rewrite H13 in *.
+        apply length_zero_iff_nil in H20. subst.
+        pose (WD := determinism H2 _ _ _ H29).
+        destruct WD. destruct H14. inversion H11.
+        inversion H13.
+      - subst. inversion H8. rewrite H5 in *.
+        apply length_zero_iff_nil in H10. subst.
+        pose (WD := determinism H _ _ _ H19).
+        destruct WD. inversion H4.
+        inversion H5.
 Qed.
 
 End Core_Erlang_Equivalence_Proofs.

--- a/Core_Erlang_Equivalence_Proofs.v
+++ b/Core_Erlang_Equivalence_Proofs.v
@@ -553,170 +553,224 @@ Example let_1_comm_2_list (env: Environment) (e1 e2 : Expression) (t t' : Value)
 t = t'. *)
 
 Example let_2_binding_swap (env: Environment)(e1 e2 : Expression) (t x x0 : Value) 
-    (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B) :
-  |env, e2, eff| -e> |inl x0, eff ++ eff2| -> 
-  |append_vars_to_env [A] [x] env, e2, eff ++ eff1| -e> |inl x0, eff ++ eff1 ++ eff2| ->
-  |env, e1, eff| -e> |inl x, eff ++ eff1| -> 
-  |append_vars_to_env [B] [x0] env, e1, eff ++ eff2| -e> |inl x, eff ++ eff2 ++ eff1| ->
-  |env, ELet [A] [e1] (ELet [B] [e2] 
-        (ECall "plus"%string [EVar A ; EVar B])), eff| -e> |inl t, eff ++ eff1 ++ eff2|
+    (eff eff1 eff2 : SideEffectList) (A B : Var) (id0 id1 id2 : nat) (VarHyp : A <> B) :
+  |env, id0, e2, eff| -e> |id0 + id2, inl x0, eff ++ eff2| -> 
+  |append_vars_to_env [A] [x] env, id0 + id1, e2, eff ++ eff1| -e> | id0 + id1 + id2, inl x0, eff ++ eff1 ++ eff2| ->
+  |env, id0, e1, eff| -e> |id0 + id1, inl x, eff ++ eff1| -> 
+  |append_vars_to_env [B] [x0] env, id0 + id2, e1, eff ++ eff2| -e> |id0 + id2 + id1, inl x, eff ++ eff2 ++ eff1| ->
+  |env, id0, ELet [A] [e1] (ELet [B] [e2] 
+        (ECall "plus"%string [EVar A ; EVar B])), eff| -e> |id0 + id1 + id2, inl t, eff ++ eff1 ++ eff2|
 <->
-|env, ELet [B] [e2] (ELet [A] [e1]
-        (ECall "plus"%string [EVar A ; EVar B])), eff| -e> |inl t, eff ++ eff2 ++ eff1|
+|env, id0, ELet [B] [e2] (ELet [A] [e1]
+        (ECall "plus"%string [EVar A ; EVar B])), eff| -e> |id0 + id2 + id1, inl t, eff ++ eff2 ++ eff1|
 .
 Proof.
   split.
-  * intros. inversion H3. subst. simpl in H8. pose (EE1 := element_exist Value 0 vals H7). inversion EE1 as [x']. inversion H4. subst. inversion H7. apply eq_sym, length_zero_iff_nil in H6. subst.
-    pose (EE2 := element_exist _ 0 _ H8). inversion EE2 as [eff1']. inversion H5. subst. inversion H8. apply eq_sym, length_zero_iff_nil in H9. subst.
-    assert (x' = x /\ eff1' = eff1).
+  * intros. inversion H3. subst.
+    pose (EE1 := element_exist Value 0 vals H7).
+    pose (EE2 := element_exist _ 0 _ H8).
+    pose (EE3 := element_exist _ 0 _ H9).
+    inversion EE1 as [x']. inversion EE2 as [eff1']. inversion EE3 as [id1'].
+    inversion H4. inversion H5. inversion H6. subst. 
+    inversion H7. inversion H8. inversion H9.
+    apply eq_sym, length_zero_iff_nil in H11.
+    apply eq_sym, length_zero_iff_nil in H13.
+    apply eq_sym, length_zero_iff_nil in H14. subst.
+    assert (x' = x /\ eff1' = eff1 /\ id1' = (id0 + id1)%nat).
     {
-      pose (P := H10 0 Nat.lt_0_1). unfold concatn in P. simpl in P. rewrite app_nil_r, app_nil_r in P.
-      pose (WD := determinism _ H1 _ _ P). inversion WD. inversion H6. apply app_inv_head in H9.
+      pose (P := H12 0 Nat.lt_0_1). unfold concatn in P. simpl in P. rewrite app_nil_r, app_nil_r in P.
+      pose (WD := determinism H1 _ _ _ P). destruct WD. destruct H11. inversion H10. apply app_inv_head in H11.
       subst. auto.
     }
-    inversion H6. subst.
-    inversion H15. subst. simpl in H13, H16.
-    pose (EE3 := element_exist Value 0 vals H13). inversion EE3 as [x0']. inversion H9.
-    subst. inversion H13. apply eq_sym, length_zero_iff_nil in H12. subst.
-    pose (EE4 := element_exist _ _ _ H16). inversion EE4 as [eff2']. inversion H11. subst.
-    inversion H16. apply eq_sym, length_zero_iff_nil in H17. subst.
-    assert (x0' = x0 /\ eff2' = eff2). 
+    destruct H10. destruct H11. subst.
+    inversion H18. subst.
+    pose (EE1' := element_exist Value 0 vals H14).
+    pose (EE2' := element_exist _ 0 _ H15).
+    pose (EE3' := element_exist _ 0 _ H16).
+    inversion EE1' as [x0']. inversion EE2' as [eff2']. inversion EE3' as [id2'].
+    inversion H10. inversion H11. inversion H13. subst. 
+    inversion H14. inversion H15. inversion H16.
+    apply eq_sym, length_zero_iff_nil in H20.
+    apply eq_sym, length_zero_iff_nil in H22.
+    apply eq_sym, length_zero_iff_nil in H23. subst.
+    assert (x0' = x0 /\ eff2' = eff2 /\ id2' = (id0 + id1 + id2)%nat).
     {
-      pose (P := H18 0 Nat.lt_0_1). unfold concatn in P. simpl in P.
+      pose (P := H21 0 Nat.lt_0_1). unfold concatn in P. simpl in P.
       rewrite app_nil_r, app_nil_r, app_nil_r in P.
-      pose (WD := determinism _ H0 _ _ P). inversion WD. inversion H12.
-      rewrite app_assoc in H17. apply app_inv_head in H17. subst. auto.
+      pose (WD := determinism H0 _ _ _ P). 
+      destruct WD. destruct H20. inversion H19.
+      rewrite app_assoc in H20. apply app_inv_head in H20. subst. auto.
     }
-    inversion H12. subst.
+    destruct H19. destruct H20. subst.
    (*proving starts*)
-   apply eval_let with (vals := [x0]) (eff := [eff2]) (eff2 := eff1); auto.
-   - intros. inversion H17.
+   apply eval_let with (vals := [x0]) (eff := [eff2]) (eff2 := eff1) (ids := [(id0 + id2)%nat]); auto.
+   - intros. inversion H19.
      + unfold concatn. simpl. rewrite app_nil_r, app_nil_r. assumption.
-     + inversion H20.
+     + inversion H22.
    - unfold concatn. simpl. rewrite app_nil_r, app_assoc. auto.
-   - apply eval_let with (vals := [x]) (eff := [eff1]) (eff2 := []); auto.
-     + intros. inversion H17.
+   - apply eval_let with (vals := [x]) (eff := [eff1]) (eff2 := []) (ids := [(id0 + id2 + id1)%nat]); auto.
+     + intros. inversion H19.
        ** subst. unfold concatn. simpl concat. simpl nth.
-       rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc. assumption.
-       ** inversion H20.
+       rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc. simpl. assumption.
+       ** inversion H22.
      + unfold concatn. simpl. rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc. auto.
    (* call information *)
-     + inversion H23. subst. simpl in H20, H21.
-       pose (EE5 := element_exist Value 1 vals H20). inversion EE5 as [x'].
-       inversion H17. subst. inversion H20.
-       pose (EE6 := element_exist Value 0 x1 H24). inversion EE6 as [x0'].
-       inversion H19. subst. inversion H24. apply eq_sym, length_zero_iff_nil in H27. subst.
-       pose (EE7 := element_exist _ _ _ H21). inversion EE7 as [eff1'].
-       inversion H26. subst. inversion H21.
-       pose (EE8 := element_exist _ _ _ H28). inversion EE8 as [eff2'].
-       inversion H27. subst. inversion H28. apply eq_sym, length_zero_iff_nil in H31. subst.
-       assert (x' = x /\ x0' = x0 /\ eff1' = [] /\ eff2' = []).
+     + inversion H27. subst.
+       pose (EC1 := element_exist _ 1 _ H22).
+       pose (EC2 := element_exist _ 1 _ H23).
+       pose (EC3 := element_exist _ 1 _ H24).
+       inversion EC1 as [x']. inversion EC2 as [eff1']. inversion EC3 as [id1'].
+       inversion H19. inversion H20. inversion H28. subst. 
+       inversion H22. inversion H23. inversion H24.
+       pose (EC1' := element_exist _ 0 _ H31).
+       pose (EC2' := element_exist _ 0 _ H32).
+       pose (EC3' := element_exist _ 0 _ H33).
+       inversion EC1' as [x0']. inversion EC2' as [eff2']. inversion EC3' as [id2'].
+       inversion H29. inversion H34. inversion H36. subst. 
+       inversion H31. inversion H32. inversion H33.
+       apply eq_sym, length_zero_iff_nil in H38.
+       apply eq_sym, length_zero_iff_nil in H39.
+       apply eq_sym, length_zero_iff_nil in H40. subst.
+       assert (x' = x /\ x0' = x0 /\ eff1' = [] /\ eff2' = [] /\ id1' = (id0 + id1 + id2)%nat /\ id2' = (id0 + id1 + id2)%nat).
        {
          pose (P1 := H25 0 Nat.lt_0_2).
          pose (P2 := H25 1 Nat.lt_1_2).
          inversion P1. inversion P2. subst.
          
-         unfold concatn in H35, H40. simpl in H35, H40.
-         apply app_inv_head in H35. apply app_inv_head, app_inv_head in H40.
-         rewrite app_nil_r in H35. rewrite app_nil_r in H40. subst.
+         simpl_concatn_H H51. simpl_concatn_H H44.
+         rewrite <- app_nil_r in H44 at 1.
+         apply app_inv_head in H44. subst.
+         rewrite <- app_nil_r in H51 at 1.
+         apply app_inv_head in H51. subst.
          
-         rewrite get_value_there in H34.
-           - rewrite get_value_here in H34. inversion H34.
-             rewrite get_value_here in H39. inversion H39. auto.
-           - unfold not. intros. inversion H30. congruence.
+         simpl in H41, H48. subst.
+         
+         rewrite get_value_there in H43.
+           - rewrite get_value_here in H43. inversion H43.
+             rewrite get_value_here in H50. inversion H50. split; auto.
+           - unfold not. intros. inversion H37. congruence.
        }
-       inversion H30. inversion H32. inversion H34. subst.
+       destruct H37. destruct H38. destruct H39. destruct H40. destruct H41. subst.
        
        (* BACK TO CALL PROOF *)
-       apply eval_call with (vals := [x ; x0]) (eff := [[];[]]); auto.
-       ** intros. inversion H31. 2: inversion H35. 3: inversion H37.
-         -- unfold concatn. simpl. assert (get_value (insert_original_value (insert_original_value env (inl B) x0) 
-                                     (inl A) x) (inl B) = inl x0). 
-                                     { rewrite get_value_there. apply get_value_here. congruence. }
-            rewrite <- H33. apply eval_var.
-         -- simpl. subst. assert (get_value (insert_original_value (insert_original_value env (inl B) x0) 
-                                           (inl A) x) (inl A) = inl x).
-                                           {  apply get_value_here. }
-            rewrite <- H33. apply eval_var.
+       apply eval_call with (vals := [x ; x0]) (eff := [[];[]]) (ids := [(id0 + id2 + id1)%nat; (id0 + id2 + id1)%nat]); auto.
+       ** intros. inversion H37. 2: inversion H39. 3: inversion H41.
+         -- simpl. assert (get_value (insert_value (insert_value env (inl B) x0) (inl A) x) (inl B) = inl x0). 
+                                     { rewrite get_value_there. apply get_value_here.
+                                             unfold not. intros. inversion H33.
+                                             congruence. }
+            rewrite <- H38. apply eval_var.
+         -- simpl. subst. assert (get_value (insert_value (insert_value env (inl B) x0) (inl A) x) (inl A) = inl x).
+                                           { apply get_value_here. }
+            rewrite <- H38. apply eval_var.
        ** unfold concatn. simpl concat. rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc.
-          unfold concatn in H29. simpl concat in H29.
-          rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc in H29.
-          apply plus_effect_changeable with (eff ++ eff1 ++ eff2). assumption.
-  * intros. inversion H3. subst. simpl in H8. pose (EE1 := element_exist Value 0 vals H7). inversion EE1 as [x0']. inversion H4. subst. inversion H7. apply eq_sym, length_zero_iff_nil in H6. subst.
-    pose (EE2 := element_exist _ 0 _ H8). inversion EE2 as [eff2']. inversion H5. subst. inversion H8. apply eq_sym, length_zero_iff_nil in H9. subst.
-    assert (x0' = x0 /\ eff2' = eff2).
+          unfold concatn in H30. simpl concat in H30.
+          rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc in H30.
+          apply plus_effect_changeable with (eff0 := eff ++ eff1 ++ eff2). assumption.
+  * intros. inversion H3. subst.
+    pose (EE1 := element_exist Value 0 vals H7).
+    pose (EE2 := element_exist _ 0 _ H8).
+    pose (EE3 := element_exist _ 0 _ H9).
+    inversion EE1 as [x0']. inversion EE2 as [eff2']. inversion EE3 as [id2'].
+    inversion H4. inversion H5. inversion H6. subst. 
+    inversion H7. inversion H8. inversion H9.
+    apply eq_sym, length_zero_iff_nil in H11.
+    apply eq_sym, length_zero_iff_nil in H13.
+    apply eq_sym, length_zero_iff_nil in H14. subst.
+    assert (x0' = x0 /\ eff2' = eff2 /\ id2' = (id0 + id2)%nat).
     {
-      pose (P := H10 0 Nat.lt_0_1). unfold concatn in P. simpl in P. rewrite app_nil_r, app_nil_r in P.
-      pose (WD := determinism _ H _ _ P). inversion WD. inversion H6. apply app_inv_head in H9.
+      pose (P := H12 0 Nat.lt_0_1). unfold concatn in P. simpl in P. rewrite app_nil_r, app_nil_r in P.
+      pose (WD := determinism H _ _ _ P). destruct WD. destruct H11. inversion H10. apply app_inv_head in H11.
       subst. auto.
     }
-    inversion H6. subst.
-    inversion H15. subst. simpl in H13, H16.
-    pose (EE3 := element_exist Value 0 vals H13). inversion EE3 as [x']. inversion H9.
-    subst. inversion H13. apply eq_sym, length_zero_iff_nil in H12. subst.
-    pose (EE4 := element_exist _ _ _ H16). inversion EE4 as [eff1']. inversion H11. subst.
-    inversion H16. apply eq_sym, length_zero_iff_nil in H17. subst.
-    assert (x' = x /\ eff1' = eff1). 
+    destruct H10. destruct H11. subst.
+    inversion H18. subst.
+    pose (EE1' := element_exist Value 0 vals H14).
+    pose (EE2' := element_exist _ 0 _ H15).
+    pose (EE3' := element_exist _ 0 _ H16).
+    inversion EE1' as [x']. inversion EE2' as [eff1']. inversion EE3' as [id1'].
+    inversion H10. inversion H11. inversion H13. subst. 
+    inversion H14. inversion H15. inversion H16.
+    apply eq_sym, length_zero_iff_nil in H20.
+    apply eq_sym, length_zero_iff_nil in H22.
+    apply eq_sym, length_zero_iff_nil in H23. subst.
+    assert (x' = x /\ eff1' = eff1 /\ id1' = (id0 + id1 + id2)%nat).
     {
-      pose (P := H18 0 Nat.lt_0_1). unfold concatn in P. simpl in P.
+      pose (P := H21 0 Nat.lt_0_1). unfold concatn in P. simpl in P.
       rewrite app_nil_r, app_nil_r, app_nil_r in P.
-      pose (WD := determinism _ H2 _ _ P). inversion WD. inversion H12.
-      rewrite app_assoc in H17. apply app_inv_head in H17. subst. auto.
+      pose (WD := determinism H2 _ _ _ P). 
+      destruct WD. destruct H20. inversion H19.
+      rewrite app_assoc in H20. apply app_inv_head in H20. subst.
+      split.
+      - reflexivity.
+      - split. reflexivity. omega.
     }
-    inversion H12. subst.
+    destruct H19. destruct H20. subst.
    (*proving starts*)
-   apply eval_let with (vals := [x]) (eff := [eff1]) (eff2 := eff2); auto.
-   - intros. inversion H17.
+   apply eval_let with (vals := [x]) (eff := [eff1]) (eff2 := eff2) (ids := [(id0 + id1)%nat]); auto.
+   - intros. inversion H19.
      + unfold concatn. simpl. rewrite app_nil_r, app_nil_r. assumption.
-     + inversion H20.
+     + inversion H22.
    - unfold concatn. simpl. rewrite app_nil_r, app_assoc. auto.
-   - apply eval_let with (vals := [x0]) (eff := [eff2]) (eff2 := []); auto.
-     + intros. inversion H17.
+   - apply eval_let with (vals := [x0]) (eff := [eff2]) (eff2 := []) (ids := [(id0 + id1 + id2)%nat]); auto.
+     + intros. inversion H19.
        ** subst. unfold concatn. simpl concat. simpl nth.
-       rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc. assumption.
-       ** inversion H20.
+       rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc. simpl. assumption.
+       ** inversion H22.
      + unfold concatn. simpl. rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc. auto.
    (* call information *)
-     + inversion H23. subst. simpl in H20, H21.
-       pose (EE5 := element_exist Value 1 vals H20). inversion EE5 as [x'].
-       inversion H17. subst. inversion H20.
-       pose (EE6 := element_exist Value 0 x1 H24). inversion EE6 as [x0'].
-       inversion H19. subst. inversion H24. apply eq_sym, length_zero_iff_nil in H27. subst.
-       pose (EE7 := element_exist _ _ _ H21). inversion EE7 as [eff1'].
-       inversion H26. subst. inversion H21.
-       pose (EE8 := element_exist _ _ _ H28). inversion EE8 as [eff2'].
-       inversion H27. subst. inversion H28. apply eq_sym, length_zero_iff_nil in H31. subst.
-       assert (x' = x /\ x0' = x0 /\ eff1' = [] /\ eff2' = []).
+     + inversion H27. subst.
+       pose (EC1 := element_exist _ 1 _ H22).
+       pose (EC2 := element_exist _ 1 _ H23).
+       pose (EC3 := element_exist _ 1 _ H24).
+       inversion EC1 as [x']. inversion EC2 as [eff1']. inversion EC3 as [id1'].
+       inversion H19. inversion H20. inversion H28. subst. 
+       inversion H22. inversion H23. inversion H24.
+       pose (EC1' := element_exist _ 0 _ H31).
+       pose (EC2' := element_exist _ 0 _ H32).
+       pose (EC3' := element_exist _ 0 _ H33).
+       inversion EC1' as [x0']. inversion EC2' as [eff2']. inversion EC3' as [id2'].
+       inversion H29. inversion H34. inversion H36. subst. 
+       inversion H31. inversion H32. inversion H33.
+       apply eq_sym, length_zero_iff_nil in H38.
+       apply eq_sym, length_zero_iff_nil in H39.
+       apply eq_sym, length_zero_iff_nil in H40. subst.
+       assert (x' = x /\ x0' = x0 /\ eff1' = [] /\ eff2' = [] /\ id1' = (id0 + id1 + id2)%nat /\ id2' = (id0 + id1 + id2)%nat).
        {
          pose (P1 := H25 0 Nat.lt_0_2).
          pose (P2 := H25 1 Nat.lt_1_2).
          inversion P1. inversion P2. subst.
          
-         unfold concatn in H35, H40. simpl in H35, H40.
-         apply app_inv_head in H35. apply app_inv_head, app_inv_head in H40.
-         rewrite app_nil_r in H35. rewrite app_nil_r in H40. subst.
+         simpl_concatn_H H51. simpl_concatn_H H44.
+         rewrite <- app_nil_r in H44 at 1.
+         apply app_inv_head in H44. subst.
+         rewrite <- app_nil_r in H51 at 1.
+         apply app_inv_head in H51. subst.
          
-         rewrite get_value_here in H34.
-         rewrite get_value_there in H39.
-         - inversion H34. rewrite get_value_here in H39. inversion H39. subst. auto.
-         - unfold not. intros. inversion H30. congruence.
+         simpl in H41, H48. subst.
+         
+         rewrite get_value_here in H43. inversion H43.
+         rewrite get_value_there in H50.
+           - rewrite get_value_here in H50. inversion H50. split; auto.
+           - congruence.
        }
-       inversion H30. inversion H32. inversion H34. subst.
+       destruct H37. destruct H38. destruct H39. destruct H40. destruct H41. subst.
        
        (* BACK TO CALL PROOF *)
-       apply eval_call with (vals := [x ; x0]) (eff := [[];[]]); auto.
-       ** intros. inversion H31. 2: inversion H35. 3: inversion H37.
-         -- unfold concatn. simpl. assert (get_value (insert_original_value (insert_original_value env (inl A) x) (inl B) x0) (inl B) = inl x0). 
-                                     { apply get_value_here. }
-            rewrite <- H33. apply eval_var.
-         -- simpl. subst. assert (get_value (insert_original_value (insert_original_value env (inl A) x) 
-                                           (inl B) x0) (inl A) = inl x).
-                                           { rewrite get_value_there. apply get_value_here. congruence. }
-            rewrite <- H33. apply eval_var.
+       apply eval_call with (vals := [x ; x0]) (eff := [[];[]]) (ids := [(id0 + id2 + id1)%nat; (id0 + id2 + id1)%nat]); auto.
+       ** intros. inversion H37. 2: inversion H39. 3: inversion H41.
+         -- simpl. assert (get_value (insert_value (insert_value env (inl A) x) (inl B) x0) (inl B) = inl x0). { apply get_value_here. }
+                                     
+            rewrite <- H38. apply eval_var.
+         -- simpl. subst. assert (get_value (insert_value (insert_value env (inl A) x) (inl B) x0) (inl A) = inl x). { rewrite get_value_there. apply get_value_here.
+                                             unfold not. intros. inversion H33.
+                                             congruence. }
+                                           
+            rewrite <- H38. assert ((id0 + id2 + id1)%nat = (id0 + id1 + id2)%nat). { omega. } rewrite H40. apply eval_var.
        ** unfold concatn. simpl concat. rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc.
-          unfold concatn in H29. simpl concat in H29.
-          rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc in H29.
-          apply plus_effect_changeable with (eff ++ eff2 ++ eff1). assumption.
+          unfold concatn in H30. simpl concat in H30.
+          rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc in H30.
+          apply plus_effect_changeable with (eff0 := eff ++ eff2 ++ eff1). assumption.
 Qed.
 
 Example let_1_binding_swap_2_list (env: Environment) (e1 e2 : Expression) (t t' v1 v2 : Value) 

--- a/Core_Erlang_Equivalence_Proofs.v
+++ b/Core_Erlang_Equivalence_Proofs.v
@@ -34,98 +34,105 @@ Qed.
 
 
 
-(* Example call_comm : forall (e e' : Expression) (x1 x2 t : Value) (env : Environment),
-  |env, e, []| -e> |inl x1, []| ->
-  |env, e', []| -e> |inl x2, []| ->
-  |env, ECall "plus"%string [e ; e'], []| -e> |inl t, []| ->
-  |env, ECall "plus"%string [e' ; e], []| -e> |inl t, []|.
+Example call_comm : forall (e e' : Expression) (x1 x2 t : Value) 
+                           (env : Environment) (id : nat),
+  |env, id, e, []| -e> |id, inl x1, []| ->
+  |env, id, e', []| -e> | id, inl x2, []| ->
+  |env, id, ECall "plus"%string [e ; e'], []| -e> | id, inl t, []| ->
+  |env, id, ECall "plus"%string [e' ; e], []| -e> | id, inl t, []|.
 Proof.
   intros. 
   (* List elements *)
-  inversion H1; subst; simpl in H4; pose (EE1 := element_exist Value 1 vals H4);
-  inversion EE1; inversion H2; subst; inversion H4; pose (EE2 := element_exist Value 0 x0 H6);
-  inversion EE2; inversion H3; subst; simpl in H4; inversion H4;
-  apply eq_sym, length_zero_iff_nil in H9; subst;
-  pose (WD1 := determinism _ H);
-  pose (WD2 := determinism _ H0);
-  pose (P1 := H7 0 Nat.lt_0_2);
-  pose (P2 := H7 1 Nat.lt_1_2);
+  inversion H1. subst; simpl in H4.
+  pose (EE1 := element_exist Value 1 vals H4).
+  inversion EE1. inversion H2. subst. inversion H4.
+  pose (EE2 := element_exist Value 0 x0 H8).
+  inversion EE2. inversion H3. subst. simpl in H4. inversion H4.
+  apply eq_sym, length_zero_iff_nil in H11. subst.
+  pose (WD1 := determinism H).
+  pose (WD2 := determinism H0).
+  pose (P1 := H7 0 Nat.lt_0_2).
+  pose (P2 := H7 1 Nat.lt_1_2).
   unfold concatn in P1, P2.
-  apply WD1 in P1; inversion P1; simpl in H9; assert (concat (firstn 1 eff) = []).
+  apply WD1 in P1; inversion P1; simpl in H9; 
+  assert (concat (firstn 1 eff) = []).
   {
     destruct eff.
     * simpl. reflexivity.
-    * simpl. inversion H9. auto.
+    * simpl. inversion H11. auto.
   }
-  rewrite H10 in *. rewrite app_nil_l in P2. simpl nth in P2.
-  apply WD2 in P2. inversion P2. inversion H5. inversion H12. inversion P1. inversion H14. subst.
-  eapply eval_call with (vals := [x3; x]) (eff := [[];[]]); auto.
-  * intros. inversion H16.
+  rewrite H12 in *. rewrite app_nil_l in P2. simpl nth in P2.
+  inversion H9. subst. destruct H11. subst.
+  rewrite <- H13 in *.
+  apply WD2 in P2. inversion P2. destruct H16.
+  inversion H14. simpl in H12. subst.
+  eapply eval_call with (vals := [x3; x]) (eff := [[];[]]) (ids := [id; id]); auto.
+  * intros. inversion H18.
     - unfold concatn. simpl. assumption.
-    - inversion H19.
+    - inversion H20.
       + unfold concatn. simpl. assumption.
-      + inversion H21.
-  * rewrite (@plus_comm_basic x x3 t). unfold concatn. simpl concat.
-    inversion H5. 
-    pose (EE3 := element_exist SideEffectList _ _ H18). inversion EE3. inversion H16.
-    subst. inversion H5.
-    pose (EE4 := element_exist SideEffectList _ _ H20). inversion EE4. inversion H19.
-    subst. inversion H20. apply eq_sym, length_zero_iff_nil in H22. subst.
-    inversion H13. rewrite app_nil_r in H22. assert (x0 = [] /\ x2 = []). 
-    { destruct x0.
-      * simpl in H22. auto.
-      * inversion H22.
-    }
-    inversion H21. subst. rewrite app_nil_r. reflexivity.
-    - inversion H5. pose (EE3 := element_exist _ _ _ H18). inversion EE3. inversion H16.
-      subst. inversion H18.
-      pose (EE4 := element_exist _ _ _ H20). inversion EE4. inversion H19. subst. inversion H20.
-      apply eq_sym, length_zero_iff_nil in H22. subst.
-      
-      unfold concatn in *. simpl app in *.
-      rewrite app_nil_r in H13. assert (x0 = [] /\ x2 = []). { destruct x0. auto. inversion H13. }
-      inversion H21. subst.
-      assumption.
-Qed. *)
+      + inversion H22.
+  * rewrite (@plus_comm_basic x x3 t). 
+      - unfold concatn. simpl concat. simpl. reflexivity.
+      - pose (EE3 := element_exist SideEffectList _ _ H5).
+        inversion EE3. inversion H18.
+        subst. inversion H5.
+        pose (EE4 := element_exist SideEffectList _ _ H20).
+        inversion EE4. inversion H19.
+        subst. inversion H20. apply eq_sym, length_zero_iff_nil in H22. subst.
+        pose (EE5 := element_exist _ _ _ H6).
+        inversion EE5. inversion H21.
+        subst. inversion H6.
+        pose (EE6 := element_exist _ _ _ H23).
+        inversion EE6. inversion H22.
+        subst. inversion H6.
+        apply eq_sym, length_zero_iff_nil in H25. subst.
+        simpl in H12. rewrite app_nil_r in H12. subst.
+        simpl_concatn_H H16. subst.
+        exact H10.
+Qed.
 
 
-(* Example let_1_comm (e1 e2 : Expression) (t x1 x2 : Value) :
-  |[], e1, []| -e> |inl x1, []| ->
-  | [(inl "X"%string, x1)], e2, []| -e> |inl x2, []| ->
-  |[], ELet ["X"%string] [e1] (ECall "plus"%string [EVar "X"%string ; e2]), []| -e> |inl t, []| ->
-  |[], ELet ["X"%string] [e1] (ECall "plus"%string [e2 ; EVar "X"%string]), []| -e> |inl t, []|.
+Example let_1_comm (e1 e2 : Expression) (t x1 x2 : Value) (id : nat) :
+  |[], id, e1, []| -e> |id, inl x1, []| ->
+  | [(inl "X"%string, x1)], id, e2, []| -e> |id, inl x2, []| ->
+  |[], id, ELet ["X"%string] [e1] (ECall "plus"%string [EVar "X"%string ; e2]), []| -e> | id, inl t, []| ->
+  |[], id, ELet ["X"%string] [e1] (ECall "plus"%string [e2 ; EVar "X"%string]), []| -e> |id, inl t, []|.
 Proof.
-  * intros. inversion H1. subst. inversion H5. inversion H6.
-    pose (EE1 := element_exist Value 0 vals H5). inversion EE1. inversion H2. subst.
-    inversion H5. apply eq_sym, length_zero_iff_nil in H9. subst.
-    pose (EE2 := element_exist _ 0 _ H6). inversion EE2. inversion H7. subst.
-    inversion H6. apply eq_sym, length_zero_iff_nil in H10. subst.
-    eapply eval_let with (vals := [x]) (eff := [[]]) (eff2 := []); auto.
-    - intros. inversion H9. 2: inversion H11.
-      simpl. pose (P1 := H8 0 Nat.lt_0_1). unfold concatn in P1. simpl in P1.
-      pose (WD1 := determinism _ H). apply WD1 in P1 as P2. inversion P2. inversion H10.
-      rewrite app_nil_r in H14. subst. exact P1.
+  * intros. inversion H1. subst.
+    pose (EE1 := element_exist Value 0 vals H5).
+    inversion EE1. inversion H2. subst.
+    inversion H5. apply eq_sym, length_zero_iff_nil in H4. subst.
+    pose (EE2 := element_exist _ 0 _ H6). inversion EE2. inversion H3. subst.
+    inversion H6. apply eq_sym, length_zero_iff_nil in H8. subst.
+    pose (EE3 := element_exist _ 0 _ H7). inversion EE3. inversion H4. subst.
+    inversion H7. apply eq_sym, length_zero_iff_nil in H9. subst.
+    eapply eval_let with (vals := [x]) (eff := [[]]) (eff2 := []) (ids := [id]); auto.
+    - intros. inversion H8. 2: inversion H11.
+      simpl. pose (P1 := H10 0 Nat.lt_0_1). unfold concatn in P1. simpl in P1.
+      pose (WD1 := determinism H). apply WD1 in P1 as P2. inversion P2. inversion H12.
+      rewrite app_nil_r in H13. subst. exact P1.
     - unfold concatn. simpl. apply call_comm with (x1 := x) (x2 := x2).
       + apply eval_var.
-      + pose (P1 := H8 0 Nat.lt_0_1). unfold concatn in P1. simpl in P1.
-        pose (WD1 := determinism _ H). apply WD1 in P1 as P2. inversion P2. inversion H9.
-        subst. assumption.
-      + unfold concatn in H13. simpl in H13. 
-        pose (P1 := H8 0 Nat.lt_0_1). unfold concatn in P1. simpl in P1.
-        pose (WD1 := determinism _ H). apply WD1 in P1 as P2. inversion P2.
-        rewrite app_nil_r in H10. subst. assumption.
-Qed. *)
+      + pose (P1 := H10 0 Nat.lt_0_1). unfold concatn in P1. simpl in P1.
+        pose (WD1 := determinism H). apply WD1 in P1 as P2. inversion P2. inversion H8.
+        inversion H9.
+        subst. exact H0.
+      + pose (P1 := H10 0 Nat.lt_0_1). unfold concatn in P1. simpl in P1.
+        pose (WD1 := determinism H). apply WD1 in P1 as P2. inversion P2.
+        inversion H8. rewrite app_nil_r in H9. destruct H9. subst. assumption.
+Qed.
 
-(* Example call_comm_ex : forall (e e' : Expression) (x1 x2 : Value) (env : Environment) (t t' : Value),
-  |env, e, []| -e> |inl x1, []| ->
-  |env, e', []| -e> |inl x2, []| ->
-  |env, ECall "plus"%string [e ; e'], []| -e> |inl t, []| ->
-  |env, ECall "plus"%string [e' ; e], []| -e> |inl t', []| ->
+Example call_comm_ex : forall (e e' : Expression) (x1 x2 : Value) (env : Environment) (t t' : Value) (id : nat),
+  |env, id, e, []| -e> |id, inl x1, []| ->
+  |env, id, e', []| -e> |id, inl x2, []| ->
+  |env, id, ECall "plus"%string [e ; e'], []| -e> |id, inl t, []| ->
+  |env, id, ECall "plus"%string [e' ; e], []| -e> |id, inl t', []| ->
   t = t'.
 Proof.
-  intros. pose (P := call_comm e e' x1 x2 t env H H0 H1). 
-  pose (DET := determinism _ P _ _ H2). inversion DET. inversion H3. reflexivity.
-Qed. *)
+  intros. pose (P := call_comm e e' x1 x2 t env _ H H0 H1). 
+  pose (DET := determinism P _ _ _ H2). inversion DET. inversion H3. reflexivity.
+Qed.
 
 Example let_2_comm_concrete_alternate_proof (t : Value + Exception) :
   |[], 0,  ELet ["X"%string] [ELit (Integer 5)] (ELet ["Y"%string] [ELit (Integer 6)]

--- a/Core_Erlang_Equivalence_Proofs.v
+++ b/Core_Erlang_Equivalence_Proofs.v
@@ -250,98 +250,121 @@ Proof.
   unfold not. intros. inversion H.
 Qed.
 
-(* Additional hypotheses needed: see details at the admit statements *)
-(* It would be sufficient the X and Y are new (fresh) variables *)
 Example let_2_comm (env: Environment)(e1 e2 : Expression) (t x x0 : Value) 
-    (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B) :
-  |env, e2, eff| -e> |inl x0, eff ++ eff2| -> 
-  |append_vars_to_env [A] [x] env, e2, eff ++ eff1| -e> |inl x0, eff ++ eff1 ++ eff2| ->
-  |env, e1, eff| -e> |inl x, eff ++ eff1| -> 
-  |append_vars_to_env [A] [x0] env, e1, eff ++ eff2| -e> |inl x, eff ++ eff2 ++ eff1| ->
-  |env, ELet [A] [e1] (ELet [B] [e2] 
-        (ECall "plus"%string [EVar A ; EVar B])), eff| -e> |inl t, eff ++ eff1 ++ eff2|
+    (eff eff1 eff2 : SideEffectList) (id0 id1 id2 : nat) (A B : Var) (VarHyp : A <> B) :
+  |env, id0, e2, eff| -e> |id0 + id2, inl x0, eff ++ eff2| -> 
+  |append_vars_to_env [A] [x] env, id0 + id1, e2, eff ++ eff1| -e> | id0 + id1 + id2, inl x0, eff ++ eff1 ++ eff2| ->
+  |env, id0, e1, eff| -e> |id0 + id1, inl x, eff ++ eff1| -> 
+  |append_vars_to_env [A] [x0] env, id0 + id2, e1, eff ++ eff2| -e> |id0 + id2 + id1, inl x, eff ++ eff2 ++ eff1| ->
+  |env, id0, ELet [A] [e1] (ELet [B] [e2] 
+        (ECall "plus"%string [EVar A ; EVar B])), eff| -e> | id0 + id1 + id2, inl t, eff ++ eff1 ++ eff2|
 ->
-|env, ELet [A] [e2] (ELet [B] [e1]
-        (ECall "plus"%string [EVar A ; EVar B])), eff| -e> |inl t, eff ++ eff2 ++ eff1|
+|env, id0, ELet [A] [e2] (ELet [B] [e1]
+        (ECall "plus"%string [EVar A ; EVar B])), eff| -e> | id0 + id2 + id1, inl t, eff ++ eff2 ++ eff1|
 .
 Proof.
-  * intros. inversion H3. subst. simpl in H8. pose (EE1 := element_exist Value 0 vals H7). inversion EE1 as [x']. inversion H4. subst. inversion H7. apply eq_sym, length_zero_iff_nil in H6. subst.
-    pose (EE2 := element_exist _ 0 _ H8). inversion EE2 as [eff1']. inversion H5. subst. inversion H8. apply eq_sym, length_zero_iff_nil in H9. subst.
-    assert (x' = x /\ eff1' = eff1).
+  * intros. inversion H3. subst.
+    pose (EE1 := element_exist Value 0 vals H7).
+    pose (EE2 := element_exist _ 0 _ H8).
+    pose (EE3 := element_exist _ 0 _ H9).
+    inversion EE1 as [x']. inversion EE2 as [eff1']. inversion EE3 as [id1'].
+    inversion H4. inversion H5. inversion H6. subst. 
+    inversion H7. inversion H8. inversion H9.
+    apply eq_sym, length_zero_iff_nil in H11.
+    apply eq_sym, length_zero_iff_nil in H13.
+    apply eq_sym, length_zero_iff_nil in H14. subst.
+    assert (x' = x /\ eff1' = eff1 /\ id1' = (id0 + id1)%nat).
     {
-      pose (P := H10 0 Nat.lt_0_1). unfold concatn in P. simpl in P. rewrite app_nil_r, app_nil_r in P.
-      pose (WD := determinism _ H1 _ _ P). inversion WD. inversion H6. apply app_inv_head in H9.
+      pose (P := H12 0 Nat.lt_0_1). unfold concatn in P. simpl in P. rewrite app_nil_r, app_nil_r in P.
+      pose (WD := determinism H1 _ _ _ P). destruct WD. destruct H11. inversion H10. apply app_inv_head in H11.
       subst. auto.
     }
-    inversion H6. subst.
-    inversion H15. subst. simpl in H13, H16.
-    pose (EE3 := element_exist Value 0 vals H13). inversion EE3 as [x0']. inversion H9.
-    subst. inversion H13. apply eq_sym, length_zero_iff_nil in H12. subst.
-    pose (EE4 := element_exist _ _ _ H16). inversion EE4 as [eff2']. inversion H11. subst.
-    inversion H16. apply eq_sym, length_zero_iff_nil in H17. subst.
-    assert (x0' = x0 /\ eff2' = eff2). 
+    destruct H10. destruct H11. subst.
+    inversion H18. subst.
+    pose (EE1' := element_exist Value 0 vals H14).
+    pose (EE2' := element_exist _ 0 _ H15).
+    pose (EE3' := element_exist _ 0 _ H16).
+    inversion EE1' as [x0']. inversion EE2' as [eff2']. inversion EE3' as [id2'].
+    inversion H10. inversion H11. inversion H13. subst. 
+    inversion H14. inversion H15. inversion H16.
+    apply eq_sym, length_zero_iff_nil in H20.
+    apply eq_sym, length_zero_iff_nil in H22.
+    apply eq_sym, length_zero_iff_nil in H23. subst.
+    assert (x0' = x0 /\ eff2' = eff2 /\ id2' = (id0 + id1 + id2)%nat).
     {
-      pose (P := H18 0 Nat.lt_0_1). unfold concatn in P. simpl in P.
+      pose (P := H21 0 Nat.lt_0_1). unfold concatn in P. simpl in P.
       rewrite app_nil_r, app_nil_r, app_nil_r in P.
-      pose (WD := determinism _ H0 _ _ P). inversion WD. inversion H12.
-      rewrite app_assoc in H17. apply app_inv_head in H17. subst. auto.
+      pose (WD := determinism H0 _ _ _ P). 
+      destruct WD. destruct H20. inversion H19.
+      rewrite app_assoc in H20. apply app_inv_head in H20. subst. auto.
     }
-    inversion H12. subst.
+    destruct H19. destruct H20. subst.
    (*proving starts*)
-   apply eval_let with (vals := [x0]) (eff := [eff2]) (eff2 := eff1); auto.
-   - intros. inversion H17.
+   apply eval_let with (vals := [x0]) (eff := [eff2]) (eff2 := eff1) (ids := [(id0 + id2)%nat]); auto.
+   - intros. inversion H19.
      + unfold concatn. simpl. rewrite app_nil_r, app_nil_r. assumption.
-     + inversion H20.
+     + inversion H22.
    - unfold concatn. simpl. rewrite app_nil_r, app_assoc. auto.
-   - apply eval_let with (vals := [x]) (eff := [eff1]) (eff2 := []); auto.
-     + intros. inversion H17.
+   - apply eval_let with (vals := [x]) (eff := [eff1]) (eff2 := []) (ids := [(id0 + id2 + id1)%nat]); auto.
+     + intros. inversion H19.
        ** subst. unfold concatn. simpl concat. simpl nth.
        rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc. assumption.
-       ** inversion H20.
+       ** inversion H22.
      + unfold concatn. simpl. rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc. auto.
    (* call information *)
-     + inversion H23. subst. simpl in H20, H21.
-       pose (EE5 := element_exist Value 1 vals H20). inversion EE5 as [x'].
-       inversion H17. subst. inversion H20.
-       pose (EE6 := element_exist Value 0 x1 H24). inversion EE6 as [x0'].
-       inversion H19. subst. inversion H24. apply eq_sym, length_zero_iff_nil in H27. subst.
-       pose (EE7 := element_exist _ _ _ H21). inversion EE7 as [eff1'].
-       inversion H26. subst. inversion H21.
-       pose (EE8 := element_exist _ _ _ H28). inversion EE8 as [eff2'].
-       inversion H27. subst. inversion H28. apply eq_sym, length_zero_iff_nil in H31. subst.
-       assert (x' = x /\ x0' = x0 /\ eff1' = [] /\ eff2' = []).
+     + inversion H27. subst.
+       pose (EC1 := element_exist _ 1 _ H22).
+       pose (EC2 := element_exist _ 1 _ H23).
+       pose (EC3 := element_exist _ 1 _ H24).
+       inversion EC1 as [x']. inversion EC2 as [eff1']. inversion EC3 as [id1'].
+       inversion H19. inversion H20. inversion H28. subst. 
+       inversion H22. inversion H23. inversion H24.
+       pose (EC1' := element_exist _ 0 _ H31).
+       pose (EC2' := element_exist _ 0 _ H32).
+       pose (EC3' := element_exist _ 0 _ H33).
+       inversion EC1' as [x0']. inversion EC2' as [eff2']. inversion EC3' as [id2'].
+       inversion H29. inversion H34. inversion H36. subst. 
+       inversion H31. inversion H32. inversion H33.
+       apply eq_sym, length_zero_iff_nil in H38.
+       apply eq_sym, length_zero_iff_nil in H39.
+       apply eq_sym, length_zero_iff_nil in H40. subst.
+       assert (x' = x /\ x0' = x0 /\ eff1' = [] /\ eff2' = [] /\ id1' = (id0 + id1 + id2)%nat /\ id2' = (id0 + id1 + id2)%nat).
        {
          pose (P1 := H25 0 Nat.lt_0_2).
          pose (P2 := H25 1 Nat.lt_1_2).
          inversion P1. inversion P2. subst.
          
-         unfold concatn in H35, H40. simpl in H35, H40.
-         apply app_inv_head in H35. apply app_inv_head, app_inv_head in H40.
-         rewrite app_nil_r in H35. rewrite app_nil_r in H40. subst.
+         simpl_concatn_H H51. simpl_concatn_H H44.
+         rewrite <- app_nil_r in H44 at 1.
+         apply app_inv_head in H44. subst.
+         rewrite <- app_nil_r in H51 at 1.
+         apply app_inv_head in H51. subst.
          
-         rewrite get_value_there in H34.
-           - rewrite get_value_here in H34. inversion H34.
-             rewrite get_value_here in H39. inversion H39. auto.
-           - unfold not. intros. inversion H30. congruence.
+         simpl in H41, H48. subst.
+         
+         rewrite get_value_there in H43.
+           - rewrite get_value_here in H43. inversion H43.
+             rewrite get_value_here in H50. inversion H50. split; auto.
+           - unfold not. intros. inversion H37. congruence.
        }
-       inversion H30. inversion H32. inversion H34. subst.
+       destruct H37. destruct H38. destruct H39. destruct H40. destruct H41. subst.
        
        (* BACK TO CALL PROOF *)
-       apply eval_call with (vals := [x0 ; x]) (eff := [[];[]]); auto.
-       ** intros. inversion H31. 2: inversion H35. 3: inversion H37.
-         -- simpl. assert (get_value (insert_original_value (insert_original_value env (inl A) x0) 
+       apply eval_call with (vals := [x0 ; x]) (eff := [[];[]]) (ids := [(id0 + id2 + id1)%nat; (id0 + id2 + id1)%nat]); auto.
+       ** intros. inversion H37. 2: inversion H39. 3: inversion H41.
+         -- simpl. assert (get_value (insert_value (insert_value env (inl A) x0) 
                                      (inl B) x) (inl B) = inl x). 
                                      { apply get_value_here. }
-            rewrite <- H33. apply eval_var.
-         -- simpl. subst. assert (get_value (insert_original_value (insert_original_value env (inl A) x0) 
+            rewrite <- H38. apply eval_var.
+         -- simpl. subst. assert (get_value (insert_value (insert_value env (inl A) x0) 
                                            (inl B) x) (inl A) = inl x0).
                                            { rewrite get_value_there. apply get_value_here.
                                              unfold not. intros. inversion H33.
                                              congruence. }
-            rewrite <- H33. apply eval_var.
+            rewrite <- H38. apply eval_var.
        ** unfold concatn. simpl concat. rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc.
-          unfold concatn in H29. simpl concat in H29.
-          rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc in H29.
+          unfold concatn in H30. simpl concat in H30.
+          rewrite app_nil_r, app_nil_r, app_nil_r, <- app_assoc in H30.
           apply plus_comm_basic_value with (eff0 := eff ++ eff1 ++ eff2). assumption.
 Qed.
 

--- a/Core_Erlang_Exception_Tests.v
+++ b/Core_Erlang_Exception_Tests.v
@@ -13,9 +13,9 @@ Import Core_Erlang_Syntax.
 Import Core_Erlang_Side_Effects.
 Import Core_Erlang_Semantics.
 
-Definition exception_call : Expression := ECall "plus" [ELiteral (Integer 5); EEmptyTuple].
+Definition exception_call : Expression := ECall "plus" [ELit (Integer 5); EEmptyTuple].
 
-Definition exception_value : Value := VList (VLiteral (Integer 5)) (VEmptyTuple).
+Definition exception_value : Value := VCons (VLit (Integer 5)) (VEmptyTuple).
 
 Example eval_exception_call :
   forall {env : Environment} {eff : SideEffectList}, 
@@ -23,7 +23,7 @@ Example eval_exception_call :
 -e> 
  |inr (badarith exception_value), eff|.
 Proof.
-  intros. eapply eval_call with (vals := [VLiteral (Integer 5); VEmptyTuple]) 
+  intros. eapply eval_call with (vals := [VLit (Integer 5); VEmptyTuple]) 
                                 (eff := [[]; []]); auto.
   * intros. inversion H. 2: inversion H1. 3: inversion H3.
     - simpl. apply eval_tuple with (eff := []); auto.
@@ -44,7 +44,7 @@ Proof.
 Qed.
 
 Example exception_list_hd :
-  |[], EList (exception_call) (ErrorExp), []|
+  |[], ECons (exception_call) (ErrorExp), []|
 -e>
   |inr (badarith exception_value), []|.
 Proof.
@@ -55,7 +55,7 @@ Proof.
 Qed.
 
 Example exception_list_tl : 
-  |[], EList (ErrorExp) (EList (exception_call) (EEmptyList)), []|
+  |[], ECons (ErrorExp) (ECons (exception_call) (ENil)), []|
 -e> 
   |inr (badarith exception_value), []|.
 Proof.
@@ -87,8 +87,8 @@ Qed.
 
 Example try_eval : 
   |[], ETry (EEmptyTuple) 
-            (ELiteral (Atom "ok"%string)) 
-            (ELiteral (Atom "error"%string)) 
+            (ELit (Atom "ok"%string)) 
+            (ELit (Atom "error"%string)) 
             "X"%string "Ex1"%string "Ex2"%string "Ex3"%string, []|
 -e>
   |inl ok, []|
@@ -106,11 +106,11 @@ Qed.
 
 Example try_eval_catch : 
   |[], ETry (exception_call) 
-            (ELiteral (Atom "ok"%string)) 
-            (ELiteral (Atom "error"%string)) 
+            (ELit (Atom "ok"%string)) 
+            (ELit (Atom "error"%string)) 
             "X"%string "Ex1"%string "Ex2"%string "Ex3"%string, []|
 -e> 
-  |inl (VLiteral (Atom "error"%string)), []|
+  |inl (VLit (Atom "error"%string)), []|
 .
 Proof.
   eapply eval_try_catch with (ex := badarith exception_value) (eff2 := []).
@@ -121,7 +121,7 @@ Qed.
 
 Example try_eval_exception : 
   |[], ETry (exception_call) 
-       (ELiteral (Atom "ok"%string)) 
+       (ELit (Atom "ok"%string)) 
        (exception_call) 
         "X"%string "Ex1"%string "Ex2"%string "Ex3"%string, []|
 -e>
@@ -137,7 +137,7 @@ Qed.
 Example try_eval_exception2 : 
   |[], ETry (EEmptyTuple)
             (exception_call)
-            (ELiteral (Atom "error"%string)) 
+            (ELit (Atom "error"%string)) 
             "X"%string "Ex1"%string "Ex2"%string "Ex3"%string, []|
 -e>
   |inr (badarith exception_value), []|
@@ -151,8 +151,8 @@ Qed.
 
 Example eval_case_pat_ex :
   | [], ECase (exception_call) [PVar "X"%string] 
-          [ELiteral (Atom "true")] 
-          [ELiteral (Integer 1)], []|
+          [ELit (Atom "true")] 
+          [ELit (Integer 1)], []|
 -e>
   |inr (badarith exception_value), []|.
 Proof.
@@ -162,13 +162,13 @@ Proof.
 Qed.
 
 Example eval_case_clause_ex :
-  | [(inl "Y"%string, VLiteral (Integer 2))], 
+  | [(inl "Y"%string, VLit (Integer 2))], 
      ECase (EVar "Y"%string)
-          [PLiteral (Integer 1); PVar "Z"%string]
-          [ELiteral (Atom "true"); ELiteral (Atom "false")]
-          [ELiteral (Integer 1); ELiteral (Integer 2)], []|
+          [PLit (Integer 1); PVar "Z"%string]
+          [ELit (Atom "true"); ELit (Atom "false")]
+          [ELit (Integer 1); ELit (Integer 2)], []|
 -e>
-  | inr (if_clause (VLiteral (Integer 2))), []|.
+  | inr (if_clause (VLit (Integer 2))), []|.
 Proof.
   eapply eval_case_clause_ex; auto.
   * reflexivity.
@@ -181,18 +181,18 @@ Qed.
 Example call_eval_body_ex : 
   |[], ECall "plus"%string [], []|
 -e>
-  |inr (undef (VLiteral (Atom "plus"))), []|.
+  |inr (undef (VLit (Atom "plus"))), []|.
 Proof.
   eapply eval_call with (vals := []) (eff := []); auto.
   * intros. inversion H.
 Qed.
 
 Example call_eval_body_ex2 :
-  |[], ECall "plus"%string [ELiteral (Integer 5); EEmptyTuple], []|
+  |[], ECall "plus"%string [ELit (Integer 5); EEmptyTuple], []|
 -e>
   |inr (badarith exception_value), []|.
 Proof.
-  apply eval_call with (vals := [VLiteral (Integer 5); VEmptyTuple]) (eff := [[];[]]); auto.
+  apply eval_call with (vals := [VLit (Integer 5); VEmptyTuple]) (eff := [[];[]]); auto.
   * intros. inversion H. 2: inversion H1. 3: inversion H3.
     - unfold concatn. simpl. apply eval_tuple with (eff := []); auto.
       + intros. inversion H0.
@@ -200,11 +200,11 @@ Proof.
 Qed.
 
 Example call_eval_param_ex :
-  |[], ECall "plus"%string [ELiteral (Integer 5); exception_call], []|
+  |[], ECall "plus"%string [ELit (Integer 5); exception_call], []|
 -e>
   |inr (badarith exception_value), []|.
 Proof.
-  eapply eval_call_ex with (i := 1) (vals := [VLiteral (Integer 5)]) (eff := [[]]).
+  eapply eval_call_ex with (i := 1) (vals := [VLit (Integer 5)]) (eff := [[]]).
   * simpl. auto.
   * simpl. auto.
   * simpl. auto.
@@ -216,11 +216,11 @@ Proof.
 Qed.
 
 Example let_eval_exception_params :
-  |[], ELet ["X"%string; "Y"%string] [ELiteral (Integer 5); exception_call] (EEmptyTuple), []|
+  |[], ELet ["X"%string; "Y"%string] [ELit (Integer 5); exception_call] (EEmptyTuple), []|
 -e>
   |inr (badarith exception_value), []|.
 Proof.
-  eapply eval_let_ex_param with (i := 1) (vals := [VLiteral (Integer 5)]) (eff := [[]]).
+  eapply eval_let_ex_param with (i := 1) (vals := [VLit (Integer 5)]) (eff := [[]]).
   * reflexivity.
   * simpl. auto.
   * reflexivity.
@@ -231,12 +231,12 @@ Proof.
 Qed.
 
 Example let_eval_exception_body :
-  |[], ELet ["X"%string; "Y"%string] [ELiteral (Integer 5); ELiteral (Integer 5)] 
+  |[], ELet ["X"%string; "Y"%string] [ELit (Integer 5); ELit (Integer 5)] 
          (exception_call), []|
 -e>
   |inr (badarith exception_value), []|.
 Proof.
-  eapply eval_let with (vals := [VLiteral (Integer 5); VLiteral (Integer 5)]) 
+  eapply eval_let with (vals := [VLit (Integer 5); VLit (Integer 5)]) 
                        (eff := [[];[]]); auto.
   * intros. inversion H.
     - simpl. apply eval_lit.
@@ -246,12 +246,12 @@ Proof.
 Qed.
 
 Example apply_eval_exception_closure :
-  |[], EApply (ELiteral (Integer 4)) [ELiteral (Integer 5); ELiteral (Integer 5)], []|
+  |[], EApp (ELit (Integer 4)) [ELit (Integer 5); ELit (Integer 5)], []|
 -e>
-  |inr (badfun (VLiteral (Integer 4))), []|.
+  |inr (badfun (VLit (Integer 4))), []|.
 Proof.
-  eapply eval_apply_ex_closure with (v := VLiteral (Integer 4)) 
-                                    (vals := [VLiteral (Integer 5); VLiteral (Integer 5)])
+  eapply eval_apply_ex_closure with (v := VLit (Integer 4)) 
+                                    (vals := [VLit (Integer 5); VLit (Integer 5)])
                                     (eff := [[];[]]); auto.
   * apply eval_lit.
   * intros. inversion H. 2: inversion H1. 3: inversion H3.
@@ -262,7 +262,7 @@ Proof.
 Qed.
 
 Example apply_eval_exception_closure2 :
-  |[], EApply (exception_call) [ELiteral (Integer 5); ELiteral (Integer 5)], []|
+  |[], EApp (exception_call) [ELit (Integer 5); ELit (Integer 5)], []|
 -e>
   |inr (badarith exception_value), []|.
 Proof.
@@ -272,13 +272,13 @@ Proof.
 Qed.
 
 Example apply_eval_exception_param :
-  |[(inl "X"%string, VClosure [] [] 0 [] (ELiteral (Integer 4)))], 
-    EApply (EVar "X"%string) [exception_call], []|
+  |[(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 4)))], 
+    EApp (EVar "X"%string) [exception_call], []|
 -e>
   |inr (badarith exception_value), []|.
 Proof.
   eapply eval_apply_ex_params with (i := 0) (vals := [])
-                                   (v := VClosure [] [] 0 [] (ELiteral (Integer 4)))
+                                   (v := VClos [] [] 0 [] (ELit (Integer 4)))
                                    (eff := []); auto.
   * apply eval_var.
   * intros. inversion H.
@@ -287,13 +287,13 @@ Proof.
 Qed.
 
 Example apply_eval_exception_param_count :
-  |[(inl "X"%string, VClosure [] [] 0 [] (ELiteral (Integer 4)))],
-   EApply (EVar "X"%string) [ELiteral (Integer 2)], []|
+  |[(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 4)))],
+   EApp (EVar "X"%string) [ELit (Integer 2)], []|
 -e>
-  |inr (badarity (VClosure [] [] 0 [] (ELiteral (Integer 4)))), []|.
+  |inr (badarity (VClos [] [] 0 [] (ELit (Integer 4)))), []|.
 Proof.
-  eapply eval_apply_ex_param_count with (vals := [VLiteral (Integer 2)]) (n := 0)
-                                        (var_list := []) (body := ELiteral (Integer 4)) 
+  eapply eval_apply_ex_param_count with (vals := [VLit (Integer 2)]) (n := 0)
+                                        (var_list := []) (body := ELit (Integer 4)) 
                                         (ref := []) (ext := []) (eff := [[]]); auto.
   * apply eval_var.
   * intros. inversion H. 2: inversion H1. apply eval_lit.
@@ -302,8 +302,8 @@ Proof.
 Qed.
 
 Example apply_eval_exception_body :
-  |[(inl "X"%string, VClosure [] [] 0 [] (exception_call))],
-   EApply (EVar "X"%string) [], []|
+  |[(inl "X"%string, VClos [] [] 0 [] (exception_call))],
+   EApp (EVar "X"%string) [], []|
 -e> 
   |inr (badarith exception_value), []|.
 Proof.
@@ -316,7 +316,7 @@ Proof.
 Qed.
 
 Example letrec_exception : 
-  |[], ELetrec [("fun1"%string, 0)] [[]] [(ErrorExp)] (exception_call), []|
+  |[], ELetRec [("fun1"%string, 0)] [[]] [(ErrorExp)] (exception_call), []|
 -e>
   |inr (badarith exception_value), []|.
 Proof.

--- a/Core_Erlang_Helpers.v
+++ b/Core_Erlang_Helpers.v
@@ -1,4 +1,5 @@
 Load Core_Erlang_Equalities.
+
 From Coq Require Lists.ListSet.
 
 

--- a/Core_Erlang_Helpers.v
+++ b/Core_Erlang_Helpers.v
@@ -26,7 +26,8 @@ Proof.
   * auto.
 Qed.
 
-Lemma list_length_helper : forall l l' : list A, length l = length l' -> length l =? length l' = true.
+Lemma list_length_helper : forall l l' :
+  list A, length l = length l' -> length l =? length l' = true.
 Proof.
   intros. induction l.
   * inversion H. auto.
@@ -112,7 +113,8 @@ match p with
  | PEmptyList => []
  | PVar v => [v]
  | PLiteral l => []
- | PList hd tl => set_union string_dec (variable_occurances_set hd) (variable_occurances_set tl)
+ | PList hd tl => set_union string_dec (variable_occurances_set hd)
+                                       (variable_occurances_set tl)
  | PTuple l => (fix variable_occurances_set_list t :=
                     match t with
                     | [] => []
@@ -173,8 +175,10 @@ Compute match_value_bind_pattern (VTuple [VLiteral (Atom "a"%string) ; VLiteral 
                                           VLiteral (Integer 2)]) 
                                  (PTuple [PVar "X"%string ; PVar "Y"%string]).
 
-(** From the list of patterns, guards and bodies, this function decides if a value matches the ith clause *)
-Fixpoint match_clause (e : Value) (ps : list Pattern) (gs : list Expression) (bs : list Expression) (i : nat)
+(** From the list of patterns, guards and bodies, this function 
+  decides if a value matches the ith clause *)
+Fixpoint match_clause (e : Value) (ps : list Pattern) (gs : list Expression) 
+   (bs : list Expression) (i : nat)
    : option (Expression * Expression * list (Var * Value)) :=
 match ps, gs, bs, i with
 | [], [], [], _ => None
@@ -187,7 +191,8 @@ end
 .
 
 (** Clause checker *)
-Fixpoint correct_clauses (ps : list Pattern) (gs : list Expression) (bs : list Expression) : bool :=
+Fixpoint correct_clauses (ps : list Pattern) (gs : list Expression)
+        (bs : list Expression) : bool :=
 match ps, gs, bs with
 | [], [], [] => true
 | p::ps, g::gs, exp::es => 
@@ -225,7 +230,8 @@ Compute variables (ELet ["X"%string] [EVar "Z"%string] (
                        (ECall "plus"%string [EVar "X"%string ; EVar "Y"%string]))).
 
 (** Building value maps based on the value ordering value_less *)
-Fixpoint map_insert (k v : Value) (kl : list Value) (vl : list Value) : (list Value) * (list Value) :=
+Fixpoint map_insert (k v : Value) (kl : list Value) (vl : list Value) 
+  : (list Value) * (list Value) :=
 match kl, vl with
 | [], [] => ([k], [v])
 | k'::ks, v'::vs => if value_less k k' 
@@ -233,7 +239,8 @@ match kl, vl with
                     else
                        if bValue_eq_dec k k' 
                        then (k'::ks, v'::vs) 
-                       else (k'::(fst (map_insert k v ks vs)), v'::(snd (map_insert k v ks vs)))
+                       else (k'::(fst (map_insert k v ks vs)), 
+                             v'::(snd (map_insert k v ks vs)))
 | _, _ => ([], [])
 end.
 
@@ -247,5 +254,13 @@ end.
 
 Compute make_value_map [VLiteral (Integer 5); VLiteral (Integer 5); VLiteral (Atom ""%string)] 
                        [VLiteral (Integer 5); VLiteral (Integer 7); VLiteral (Atom ""%string)].
+
+Definition nth_id (ids : list nat) (def i : nat) :=
+match i with
+| 0 => def
+| S i' => nth i' ids 0
+end.
+
+Compute nth_id [4; 7; 8] 3 2 = 7.
 
 End Core_Erlang_Helpers.

--- a/Core_Erlang_Proofs.v
+++ b/Core_Erlang_Proofs.v
@@ -209,267 +209,231 @@ Proof.
 
   (* LIST HEAD EXCEPTION *)
   * intros. inversion H0; subst.
-    - pose (IH := IHIND (inl tlv) (eff1 ++ eff4) H5). inversion IH. inversion H.
+    - pose (IH := IHIND (inl tlv) (eff1 ++ eff4) _ H6). inversion IH. congruence.
     - apply IHIND. assumption.
-    - pose (IH := IHIND (inl vtl) (eff1 ++ eff4) H5). inversion IH. inversion H.
+    - pose (IH := IHIND (inl vtl) (eff1 ++ eff4) _ H6). inversion IH. congruence.
 
   (* LIST TAIL EXCEPTION *)
   * intros. inversion H0; subst.
-    - pose (IH1 := IHIND1 (inl tlv) (eff1 ++ eff5) H5). inversion IH1.
-      apply app_inv_head in H1. inversion H. subst.
-      pose (IH2 := IHIND2 (inl hdv) (eff1 ++ eff5 ++ eff6) H9). inversion IH2. inversion H1.
-    - pose (IH1 := IHIND1 (inr ex0) (eff1 ++ eff5) H8). inversion IH1. inversion H.
-    - pose (IH1 := IHIND1 (inl vtl0) (eff1 ++ eff5) H5). inversion IH1.
+    - pose (IH1 := IHIND1 (inl tlv) (eff1 ++ eff5) _ H6). inversion IH1.
+      destruct H1. apply app_inv_head in H1. inversion H. subst.
+      pose (IH2 := IHIND2 (inl hdv) (eff1 ++ eff5 ++ eff6) _ H11). inversion IH2. congruence.
+    - pose (IH1 := IHIND1 (inr ex0) (eff1 ++ eff5) _ H10). inversion IH1. congruence.
+    - pose (IH1 := IHIND1 (inl vtl0) (eff1 ++ eff5) _ H6). destruct IH1. destruct H1.
       apply app_inv_head in H1. inversion H. subst.
       apply IHIND2. assumption.
 
   (* TUPLE EXCEPTION *)
-  * intros. inversion H5.
+  * intros. inversion H6.
     - subst.
-      pose (P1 := H9 (length vals) H0).
-      pose (EU := eff_until_i_rev exps vals vals0 eff5 H3 H9 H0 H1 H7 H8).
-      rewrite EU in P1.
-      pose (IH2 := IHIND (inl (nth (Datatypes.length vals) vals0 ErrorValue))
-                  (concatn eff1 eff5 (S (Datatypes.length vals))) P1).
-      destruct IH2. inversion H.
-    - rewrite H11 in H13. 
+      pose (EU := @eff_until_i_rev env eff eff5 exps vals vals0 eff1 ids ids0 id _ _ _ H4 H11 IHIND H0 H1 H8 H9 H10 H2). inversion EU.
+    - rewrite H13 in H16.
       pose (EE := exception_equality vals vals0 ex eff1 eff eff6 i
-             i0 eff3 ex0 eff4 H3 H13 IHIND H10 H H0 H1 H7 H8 H9).
-      inversion EE. inversion H18. subst.
-      pose (IHIND (inr ex0) (concatn eff1 eff6 (Datatypes.length vals0) ++ eff4) H13). assumption.
+             i0 eff3 ex0 eff4 _ _ _ _ _ H4 H16 IHIND H12 H H0 H1 H8 H9 H10 H2 H11).
+      destruct EE. destruct H22. inversion H23. subst.
+      apply (IHIND (inr ex0) (concatn eff1 eff6 (Datatypes.length vals0) ++ eff4) _ H16).
   
   (* CORECT TRY *)
   * intros. inversion H0.
-    - subst. apply IHIND2. pose (IH1 := IHIND1 (inl val'0) (eff1 ++ eff5) H12).
-      inversion IH1. inversion H. apply app_inv_head in H1. subst. assumption.
-    - subst. pose (IH1 := IHIND1 (inr ex) _ H12). inversion IH1. inversion H.
+    - subst. apply IHIND2. pose (IH1 := IHIND1 (inl val'0) (eff1 ++ eff5) _ H14).
+      destruct IH1. inversion H. destruct H1. apply app_inv_head in H1. subst. assumption.
+    - subst. pose (IH1 := IHIND1 (inr ex) _ _ H14). inversion IH1. congruence.
   
   (* CORRECT CATCH *)
   * intros. inversion H0.
-    - subst. pose (IH1 := IHIND1 (inl val') _ H12). inversion IH1. inversion H.
-    - subst. apply IHIND2. pose (IH1 := IHIND1 (inr ex0) _ H12). inversion IH1.
-      inversion H. apply app_inv_head in H1. subst. assumption.
+    - subst. pose (IH1 := IHIND1 (inl val') _ _ H14). destruct IH1. congruence.
+    - subst. apply IHIND2. pose (IH1 := IHIND1 (inr ex0) _ _ H14). destruct IH1.
+      inversion H. destruct H1. apply app_inv_head in H1. subst. assumption.
 
   (* CASE EXCEPTIONS *)
   (** binding expression exception *)
   * intros. inversion H2.
-    - subst. apply IHIND in H9. inversion H9. inversion H1.
-    - subst. apply IHIND in H14. assumption.
-    - subst. apply IHIND in H14. inversion H14. inversion H1.
+    - subst. apply IHIND in H9. inversion H9. congruence.
+    - subst. apply IHIND in H16. assumption.
+    - subst. apply IHIND in H16. inversion H16. congruence.
 
   (** no matching clause *)
   * intros. inversion H4.
-    - subst. apply IHIND in H11. inversion H11. apply app_inv_head in H5. inversion H1.
+    - subst. apply IHIND in H11. destruct H11. destruct H5. apply app_inv_head in H5. inversion H1.
       subst. pose (EE := H3 i H12 guard exp bindings H13).
-      pose (IHE := EE _ _ H20). inversion IHE. inversion H5.
-    - subst. apply IHIND in H16. inversion H16. inversion H1.
-    - subst. apply IHIND in H16. inversion H16. apply app_inv_head in H5. inversion H1.
-      subst. auto.
+      pose (IHE := EE _ _ _ H22). inversion IHE. inversion H5.
+    - subst. apply IHIND in H18. inversion H18. congruence.
+    - subst. apply IHIND in H18. inversion H18. destruct H5. apply app_inv_head in H5. inversion H1. subst. auto.
+
   (* CALL EXCEPTION *)
-  * intros. inversion H5.
+  * intros. inversion H6.
     - subst.
-      pose (P1 := H11 (length vals) H0).
-      pose (EU := eff_until_i_rev params vals vals0 eff5 H3 H11 H0 H1 H8 H9).
-      rewrite EU in P1.
-      pose (IH2 := IHIND (inl (nth (Datatypes.length vals) vals0 ErrorValue))
-                     (concatn eff1 eff5 (S (Datatypes.length vals))) P1).
-      destruct IH2. inversion H.
-    - rewrite H13 in H17. apply IHIND.
-      pose (EEQ := exception_equality vals vals0 ex
-          eff1 eff eff6 i i0 eff3 ex0 eff4 H3 H17 IHIND H11 H H0 H1 H8 H9 H10).
-      inversion EEQ. inversion H19. subst. assumption.
+      pose (EU := @eff_until_i_rev env eff eff5 params vals vals0 eff1 ids ids0 id _ _ _ H4 H12 IHIND H0 H1 H9 H10 H11 H2). inversion EU.
+    - rewrite H16 in H21. apply IHIND.
+      pose (EEQ := exception_equality vals vals0 ex eff1 eff eff6 i
+             i0 eff3 ex0 eff4 _ _ _ _ _ H4 H21 IHIND H13 H H0 H1 H9 H10 H11 H2 H12).
+      destruct EEQ. destruct H23. destruct H24. subst. assumption.
 
   (* APPLY EXCEPTION *)
   (* name evaluates to an exception *)
   * intros. inversion H0.
-    - subst. pose (IH := IHIND _ _ H4). inversion IH. inversion H.
+    - subst. pose (IH := IHIND _ _ _ H4). inversion IH. congruence.
     - subst. apply IHIND. assumption.
-    - subst. pose (IH := IHIND _ _ H6). inversion IH. inversion H.
-    - subst. pose (IH := IHIND _ _ H5). inversion IH. inversion H.
-    - subst. pose (IH := IHIND _ _ H5). inversion IH. inversion H.
+    - subst. pose (IH := IHIND _ _ _ H7). inversion IH. congruence.
+    - subst. pose (IH := IHIND _ _ _ H6). inversion IH. congruence.
+    - subst. pose (IH := IHIND _ _ _ H6). inversion IH. congruence.
 
   (* parameter exception *)
-  * intros. inversion H5.
-    - subst. apply IHIND1 in H9. inversion H9. inversion H. apply app_inv_head in H4. subst.
-      pose (P1 := eff_until_i_rev params vals vals0 eff8 H3 H12 H0 H1 H8 H11).
-      pose (P2 := H12 (length vals) H0 ).
-      pose (P3 := IHIND2 (inl (nth (Datatypes.length vals) vals0 ErrorValue))
-                     (concatn (eff1 ++ eff5) eff8 (S (Datatypes.length vals)))).
-      rewrite <- P1 in P3.
-      pose (P4 := P3 P2).
-      inversion P4. inversion H4.
-    - subst. apply IHIND1 in H13. inversion H13. inversion H.
-    - apply IHIND1 in H11. inversion H11. inversion H19. apply app_inv_head in H20.
-      rewrite H20, H22 in *.
-      rewrite H14 in *.
-      assert (| env, nth i0 params ErrorExp, concatn (eff1 ++ eff5) eff8 i0 |
-      -e> | inr ex0, concatn (eff1 ++ eff5) eff8 i0 ++ eff6 |). { assumption. }
+  * intros. inversion H6.
+    - subst. apply IHIND1 in H10. destruct H10. destruct H5. inversion H.
+      apply app_inv_head in H5. subst.
+      pose (P1 := @eff_until_i_rev env eff _ params vals vals0 (eff1 ++ eff5) ids ids0 id'0 _ _ _ H4 H14 IHIND2 H0 H1 H9 H12 H13 H2). inversion P1.
+    - subst. apply IHIND1 in H16. inversion H16. congruence.
+    - apply IHIND1 in H13. destruct H13. destruct H23. apply app_inv_head in H23. inversion H13.
+      rewrite H26, H23, H24 in *.
+      rewrite H17 in *.
+      assert (| env, last ids0 id'0, nth i0 params ErrorExp, concatn (eff1 ++ eff5) eff8 i0 | -e> | id''0,
+      inr ex0, concatn (eff1 ++ eff5) eff8 i0 ++ eff6 |). { assumption. }
       pose (EE := exception_equality vals vals0 ex (eff1 ++ eff5) eff eff8 i i0 eff4 ex0
-                 eff6 H3 H18 IHIND2 H12 (eq_sym H) H0 H1 (eq_sym H8) H9 H10).
-      inversion EE. inversion H24. subst.
-      apply IHIND2 in H21.
+                 eff6 _ _ _ _ _ H4 H22 IHIND2 H14 (eq_sym H) H0 H1 (eq_sym H9) H10 H11 H2 H12).
+      destruct EE. destruct H28. destruct H29. subst.
+      apply IHIND2 in H25.
       assumption.
-    - subst. apply IHIND1 in H10. inversion H10. inversion H. apply app_inv_head in H4. subst.
-      pose (P1 := eff_until_i_rev params vals vals0 eff7 H3 H11 H0 H1 H8 H9).
-      pose (P2 := H11 (length vals) H0 ).
-      pose (P3 := IHIND2 (inl (nth (Datatypes.length vals) vals0 ErrorValue))
-                     (concatn (eff1 ++ eff5) eff7 (S (Datatypes.length vals)))).
-      rewrite <- P1 in P3.
-      pose (P4 := P3 P2).
-      inversion P4. inversion H4.
-    - subst. apply IHIND1 in H10. inversion H10. inversion H. apply app_inv_head in H4. subst.
-      pose (P1 := eff_until_i_rev params vals vals0 eff7 H3 H11 H0 H1 H8 H9).
-      pose (P2 := H11 (length vals) H0 ).
-      pose (P3 := IHIND2 (inl (nth (Datatypes.length vals) vals0 ErrorValue))
-                     (concatn (eff1 ++ eff5) eff7 (S (Datatypes.length vals)))).
-      rewrite <- P1 in P3.
-      pose (P4 := P3 P2).
-      inversion P4. inversion H4.
+    - subst. apply IHIND1 in H12. destruct H12. inversion H. destruct H5.
+      apply app_inv_head in H5. subst.
+      pose (P1 := @eff_until_i_rev env eff _ params vals vals0 (eff1 ++ eff5) ids ids0 id'0 _ _ _ H4 H13 IHIND2 H0 H1 H9 H10 H11 H2). inversion P1.
+    - subst. apply IHIND1 in H12. destruct H12. inversion H. destruct H5.
+      apply app_inv_head in H5. subst.
+      pose (P1 := @eff_until_i_rev env eff _ params vals vals0 (eff1 ++ eff5) ids ids0 id'0 _ _ _ H4 H13 IHIND2 H0 H1 H9 H10 H11 H2). inversion P1.
 
   (* name evaluate to a non-closure value *)
-  * intros. inversion H5.
-    - apply IHIND in H9. inversion H9. inversion H19.
-      pose (P := H3 ref ext var_list body _ H22). inversion P.
-    - subst. apply IHIND in H13. inversion H13. inversion H4.
-    - subst. apply IHIND in H11. inversion H11. inversion H4. apply app_inv_head in H6. subst.
-      pose (P1 := eff_until_i vals vals0 (eff1 ++ eff4) eff eff7 H H0 H10 H9 H2 H12).
-      pose (P2 := H2 (length vals0) H9 (inr ex) (concatn (eff1 ++ eff4) eff7 
-                     (Datatypes.length vals0) ++ eff5)).
-      rewrite <- P1 in P2.
-      pose (P3 := P2 H18). inversion P3. inversion H6.
-    - subst. apply IHIND in H10. inversion H10. inversion H4. apply app_inv_head in H6. subst.
-      pose (LEQ := @list_equality env params (eff1 ++ eff4) vals vals0 eff eff6 H1 H2 H11 H8 H9 H H0).
-      inversion LEQ. subst. auto.
-    - subst. apply IHIND in H10. inversion H10. inversion H4. apply app_inv_head in H6. subst.
-      pose (P := H3 ref ext var_list body). congruence.
+  * intros. inversion H7.
+    - apply IHIND in H11. destruct H11. destruct H24. inversion H11.
+      pose (P := H4 ref ext var_list body _ H27). inversion P.
+    - subst. apply IHIND in H17. inversion H17. congruence.
+    - subst. apply IHIND in H14. destruct H14. inversion H5. destruct H6. apply app_inv_head in H6. subst.
+      pose (P1 := @eff_until_i env eff eff7 params vals vals0 (eff1 ++ eff4) ids ids0 id'0 id''0 ex eff5 H H0 H12 H11 H1 H13 H3 H15 H23). inversion P1.
+    - subst. apply IHIND in H13. destruct H13. inversion H5. destruct H6. apply app_inv_head in H6. subst.
+      pose (LEQ := @list_equality env params (eff1 ++ eff4) vals vals0 eff eff6 _ _ _ H2 H3 H14 H10 H11 H H0 H1 H12).
+      destruct LEQ. destruct H8. subst. auto.
+    - subst. apply IHIND in H13. destruct H13. inversion H5. destruct H6. apply app_inv_head in H6. subst.
+      pose (P := H4 ref ext var_list body). congruence.
 
   (* paramlist is too short/long *)
-  * intros. inversion H5.
+  * intros. inversion H7.
     - subst. 
-      pose (P1 := IHIND _ _ H9). inversion P1. apply app_inv_head in H6. inversion H4. subst.
-      pose (EL:= list_equality vals vals0 eff eff7 H1 H2 H12 H8 H11 H H0). inversion EL. subst. intuition. 
-    - subst. pose (IH := IHIND _ _ H13). inversion IH. inversion H4.
+      pose (P1 := IHIND _ _ _ H11). destruct P1. destruct H6. apply app_inv_head in H6. inversion H5. subst.
+      pose (EL:= list_equality vals vals0 eff eff7 _ _ _ H2 H3 H15 H10 H13 H H0 H1 H14). destruct EL. destruct H8. subst. intuition. 
+    - subst. pose (IH := IHIND _ _ _ H17). inversion IH. congruence.
     - subst.
-      pose (P1 := IHIND _ _ H11). inversion P1. apply app_inv_head in H6. inversion H4. subst.
-      pose (P2 := eff_until_i vals vals0 (eff1 ++ eff4) eff eff7 H H0 H10 H9 H2 H12).
-      rewrite P2 in H18.
-      pose (P3 := H2 (length vals0) H9 _ _ H18). inversion P3. inversion H6.
+      pose (P1 := IHIND _ _ _ H14). destruct P1. destruct H6. apply app_inv_head in H6. inversion H5. subst.
+      pose (P2 := @eff_until_i env eff eff7 params vals vals0 (eff1 ++ eff4) ids ids0 id'0 id''0 ex eff5 H H0 H12 H11 H1 H13 H3 H15 H23). inversion P2.
     - subst.
-      pose (P1 := IHIND _ _ H10). inversion P1. inversion H4. subst.
-      pose (P2 := H13 ref ext var_list body).
+      pose (P1 := IHIND _ _ _ H13). destruct P1. destruct H6. inversion H5. subst.
+      pose (P2 := H15 ref ext var_list body).
       congruence.
     - subst.
-      pose (P1 := IHIND _ _ H10). inversion P1. apply app_inv_head in H6. inversion H4. subst.
-      pose (EL:= @list_equality env params (eff1 ++ eff4) vals vals0 eff eff6 H1 H2 H11 H8 H9 H H0).
-      inversion EL. subst. split; reflexivity.
+      pose (P1 := IHIND _ _ _ H13). destruct P1. destruct H6. apply app_inv_head in H6. inversion H5. subst.
+      pose (EL:= @list_equality env params (eff1 ++ eff4) vals vals0 eff eff6 _ _ _ H2 H3 H14 H10 H11 H H0 H1 H12).
+      destruct EL. destruct H8. subst. auto.
 
   
   (* LET EXCEPTION *)
-  * intros. inversion H5.
+  * intros. inversion H6.
     - subst.
-      pose (P1 := H12 (length vals) H0).
-      pose (EU := eff_until_i_rev exps vals vals0 eff0 H3 H12 H0 H1 H9 H10).
-      rewrite EU in P1.
-      pose (IH2 := IHIND (inl (nth (Datatypes.length vals) vals0 ErrorValue))
-             (concatn eff1 eff0 (S (Datatypes.length vals))) P1). destruct IH2. inversion H.
-    - rewrite H17 in H18. apply IHIND. 
+      pose (EU := @eff_until_i_rev env eff _ exps vals vals0 eff1 ids ids0 _ _ _ _ H4 H15 IHIND H0 H1 H10 H11 H12 H2). inversion EU.
+    - rewrite H21 in H22. apply IHIND. 
       pose (EEQ := exception_equality vals vals0 ex eff1 eff eff6
-            i i0 eff3 ex0 eff4 H3 H18 IHIND H13 H H0 H1 H9 H10 H11).
-      inversion EEQ. inversion H20. subst. assumption.
+            i i0 eff3 ex0 eff4 _ _ _ _ _ H4 H22 IHIND H16 H H0 H1 H10 H11 H12 H2 H13).
+      destruct EEQ. destruct H24. destruct H25. subst. assumption.
 
   (* MAP KEY EXCEPTION *)
-  * intros. inversion H9.
-    - rewrite H8 in IHIND.
-      assert ((forall (v2 : Value + Exception) (eff'' : SideEffectList),
-               | env, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | v2, eff'' |
+  * intros. inversion H10.
+    - rewrite H9 in IHIND.
+      assert ((forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+               | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> |id'', v2, eff'' |
                ->
-                inr ex = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'')
+                inr ex = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'' /\ id' = id'')
                \/
-            (forall (v2 : Value + Exception) (eff'' : SideEffectList),
-             | env, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | v2, eff'' | ->
-             inl ErrorValue = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'')
+            (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+             | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | id'', v2, eff'' | ->
+             inl ErrorValue = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'' /\ id' = id'')
              /\
-            (forall (v2 : Value + Exception) (eff'' : SideEffectList),
-             | env, nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2 | -e> | v2, eff'' | ->
-             inr ex = v2 /\ [] = eff'')). { auto. }
+            (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id''' : nat),
+             | env, id', nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2 | -e> | id''', v2, eff'' | ->
+             inr ex = v2 /\ [] = eff'' /\ id'' = id''')). { auto. }
      pose (MEQ := map_lists_equal_until_i_key_or_val kvals vvals kvals0 vvals0 i eff1 eff eff5 eff2
-                        [] ErrorValue ex H5 H7 H24 H12 H0 H1 (Nat.lt_le_incl _ _ H2) H3 H17 H19 H13
-                        H14 (eq_sym H15)).
-     inversion MEQ. inversion H26. inversion H28. subst.
+                        [] ErrorValue ex _ _ _ _ _ H6 H8 H29 H H0 H1 (Nat.lt_le_incl _ _ H2) H3 H4 H19 H20 H14 H15 (eq_sym H16) (eq_sym H17)).
+     destruct MEQ. destruct H31. inversion H32. destruct H34. subst.
      assert (Datatypes.length vvals0 < Datatypes.length vl). { omega. }
-     pose (ERR := H17 (length vvals0) H0).
-     pose (DIS := IHIND _ _ ERR). inversion DIS. inversion H8.
-    - rewrite H8 in IHIND. rewrite H20 in H24.
-      assert (| env, nth i0 kl ErrorExp, concatn eff1 eff6 (2 * i0) | 
-              -e> | inr ex0, concatn eff1 eff6 (2 * i0) ++ eff4 | \/
-              | env, nth i0 kl ErrorExp, concatn eff1 eff6 (2 * i0) | -e> | inl ErrorValue,
+     pose (ERR := H19 (length vvals0) H0).
+     rewrite last_nth_equal, H4, mult_comm in IHIND.
+     pose (DIS := IHIND _ _ _ ERR). inversion DIS. congruence.
+    - rewrite H9 in IHIND. rewrite H23 in H28.
+      assert (| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff6 (2 * i0) | 
+              -e> | id'', inr ex0, concatn eff1 eff6 (2 * i0) ++ eff4 | \/
+              | env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff6 (2 * i0) | -e> | id'', inl ErrorValue,
                concatn eff1 eff6 (2 * i0) ++ eff4 | /\
-               | env, nth i0 vl ErrorExp, concatn eff1 eff6 (2 * i0) ++ eff4 | -e> | inr ex0,
-               concatn eff1 eff6 (2 * i0) ++ eff4 ++ [] |). { left. auto. }
+               | env, id'', nth i0 vl ErrorExp, concatn eff1 eff6 (2 * i0) ++ eff4 | -e> | id'', inr ex0,
+               concatn eff1 eff6 (2 * i0) ++ eff4 ++ [] |). { left. exact H28. }
       pose (MEQ := map_lists_equal_until_i_key kvals vvals kvals0 vvals0 i i0 eff1 eff eff6 ex0 eff4
-                   eff2 [] ErrorValue ex H5 H7 IHIND H12 H0 H1 (Nat.lt_le_incl _ _ H2) H3 H17 H18 H13 H14
-                   (Nat.lt_le_incl _ _ H15) H16 H25).
-      inversion MEQ. inversion H27. inversion H29. subst.
-      pose (IH1 := IHIND _ _ H24). inversion IH1. inversion H0.
-      apply app_inv_head in H8. subst. auto.
-    - rewrite H8 in IHIND. rewrite H21 in H25.
-      assert (| env, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) |
-              -e> | inr ex0, concatn eff1 eff7 (2 * i0) ++ eff4 | \/
-               | env, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | inl val,
+                   eff2 [] ErrorValue ex _ _ _ _ _ _ H6 H8 IHIND H H0 H1 (Nat.lt_le_incl _ _ H2) H3 H4 H19 H20 H14 H15 (Nat.lt_le_incl _ _ H16) H17 H18 H29).
+      destruct MEQ. destruct H31. destruct H32. destruct H33. subst.
+      pose (IH1 := IHIND _ _ _ H28). inversion IH1. inversion H0.
+      destruct H9. apply app_inv_head in H9. subst. auto.
+    - rewrite H9 in IHIND. rewrite H24 in H29.
+      assert (| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) |
+              -e> | id'0, inr ex0, concatn eff1 eff7 (2 * i0) ++ eff4 | \/
+               | env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id'0, inl val,
                concatn eff1 eff7 (2 * i0) ++ eff4 | /\
-               | env, nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff4 | -e> | inr ex0,
+               | env, id'0, nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff4 | -e> | id'', inr ex0,
                concatn eff1 eff7 (2 * i0) ++ eff4 ++ eff5 |). { auto. }
       pose (MEQ := map_lists_equal_until_i_key kvals vvals kvals0 vvals0 i i0 eff1 eff eff7 ex0 eff4
-                   eff2 eff5 val ex H5 H7 IHIND H12 H0 H1 (Nat.lt_le_incl _ _ H2)
-                   H3 H17 H18 H13 H14 (Nat.lt_le_incl _ _ H15) H16 H26).
-      inversion MEQ. inversion H28. inversion H30. subst.
-      pose (IH1 := IHIND _ _ H19). inversion IH1. inversion H0.
+                   eff2 eff5 val ex _ _ _ _ _ _ H6 H8 IHIND H H0 H1 (Nat.lt_le_incl _ _ H2) H3 H4 H19 H20 H14 H15 (Nat.lt_le_incl _ _ H16) H17 H18 H30).
+      destruct MEQ. destruct H32. destruct H33. destruct H34. subst.
+      pose (IH1 := IHIND _ _ _ H21). inversion IH1. congruence.
 
   (* MAP VALUE EXCEPTION *)
-  * intros. inversion H9.
-    - assert ((forall (v2 : Value + Exception) (eff'' : SideEffectList),
-              | env, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | v2, eff'' | ->
-              inr ex = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'') \/
-             (forall (v2 : Value + Exception) (eff'' : SideEffectList),
-              | env, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | v2, eff'' | ->
-              inl val = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'') /\
-             (forall (v2 : Value + Exception) (eff'' : SideEffectList),
-              | env, nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2 | -e> | v2, eff'' | ->
-              inr ex = v2 /\ eff4 = eff'')). { right. split. exact IHIND1. exact IHIND2. }
+  * intros. inversion H10.
+    - assert ((forall (v2 : Value + Exception) (eff'' : SideEffectList) (id''' : nat),
+              | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | id''', v2, eff'' | ->
+              inr ex = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'' /\ id' = id''') \/
+             (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id''' : nat),
+              | env, last ids id, nth i kl ErrorExp, concatn eff1 eff (2 * i) | -e> | id''', v2, eff'' | ->
+              inl val = v2 /\ concatn eff1 eff (2 * i) ++ eff2 = eff'' /\ id' = id''') /\
+             (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id''' : nat),
+              | env, id', nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2 | -e> | id''', v2, eff'' | ->
+              inr ex = v2 /\ eff4 = eff'' /\ id'' = id''')). { right. split. exact IHIND1. exact IHIND2. }
       pose (MEQ := map_lists_equal_until_i_key_or_val kvals vvals kvals0 vvals0 i eff1 eff eff6 eff2
-                  eff4 val ex H5 H7 H24 H12 H0 H1 (Nat.lt_le_incl _ _ H2)
-                  H3 H17 H19 H13 H14 (eq_sym H15)).
-      inversion MEQ. inversion H26. inversion H28. subst.
+                  eff4 val ex _ _ _ _ _ H6 H8 H29 H H0 H1 (Nat.lt_le_incl _ _ H2)
+                  H3 H4 H19 H20 H14 H15 (eq_sym H16) (eq_sym H17)).
+      destruct MEQ. destruct H31. destruct H32. destruct H33. subst.
       assert (Datatypes.length vvals0 < Datatypes.length vl). { omega. }
-      pose (GOOD := H17 (length vvals0) H0).
-      pose (GOOD' := IHIND1 _ _ GOOD). inversion GOOD'. inversion H8.
-      pose (BAD := H19 (length vvals0) H0). rewrite <- H10 in BAD.
-      pose (BAD' := IHIND2 _ _ BAD). inversion BAD'. inversion H11.
-    - rewrite H20 in H24.
-      assert (| env, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | inr ex0,
+      pose (GOOD := H19 (length vvals0) H0).
+      rewrite last_nth_equal, H4, mult_comm in IHIND1.
+      pose (GOOD' := IHIND1 _ _ _ GOOD). inversion GOOD'. inversion H9. destruct H11.
+      pose (BAD := H20 (length vvals0) H0). rewrite <- H11, <- H12 in BAD.
+      pose (BAD' := IHIND2 _ _ _ BAD). inversion BAD'. congruence.
+    - rewrite H23 in H28.
+      assert (| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id''0, inr ex0,
               concatn eff1 eff7 (2 * i0) ++ eff5 | \/
-              | env, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | inl ErrorValue,
+              | env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id''0, inl ErrorValue,
               concatn eff1 eff7 (2 * i0) ++ eff5 | /\
-              | env, nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff5 | -e> | 
-              inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 ++ [] |). { auto. }
+              | env, id''0, nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff5 | -e> | 
+              id''0, inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 ++ [] |). { auto. }
       pose (MEQ := map_lists_equal_until_i_val kvals vvals kvals0 vvals0 i i0 eff1 eff eff7 ex0 eff5 eff2
-                   eff4 [] val ErrorValue ex H5 H7 IHIND1 IHIND2 H H0 H1 (Nat.lt_le_incl _ _ H2)
-                   H3 H17 H18 H13 H14 (Nat.lt_le_incl _ _ H15) H16 H25).
-      inversion MEQ. inversion H27. inversion H29. subst.
-      pose (IH1 := IHIND1 _ _ H24). inversion IH1. inversion H0.
-    - rewrite H21 in H25.
-      assert (| env, nth i0 kl ErrorExp, concatn eff1 eff8 (2 * i0) | -e> | inr ex0,
+                   eff4 [] val ErrorValue ex _ _ _ _ _ _ _ H6 H8 IHIND1 IHIND2 H H0 H1 (Nat.lt_le_incl _ _ H2)
+                   H3 H4 H19 H20 H14 H15 (Nat.lt_le_incl _ _ H16) H17 H18 H29).
+      destruct MEQ. destruct H31. destruct H32. destruct H33. subst.
+      pose (IH1 := IHIND1 _ _ _ H28). inversion IH1. congruence.
+    - rewrite H24 in H29.
+      assert (| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff8 (2 * i0) | -e> | id'0, inr ex0,
               concatn eff1 eff8 (2 * i0) ++ eff5 | \/
-              | env, nth i0 kl ErrorExp, concatn eff1 eff8 (2 * i0) | -e> | inl val0,
+              | env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff8 (2 * i0) | -e> | id'0, inl val0,
               concatn eff1 eff8 (2 * i0) ++ eff5 | /\
-              | env, nth i0 vl ErrorExp, concatn eff1 eff8 (2 * i0) ++ eff5 | -e> | 
+              | env, id'0, nth i0 vl ErrorExp, concatn eff1 eff8 (2 * i0) ++ eff5 | -e> | id''0,
               inr ex0, concatn eff1 eff8 (2 * i0) ++ eff5 ++ eff6 |). { auto. }
       pose (MEQ := map_lists_equal_until_i_val kvals vvals kvals0 vvals0 i i0 eff1 eff eff8 ex0 eff5 eff2
-                   eff4 eff6 val val0 ex H5 H7 IHIND1 IHIND2 H H0 H1 (Nat.lt_le_incl _ _ H2) H3 H17 H18
-                   H13 H14 (Nat.lt_le_incl _ _ H15) H16 H26). inversion MEQ. inversion H28. inversion H30. subst.
-      pose (IH1 := IHIND1 _ _ H19). inversion IH1. inversion H0. apply app_inv_head in H8. subst.
-      pose (IH2 := IHIND2 _ _ H25). assumption. *)
-Admitted.
+                   eff4 eff6 val val0 ex _ _ _ _ _ _ _ H6 H8 IHIND1 IHIND2 H H0 H1 (Nat.lt_le_incl _ _ H2) H3  H4 H19 H20 H14 H15 (Nat.lt_le_incl _ _ H16) H17 H18 H30).
+      destruct MEQ. inversion H32. destruct H34. destruct H35. subst.
+      pose (IH1 := IHIND1 _ _ _ H21). destruct IH1. inversion H0. destruct H9. apply app_inv_head in H9. subst.
+      pose (IH2 := IHIND2 _ _ _ H29). assumption.
+Qed.
 
 (* Theorem env_app_get (env : Environment) (var : Var + FunctionIdentifier) (val : Value):
 get_value (insert_value env var val) var = inl val.

--- a/Core_Erlang_Proofs.v
+++ b/Core_Erlang_Proofs.v
@@ -98,47 +98,45 @@ Proof.
   * intros. inversion H6; subst.
     - pose (LEQ := list_equality vals vals0 eff eff4 _ _ _ H2 H3 H11 H8 H9 H H0 H1 H10).
       inversion LEQ. inversion H5. subst. auto.
-    - pose (P1 := H2 (Datatypes.length vals0) H7 (inr ex)
+    - pose (P1 := H3 (Datatypes.length vals0) H9 (inr ex)
           (concatn eff1 eff5 (Datatypes.length vals0) ++ eff3)).
-      pose (EU := eff_until_i vals vals0 eff1 eff eff5 H H0 H8 H7 H2 H9).
-      rewrite EU in H12. rewrite EU in P1. pose (P2 := P1 H12). inversion P2. inversion H3.
+      pose (EU := @eff_until_i env eff eff5 exps vals vals0 eff1 _ _ id _ _ _ H H0 H10 H9 H1 H11 H3 H12 H16). inversion EU.
 
   (* LIST *)
   * intros. inversion H0. 
-    - subst. pose (IH1 := IHIND1 (inl tlv0) (eff1 ++ eff5) H5). 
-      inversion IH1. apply app_inv_head in H1. subst.
-      pose (IH2 := IHIND2 (inl hdv0) (eff1 ++ eff5 ++ eff6) H9). inversion IH2.
-      apply app_inv_head, app_inv_head in H2. inversion H1. inversion H. subst. split; reflexivity.
-    - subst. pose (IH1 := IHIND1 (inr ex) (eff1 ++ eff5) H8). inversion IH1. inversion H.
+    - subst. pose (IH1 := IHIND1 (inl tlv0) (eff1 ++ eff5) _ H6). 
+      inversion IH1. destruct H1. apply app_inv_head in H1. subst.
+      pose (IH2 := IHIND2 (inl hdv0) (eff1 ++ eff5 ++ eff6) _ H11). inversion IH2. destruct H2.
+      apply app_inv_head, app_inv_head in H2. inversion H1. inversion H. subst. auto.
+    - subst. pose (IH1 := IHIND1 (inr ex) (eff1 ++ eff5) _ H10). inversion IH1. inversion H.
     - subst.
-      pose (IH1 := IHIND1 (inl vtl) (eff1 ++ eff5) H5).
-      inversion IH1. apply app_inv_head in H1. subst.
-      pose (IH2 := IHIND2 (inr ex) (eff1 ++ eff5 ++ eff6) H9). inversion IH2. inversion H1.
+      pose (IH1 := IHIND1 (inl vtl) (eff1 ++ eff5) _ H6).
+      inversion IH1. destruct H1. apply app_inv_head in H1. subst.
+      pose (IH2 := IHIND2 (inr ex) (eff1 ++ eff5 ++ eff6) _ H11). inversion IH2. inversion H1.
 
   (* CASE *)
   * intros. inversion H6. 
-    - subst. apply IHIND1 in H13. inversion H13. inversion H5. apply app_inv_head in H7. subst.
+    - subst. apply IHIND1 in H13. inversion H13. inversion H5. destruct H7. apply app_inv_head in H7. subst.
       assert (match_clause v0 patts guards bodies i = Some (guard, exp, bindings)). { auto. }
       pose (IEQ := index_case_equality i i0 guard guard0 exp exp0 bindings bindings0 
-                   (eff1 ++ eff5) H4 H17 H2 H15 H22 IND2 IHIND2). rewrite IEQ in H7.
+                   (eff1 ++ eff5) _ H4 H18 H2 H15 H24 IND2 IHIND2). rewrite IEQ in H7.
       rewrite H15 in H7. inversion H7. rewrite H9, H10, H16 in *.
-      apply IHIND3 in H23. inversion H23.
-      apply app_inv_head, app_inv_head in H18. rewrite H8, H18. auto.
-    - subst. apply IHIND1 in H18. inversion H18. inversion H5. 
-    - subst. apply IHIND1 in H18. inversion H18. apply app_inv_head in H7. inversion H5.
-      subst. pose (EE := H19 i H1 guard exp bindings H2).
-      pose (IHE := IHIND2 _ _ EE). inversion IHE. inversion H7.
+      apply IHIND3 in H25. destruct H25. destruct H17.
+      apply app_inv_head, app_inv_head in H17. rewrite H8, H17. auto.
+    - subst. apply IHIND1 in H20. inversion H20. inversion H5. 
+    - subst. apply IHIND1 in H20. inversion H20. destruct H7. apply app_inv_head in H7. inversion H5.
+      subst. pose (EE := H21 i H1 guard exp bindings H2).
+      pose (IHE := IHIND2 _ _ _ EE). inversion IHE. inversion H7.
 
   (* CALL *)
-  * intros. inversion H4.
+  * intros. inversion H6.
     - subst.
-      pose (LEQ := list_equality vals vals0 eff eff4 H1 H2 H10 H7 H8 H H0).
-      destruct LEQ. rewrite H5, H6 in *. rewrite H3 in H14. inversion H14.
-      subst. split; reflexivity.
-    - subst. pose (P1 := H2 (Datatypes.length vals0) H8 (inr ex)
+      pose (LEQ := list_equality vals vals0 eff eff4 _ _ _ H2 H3 H12 H9 H10 H H0 H1 H11).
+      destruct LEQ. destruct H7. subst. rewrite H4 in H15. inversion H15.
+      subst. auto.
+    - subst. pose (P1 := H3 (Datatypes.length vals0) H10 (inr ex)
                             (concatn eff1 eff5 (Datatypes.length vals0) ++ eff3)).
-      pose (EU := eff_until_i vals vals0 eff1 eff eff5 H H0 H9 H8 H2 H10).
-      rewrite EU in H16. rewrite EU in P1. pose (P2 := P1 H16). inversion P2. inversion H5.
+      pose (EU := @eff_until_i env eff eff5 params vals vals0 eff1 _ _ id _ _ _ H H0 H11 H10 H1 H12 H3 H13 H21). inversion EU.
 
   (* APPLY *)
   * intros. inversion H5.

--- a/Core_Erlang_Proofs.v
+++ b/Core_Erlang_Proofs.v
@@ -87,7 +87,8 @@ Theorem determinism : forall {env : Environment} {e : Expression} {v1 : Value + 
     {id id' : nat} {eff eff' : SideEffectList}, 
   |env, id, e, eff| -e> | id', v1, eff'|
 ->
-  (forall v2 eff'' id'', |env, id, e, eff| -e> |id'', v2, eff''| -> v1 = v2 /\ eff' = eff'' /\ id' = id'').
+  (forall v2 eff'' id'', |env, id, e, eff| -e> |id'', v2, eff''| -> v1 = v2 /\ eff' = eff''
+      /\ id' = id'').
 Proof.
   intro. intro. intro. intro. intro. intro. intro. intro IND. induction IND.
   (* LITERAL, VARIABLE, FUNCTION SIGNATURE, FUNCTION DEFINITION *)
@@ -100,7 +101,8 @@ Proof.
       inversion LEQ. inversion H5. subst. auto.
     - pose (P1 := H3 (Datatypes.length vals0) H9 (inr ex)
           (concatn eff1 eff5 (Datatypes.length vals0) ++ eff3)).
-      pose (EU := @eff_until_i env eff eff5 exps vals vals0 eff1 _ _ id _ _ _ H H0 H10 H9 H1 H11 H3 H12 H16). inversion EU.
+      pose (EU := @eff_until_i env eff eff5 exps vals vals0 eff1 _ _ id _ _ _
+               H H0 H10 H9 H1 H11 H3 H12 H16). inversion EU.
 
   (* LIST *)
   * intros. inversion H0. 
@@ -116,7 +118,8 @@ Proof.
 
   (* CASE *)
   * intros. inversion H6. 
-    - subst. apply IHIND1 in H13. inversion H13. inversion H5. destruct H7. apply app_inv_head in H7. subst.
+    - subst. apply IHIND1 in H13. inversion H13. inversion H5. destruct H7.
+      apply app_inv_head in H7. subst.
       assert (match_clause v0 patts guards bodies i = Some (guard, exp, bindings)). { auto. }
       pose (IEQ := index_case_equality i i0 guard guard0 exp exp0 bindings bindings0 
                    (eff1 ++ eff5) _ H4 H18 H2 H15 H24 IND2 IHIND2). rewrite IEQ in H7.
@@ -136,7 +139,8 @@ Proof.
       subst. auto.
     - subst. pose (P1 := H3 (Datatypes.length vals0) H10 (inr ex)
                             (concatn eff1 eff5 (Datatypes.length vals0) ++ eff3)).
-      pose (EU := @eff_until_i env eff eff5 params vals vals0 eff1 _ _ id _ _ _ H H0 H11 H10 H1 H12 H3 H13 H21). inversion EU.
+      pose (EU := @eff_until_i env eff eff5 params vals vals0 eff1 _ _ id _ _ _ 
+                H H0 H11 H10 H1 H12 H3 H13 H21). inversion EU.
 
   (* APPLY *)
   * intros. inversion H6.
@@ -148,7 +152,8 @@ Proof.
     - subst. apply IHIND1 in H16. inversion H16. congruence.
     - subst. apply IHIND1 in H13. destruct H13. destruct H7.
       inversion H5. apply app_inv_head in H7. subst.
-      pose (P1 := @eff_until_i env eff eff8 params vals vals0 _ _ _ _ _ _ _ H H1 H11 H10 H2 H12 H4 H14 H22).
+      pose (P1 := @eff_until_i env eff eff8 params vals vals0 _ _ _ _ _ _ _
+                H H1 H11 H10 H2 H12 H4 H14 H22).
       inversion P1.
     - subst. apply IHIND1 in H12. inversion H12. inversion H5. subst.
       pose (P := H14 ref ext var_list body). congruence.
@@ -156,9 +161,11 @@ Proof.
 
   (* LET *)
   * intros. inversion H5. subst.
-   - pose (LEQ := list_equality vals vals0 eff eff0 _ _ _ H2 H3 H14 H9 H10 H H0 H1 H11). destruct LEQ. destruct H6. subst.
+   - pose (LEQ := list_equality vals vals0 eff eff0 _ _ _ H2 H3 H14 H9 H10 H H0 H1 H11).
+     destruct LEQ. destruct H6. subst.
      pose (IH1 := IHIND v2 (concatn eff1 eff0 (Datatypes.length exps) ++ eff5) _ H20). assumption.
-   - subst. pose (EU := @eff_until_i env eff eff6 exps vals vals0 _ _ _ _ _ _ _ H H0 H11 H10  H1 H12 H3 H15 H21). inversion EU.
+   - subst. pose (EU := @eff_until_i env eff eff6 exps vals vals0 _ _ _ _ _ _ _
+                 H H0 H11 H10  H1 H12 H3 H15 H21). inversion EU.
 
   (* LETREC *)
   * intros. inversion H2. 
@@ -226,7 +233,8 @@ Proof.
   (* TUPLE EXCEPTION *)
   * intros. inversion H6.
     - subst.
-      pose (EU := @eff_until_i_rev env eff eff5 exps vals vals0 eff1 ids ids0 id _ _ _ H4 H11 IHIND H0 H1 H8 H9 H10 H2). inversion EU.
+      pose (EU := @eff_until_i_rev env eff eff5 exps vals vals0 eff1 ids ids0 id _ _ _
+               H4 H11 IHIND H0 H1 H8 H9 H10 H2). inversion EU.
     - rewrite H13 in H16.
       pose (EE := exception_equality vals vals0 ex eff1 eff eff6 i
              i0 eff3 ex0 eff4 _ _ _ _ _ H4 H16 IHIND H12 H H0 H1 H8 H9 H10 H2 H11).
@@ -258,12 +266,14 @@ Proof.
       subst. pose (EE := H3 i H12 guard exp bindings H13).
       pose (IHE := EE _ _ _ H22). inversion IHE. inversion H5.
     - subst. apply IHIND in H18. inversion H18. congruence.
-    - subst. apply IHIND in H18. inversion H18. destruct H5. apply app_inv_head in H5. inversion H1. subst. auto.
+    - subst. apply IHIND in H18. inversion H18. destruct H5. apply app_inv_head in H5.
+      inversion H1. subst. auto.
 
   (* CALL EXCEPTION *)
   * intros. inversion H6.
     - subst.
-      pose (EU := @eff_until_i_rev env eff eff5 params vals vals0 eff1 ids ids0 id _ _ _ H4 H12 IHIND H0 H1 H9 H10 H11 H2). inversion EU.
+      pose (EU := @eff_until_i_rev env eff eff5 params vals vals0 eff1 ids ids0 id _ _ _
+              H4 H12 IHIND H0 H1 H9 H10 H11 H2). inversion EU.
     - rewrite H16 in H21. apply IHIND.
       pose (EEQ := exception_equality vals vals0 ex eff1 eff eff6 i
              i0 eff3 ex0 eff4 _ _ _ _ _ H4 H21 IHIND H13 H H0 H1 H9 H10 H11 H2 H12).
@@ -282,7 +292,8 @@ Proof.
   * intros. inversion H6.
     - subst. apply IHIND1 in H10. destruct H10. destruct H5. inversion H.
       apply app_inv_head in H5. subst.
-      pose (P1 := @eff_until_i_rev env eff _ params vals vals0 (eff1 ++ eff5) ids ids0 id'0 _ _ _ H4 H14 IHIND2 H0 H1 H9 H12 H13 H2). inversion P1.
+      pose (P1 := @eff_until_i_rev env eff _ params vals vals0 (eff1 ++ eff5) ids ids0 id'0 _ _ _
+                   H4 H14 IHIND2 H0 H1 H9 H12 H13 H2). inversion P1.
     - subst. apply IHIND1 in H16. inversion H16. congruence.
     - apply IHIND1 in H13. destruct H13. destruct H23. apply app_inv_head in H23. inversion H13.
       rewrite H26, H23, H24 in *.
@@ -296,20 +307,25 @@ Proof.
       assumption.
     - subst. apply IHIND1 in H12. destruct H12. inversion H. destruct H5.
       apply app_inv_head in H5. subst.
-      pose (P1 := @eff_until_i_rev env eff _ params vals vals0 (eff1 ++ eff5) ids ids0 id'0 _ _ _ H4 H13 IHIND2 H0 H1 H9 H10 H11 H2). inversion P1.
+      pose (P1 := @eff_until_i_rev env eff _ params vals vals0 (eff1 ++ eff5) ids ids0 id'0 _ _ _
+                 H4 H13 IHIND2 H0 H1 H9 H10 H11 H2). inversion P1.
     - subst. apply IHIND1 in H12. destruct H12. inversion H. destruct H5.
       apply app_inv_head in H5. subst.
-      pose (P1 := @eff_until_i_rev env eff _ params vals vals0 (eff1 ++ eff5) ids ids0 id'0 _ _ _ H4 H13 IHIND2 H0 H1 H9 H10 H11 H2). inversion P1.
+      pose (P1 := @eff_until_i_rev env eff _ params vals vals0 (eff1 ++ eff5) ids ids0 id'0 _ _ _
+                 H4 H13 IHIND2 H0 H1 H9 H10 H11 H2). inversion P1.
 
   (* name evaluate to a non-closure value *)
   * intros. inversion H7.
     - apply IHIND in H11. destruct H11. destruct H24. inversion H11.
       pose (P := H4 ref ext var_list body _ H27). inversion P.
     - subst. apply IHIND in H17. inversion H17. congruence.
-    - subst. apply IHIND in H14. destruct H14. inversion H5. destruct H6. apply app_inv_head in H6. subst.
-      pose (P1 := @eff_until_i env eff eff7 params vals vals0 (eff1 ++ eff4) ids ids0 id'0 id''0 ex eff5 H H0 H12 H11 H1 H13 H3 H15 H23). inversion P1.
+    - subst. apply IHIND in H14. destruct H14. inversion H5. destruct H6.
+      apply app_inv_head in H6. subst.
+      pose (P1 := @eff_until_i env eff eff7 params vals vals0 (eff1 ++ eff4) ids ids0 id'0 id''0 ex eff5
+                         H H0 H12 H11 H1 H13 H3 H15 H23). inversion P1.
     - subst. apply IHIND in H13. destruct H13. inversion H5. destruct H6. apply app_inv_head in H6. subst.
-      pose (LEQ := @list_equality env params (eff1 ++ eff4) vals vals0 eff eff6 _ _ _ H2 H3 H14 H10 H11 H H0 H1 H12).
+      pose (LEQ := @list_equality env params (eff1 ++ eff4) vals vals0 eff eff6 _ _ _
+                     H2 H3 H14 H10 H11 H H0 H1 H12).
       destruct LEQ. destruct H8. subst. auto.
     - subst. apply IHIND in H13. destruct H13. inversion H5. destruct H6. apply app_inv_head in H6. subst.
       pose (P := H4 ref ext var_list body). congruence.
@@ -318,25 +334,29 @@ Proof.
   * intros. inversion H7.
     - subst. 
       pose (P1 := IHIND _ _ _ H11). destruct P1. destruct H6. apply app_inv_head in H6. inversion H5. subst.
-      pose (EL:= list_equality vals vals0 eff eff7 _ _ _ H2 H3 H15 H10 H13 H H0 H1 H14). destruct EL. destruct H8. subst. intuition. 
+      pose (EL:= list_equality vals vals0 eff eff7 _ _ _ H2 H3 H15 H10 H13 H H0 H1 H14).
+      destruct EL. destruct H8. subst. intuition. 
     - subst. pose (IH := IHIND _ _ _ H17). inversion IH. congruence.
     - subst.
       pose (P1 := IHIND _ _ _ H14). destruct P1. destruct H6. apply app_inv_head in H6. inversion H5. subst.
-      pose (P2 := @eff_until_i env eff eff7 params vals vals0 (eff1 ++ eff4) ids ids0 id'0 id''0 ex eff5 H H0 H12 H11 H1 H13 H3 H15 H23). inversion P2.
+      pose (P2 := @eff_until_i env eff eff7 params vals vals0 (eff1 ++ eff4) ids ids0 id'0 id''0 ex eff5
+                     H H0 H12 H11 H1 H13 H3 H15 H23). inversion P2.
     - subst.
       pose (P1 := IHIND _ _ _ H13). destruct P1. destruct H6. inversion H5. subst.
       pose (P2 := H15 ref ext var_list body).
       congruence.
     - subst.
       pose (P1 := IHIND _ _ _ H13). destruct P1. destruct H6. apply app_inv_head in H6. inversion H5. subst.
-      pose (EL:= @list_equality env params (eff1 ++ eff4) vals vals0 eff eff6 _ _ _ H2 H3 H14 H10 H11 H H0 H1 H12).
+      pose (EL:= @list_equality env params (eff1 ++ eff4) vals vals0 eff eff6 _ _ _
+                     H2 H3 H14 H10 H11 H H0 H1 H12).
       destruct EL. destruct H8. subst. auto.
 
   
   (* LET EXCEPTION *)
   * intros. inversion H6.
     - subst.
-      pose (EU := @eff_until_i_rev env eff _ exps vals vals0 eff1 ids ids0 _ _ _ _ H4 H15 IHIND H0 H1 H10 H11 H12 H2). inversion EU.
+      pose (EU := @eff_until_i_rev env eff _ exps vals vals0 eff1 ids ids0 _ _ _ _
+                      H4 H15 IHIND H0 H1 H10 H11 H12 H2). inversion EU.
     - rewrite H21 in H22. apply IHIND. 
       pose (EEQ := exception_equality vals vals0 ex eff1 eff eff6
             i i0 eff3 ex0 eff4 _ _ _ _ _ H4 H22 IHIND H16 H H0 H1 H10 H11 H12 H2 H13).
@@ -358,7 +378,8 @@ Proof.
              | env, id', nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2 | -e> | id''', v2, eff'' | ->
              inr ex = v2 /\ [] = eff'' /\ id'' = id''')). { auto. }
      pose (MEQ := map_lists_equal_until_i_key_or_val kvals vvals kvals0 vvals0 i eff1 eff eff5 eff2
-                        [] ErrorValue ex _ _ _ _ _ H6 H8 H29 H H0 H1 (Nat.lt_le_incl _ _ H2) H3 H4 H19 H20 H14 H15 (eq_sym H16) (eq_sym H17)).
+                        [] ErrorValue ex _ _ _ _ _ H6 H8 H29 H H0 H1 (Nat.lt_le_incl _ _ H2)
+                        H3 H4 H19 H20 H14 H15 (eq_sym H16) (eq_sym H17)).
      destruct MEQ. destruct H31. inversion H32. destruct H34. subst.
      assert (Datatypes.length vvals0 < Datatypes.length vl). { omega. }
      pose (ERR := H19 (length vvals0) H0).
@@ -367,24 +388,30 @@ Proof.
     - rewrite H9 in IHIND. rewrite H23 in H28.
       assert (| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff6 (2 * i0) | 
               -e> | id'', inr ex0, concatn eff1 eff6 (2 * i0) ++ eff4 | \/
-              | env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff6 (2 * i0) | -e> | id'', inl ErrorValue,
+              | env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff6 (2 * i0) | -e> 
+              | id'', inl ErrorValue,
                concatn eff1 eff6 (2 * i0) ++ eff4 | /\
-               | env, id'', nth i0 vl ErrorExp, concatn eff1 eff6 (2 * i0) ++ eff4 | -e> | id'', inr ex0,
+               | env, id'', nth i0 vl ErrorExp, concatn eff1 eff6 (2 * i0) ++ eff4 | -e> 
+               | id'', inr ex0,
                concatn eff1 eff6 (2 * i0) ++ eff4 ++ [] |). { left. exact H28. }
       pose (MEQ := map_lists_equal_until_i_key kvals vvals kvals0 vvals0 i i0 eff1 eff eff6 ex0 eff4
-                   eff2 [] ErrorValue ex _ _ _ _ _ _ H6 H8 IHIND H H0 H1 (Nat.lt_le_incl _ _ H2) H3 H4 H19 H20 H14 H15 (Nat.lt_le_incl _ _ H16) H17 H18 H29).
+                   eff2 [] ErrorValue ex _ _ _ _ _ _ H6 H8 IHIND H H0 H1 (Nat.lt_le_incl _ _ H2)
+                   H3 H4 H19 H20 H14 H15 (Nat.lt_le_incl _ _ H16) H17 H18 H29).
       destruct MEQ. destruct H31. destruct H32. destruct H33. subst.
       pose (IH1 := IHIND _ _ _ H28). inversion IH1. inversion H0.
       destruct H9. apply app_inv_head in H9. subst. auto.
     - rewrite H9 in IHIND. rewrite H24 in H29.
       assert (| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) |
               -e> | id'0, inr ex0, concatn eff1 eff7 (2 * i0) ++ eff4 | \/
-               | env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id'0, inl val,
+               | env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> 
+               | id'0, inl val,
                concatn eff1 eff7 (2 * i0) ++ eff4 | /\
-               | env, id'0, nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff4 | -e> | id'', inr ex0,
+               | env, id'0, nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff4 | -e> 
+               | id'', inr ex0,
                concatn eff1 eff7 (2 * i0) ++ eff4 ++ eff5 |). { auto. }
       pose (MEQ := map_lists_equal_until_i_key kvals vvals kvals0 vvals0 i i0 eff1 eff eff7 ex0 eff4
-                   eff2 eff5 val ex _ _ _ _ _ _ H6 H8 IHIND H H0 H1 (Nat.lt_le_incl _ _ H2) H3 H4 H19 H20 H14 H15 (Nat.lt_le_incl _ _ H16) H17 H18 H30).
+                   eff2 eff5 val ex _ _ _ _ _ _ H6 H8 IHIND H H0 H1 (Nat.lt_le_incl _ _ H2) 
+                   H3 H4 H19 H20 H14 H15 (Nat.lt_le_incl _ _ H16) H17 H18 H30).
       destruct MEQ. destruct H32. destruct H33. destruct H34. subst.
       pose (IH1 := IHIND _ _ _ H21). inversion IH1. congruence.
 
@@ -410,9 +437,11 @@ Proof.
       pose (BAD := H20 (length vvals0) H0). rewrite <- H11, <- H12 in BAD.
       pose (BAD' := IHIND2 _ _ _ BAD). inversion BAD'. congruence.
     - rewrite H23 in H28.
-      assert (| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id''0, inr ex0,
+      assert (| env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> 
+      | id''0, inr ex0,
               concatn eff1 eff7 (2 * i0) ++ eff5 | \/
-              | env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> | id''0, inl ErrorValue,
+              | env, last ids0 id, nth i0 kl ErrorExp, concatn eff1 eff7 (2 * i0) | -e> 
+              | id''0, inl ErrorValue,
               concatn eff1 eff7 (2 * i0) ++ eff5 | /\
               | env, id''0, nth i0 vl ErrorExp, concatn eff1 eff7 (2 * i0) ++ eff5 | -e> | 
               id''0, inr ex0, concatn eff1 eff7 (2 * i0) ++ eff5 ++ [] |). { auto. }
@@ -429,7 +458,8 @@ Proof.
               | env, id'0, nth i0 vl ErrorExp, concatn eff1 eff8 (2 * i0) ++ eff5 | -e> | id''0,
               inr ex0, concatn eff1 eff8 (2 * i0) ++ eff5 ++ eff6 |). { auto. }
       pose (MEQ := map_lists_equal_until_i_val kvals vvals kvals0 vvals0 i i0 eff1 eff eff8 ex0 eff5 eff2
-                   eff4 eff6 val val0 ex _ _ _ _ _ _ _ H6 H8 IHIND1 IHIND2 H H0 H1 (Nat.lt_le_incl _ _ H2) H3  H4 H19 H20 H14 H15 (Nat.lt_le_incl _ _ H16) H17 H18 H30).
+                   eff4 eff6 val val0 ex _ _ _ _ _ _ _ H6 H8 IHIND1 IHIND2 H H0 H1 (Nat.lt_le_incl _ _ H2) 
+                   H3 H4 H19 H20 H14 H15 (Nat.lt_le_incl _ _ H16) H17 H18 H30).
       destruct MEQ. inversion H32. destruct H34. destruct H35. subst.
       pose (IH1 := IHIND1 _ _ _ H21). destruct IH1. inversion H0. destruct H9. apply app_inv_head in H9. subst.
       pose (IH2 := IHIND2 _ _ _ H29). assumption.

--- a/Core_Erlang_Proofs.v
+++ b/Core_Erlang_Proofs.v
@@ -84,20 +84,20 @@ Qed.
 Import Arith.PeanoNat.
 
 Theorem determinism : forall {env : Environment} {e : Expression} {v1 : Value + Exception} 
-    {eff : SideEffectList} (eff' : SideEffectList), 
-  |env, e, eff| -e> |v1, eff'|
+    {id id' : nat} {eff eff' : SideEffectList}, 
+  |env, id, e, eff| -e> | id', v1, eff'|
 ->
-  (forall v2 eff'', |env, e, eff| -e> |v2, eff''| -> v1 = v2 /\ eff' = eff'').
+  (forall v2 eff'' id'', |env, id, e, eff| -e> |id'', v2, eff''| -> v1 = v2 /\ eff' = eff'' /\ id' = id'').
 Proof.
-  intro. intro. intro. intro. intro. intro IND. induction IND.
+  intro. intro. intro. intro. intro. intro. intro. intro IND. induction IND.
   (* LITERAL, VARIABLE, FUNCTION SIGNATURE, FUNCTION DEFINITION *)
-  1-4: intros; inversion H; subst; split; reflexivity.
-  * intros. inversion H. split; reflexivity.
+  1-4: intros; inversion H; subst; auto.
+  * intros. inversion H. auto.
 
   (* TUPLE *)
-  * intros. inversion H4; subst.
-    - pose (LEQ := list_equality vals vals0 eff eff4 H1 H2 H8 H6 H7 H H0).
-      inversion LEQ. subst. split; reflexivity.
+  * intros. inversion H6; subst.
+    - pose (LEQ := list_equality vals vals0 eff eff4 _ _ _ H2 H3 H11 H8 H9 H H0 H1 H10).
+      inversion LEQ. inversion H5. subst. auto.
     - pose (P1 := H2 (Datatypes.length vals0) H7 (inr ex)
           (concatn eff1 eff5 (Datatypes.length vals0) ++ eff3)).
       pose (EU := eff_until_i vals vals0 eff1 eff eff5 H H0 H8 H7 H2 H9).

--- a/Core_Erlang_Proofs.v
+++ b/Core_Erlang_Proofs.v
@@ -138,74 +138,74 @@ Proof.
                             (concatn eff1 eff5 (Datatypes.length vals0) ++ eff3)).
       pose (EU := @eff_until_i env eff eff5 params vals vals0 eff1 _ _ id _ _ _ H H0 H11 H10 H1 H12 H3 H13 H21). inversion EU.
 
-  (* (* APPLY *)
-  * intros. inversion H5.
-    - subst. apply IHIND1 in H9. inversion H9. apply app_inv_head in H6. inversion H4. subst.
-      pose (EQ := list_equality vals vals0 eff eff8 H2 H3 H12 H8 H11 H H1). inversion EQ. subst.
-      apply IHIND2 in H18. inversion H18. auto.
-    - subst. apply IHIND1 in H13. inversion H13. congruence.
-    - subst. apply IHIND1 in H11. inversion H11. inversion H4. apply app_inv_head in H6. subst.
-      pose (P1 := eff_until_i vals vals0 (eff1 ++ eff5) eff eff8 H H1 H10 H9 H3 H12).
-      pose (P2 := H3 (Datatypes.length vals0) H9 (inr ex) (concatn (eff1 ++ eff5) 
-                  eff8 (Datatypes.length vals0) ++ eff6)).
-      rewrite <- P1 in P2. pose (P3 := P2 H18). inversion P3. inversion H6.
-    - subst. apply IHIND1 in H10. inversion H10. inversion H4. subst.
-      pose (P := H13 ref ext var_list body). congruence.
-    - subst. apply IHIND1 in H10. inversion H10. inversion H4. subst. congruence.
+  (* APPLY *)
+  * intros. inversion H6.
+    - subst. apply IHIND1 in H10. inversion H10. destruct H7.
+      apply app_inv_head in H7. inversion H5. subst.
+      pose (EQ := list_equality vals vals0 eff eff8 _ _ _ H3 H4 H14 H9 H12 H H1 H2 H13).
+      inversion EQ. destruct H8. subst.
+      apply IHIND2 in H22. destruct H22. destruct H8. auto.
+    - subst. apply IHIND1 in H16. inversion H16. congruence.
+    - subst. apply IHIND1 in H13. destruct H13. destruct H7.
+      inversion H5. apply app_inv_head in H7. subst.
+      pose (P1 := @eff_until_i env eff eff8 params vals vals0 _ _ _ _ _ _ _ H H1 H11 H10 H2 H12 H4 H14 H22).
+      inversion P1.
+    - subst. apply IHIND1 in H12. inversion H12. inversion H5. subst.
+      pose (P := H14 ref ext var_list body). congruence.
+    - subst. apply IHIND1 in H12. inversion H12. inversion H5. subst. congruence.
 
   (* LET *)
-  * intros. inversion H4. subst.
-   - pose (LEQ := list_equality vals vals0 eff eff0 H1 H2 H11 H8 H9 H H0). destruct LEQ. subst.
-     pose (IH1 := IHIND v2 (concatn eff1 eff0 (Datatypes.length exps) ++ eff5) H16). assumption.
-   - subst. pose (P1 := H2 (Datatypes.length vals0) H9 (inr ex)
-                           (concatn eff1 eff6 (Datatypes.length vals0) ++ eff4)).
-     pose (EU := eff_until_i vals vals0 eff1 eff eff6 H H0 H10 H9 H2 H12).
-     rewrite EU in H17. rewrite EU in P1. pose (P2 := P1 H17). inversion P2. inversion H3.
+  * intros. inversion H5. subst.
+   - pose (LEQ := list_equality vals vals0 eff eff0 _ _ _ H2 H3 H14 H9 H10 H H0 H1 H11). destruct LEQ. destruct H6. subst.
+     pose (IH1 := IHIND v2 (concatn eff1 eff0 (Datatypes.length exps) ++ eff5) _ H20). assumption.
+   - subst. pose (EU := @eff_until_i env eff eff6 exps vals vals0 _ _ _ _ _ _ _ H H0 H11 H10  H1 H12 H3 H15 H21). inversion EU.
 
   (* LETREC *)
   * intros. inversion H2. 
-    - subst. pose (IH2 := IHIND v2 (eff1 ++ eff4) H13). destruct IH2.
-      apply app_inv_head in H3. subst. split; reflexivity.
+    - subst. pose (IH2 := IHIND v2 (eff1 ++ eff4) _ H15). destruct IH2. destruct H3.
+      apply app_inv_head in H3. subst. auto.
 
   (* MAP *)
-  * intros. inversion H9.
-    - pose (MEQ := map_lists_equality kvals vvals kvals0 vvals0 eff1
-                   eff eff4 H5 H7 H12 H0 H1 H2 H17 H19 H13 H14 H15).
-     inversion MEQ. inversion H25. subst. rewrite H3 in H16. inversion H16. auto.
-    - rewrite H20 in H24.
-      assert (| env, nth i kl ErrorExp, concatn eff1 eff5 (2 * i) | 
-              -e> | inr ex, concatn eff1 eff5 (2 * i) ++ eff3 |
+  * intros. inversion H11.
+    - subst. pose (MEQ := map_lists_equality kvals vvals kvals0 vvals0 eff1
+                   eff eff4 ids ids0 id H6 H8 H H0 H1 H2 H3 H20 H21 H15 H16 H17 H18).
+      destruct MEQ. destruct H10. destruct H12. subst. rewrite H4 in H19. inversion H19. auto.
+    - rewrite H24 in H29.
+      assert (| env, last ids0 id, nth i kl ErrorExp, concatn eff1 eff5 (2 * i) | 
+              -e> | id'', inr ex, concatn eff1 eff5 (2 * i) ++ eff3 |
               \/
-              | env, nth i kl ErrorExp, concatn eff1 eff5 (2 * i) | 
-              -e> | inl ErrorValue, concatn eff1 eff5 (2 * i) ++ eff3 |
+              | env, last ids0 id, nth i kl ErrorExp, concatn eff1 eff5 (2 * i) | 
+              -e> | id'', inl ErrorValue, concatn eff1 eff5 (2 * i) ++ eff3 |
               /\
-              | env, nth i vl ErrorExp, concatn eff1 eff5 (2 * i) ++ eff3 | -e> 
-              | inr ex, concatn eff1 eff5 (2 * i) ++ eff3 ++ [] |). { left. exact H24. }
+              | env, id'', nth i vl ErrorExp, concatn eff1 eff5 (2 * i) ++ eff3 | -e> 
+              | id'', inr ex, concatn eff1 eff5 (2 * i) ++ eff3 ++ [] |). { left. exact H29. }
       assert (Datatypes.length vvals0 < Datatypes.length vl). { omega. }
       pose (MEQ := map_lists_equal_until_i kvals vvals kvals0 vvals0 
-                   i eff1 eff eff5 ex eff3 [] ErrorValue H5 H7 H12 H0 H1 (eq_sym H2) 
-                   H17 H18 H13 H14 (Nat.lt_le_incl _ _ H15) H16 H25).
-      inversion MEQ. inversion H28. inversion H30. subst.
-      pose (IH1 := H5 (length vvals0) H26 (inr ex)
-                   (concatn eff1 eff5 (2 * Datatypes.length vvals0) ++ eff3) H24).
-      inversion IH1. inversion H8.
-    - rewrite H21 in H25.
-      assert (| env, nth i kl ErrorExp, concatn eff1 eff6 (2 * i) |
-              -e> | inr ex, concatn eff1 eff6 (2 * i) ++ eff3 |
+                   i eff1 eff eff5 ex eff3 [] ErrorValue _ _ _ _ _ H6 H8 H14 H0 H1 H2 H3
+                   H20 H21 H15 H16 (Nat.lt_le_incl _ _ H17) H18 H19 H30).
+      destruct MEQ. destruct H33. destruct H34. destruct H35. subst.
+      rewrite last_nth_equal, H19, Nat.mul_comm in H29.
+      pose (IH1 := H6 (length vvals0) H31 (inr ex)
+                   (concatn eff1 eff5 (2 * Datatypes.length vvals0) ++ eff3) _ H29).
+      destruct IH1. congruence.
+    - rewrite H25 in H30.
+      assert (| env, last ids0 id, nth i kl ErrorExp, concatn eff1 eff6 (2 * i) |
+              -e> | id'0, inr ex, concatn eff1 eff6 (2 * i) ++ eff3 |
               \/
-              | env, nth i kl ErrorExp, concatn eff1 eff6 (2 * i) |
-              -e> | inl val, concatn eff1 eff6 (2 * i) ++ eff3 |
+              | env, last ids0 id, nth i kl ErrorExp, concatn eff1 eff6 (2 * i) |
+              -e> | id'0, inl val, concatn eff1 eff6 (2 * i) ++ eff3 |
               /\
-              | env, nth i vl ErrorExp, concatn eff1 eff6 (2 * i) ++ eff3 |
-              -e> | inr ex, concatn eff1 eff6 (2 * i) ++ eff3 ++ eff4 |). { auto. }
+              | env, id'0, nth i vl ErrorExp, concatn eff1 eff6 (2 * i) ++ eff3 |
+              -e> | id'', inr ex, concatn eff1 eff6 (2 * i) ++ eff3 ++ eff4 |). { auto. }
       pose (MEQ := map_lists_equal_until_i kvals vvals kvals0 vvals0 i eff1 eff eff6 ex
-                   eff3 eff4 val H5 H7 H12 H0 H1 (eq_sym H2) H17 H18 H13 H14
-                   (Nat.lt_le_incl _ _ H15) H16 H26).
-      inversion MEQ. inversion H28. inversion H30. subst.
+                   eff3 eff4 val _ _ _ _ _ H6 H8 H14 H0 H1 H2 H3 H20 H21 H15 H16
+                   (Nat.lt_le_incl _ _ H17) H18 H19 H31).
+      destruct MEQ. destruct H33. destruct H34. destruct H35. subst.
       assert (Datatypes.length vvals0 < Datatypes.length vl). { omega. }
-      pose (IH1 := H5 (length vvals0) H8 _ _ H19). inversion IH1. inversion H10.
-      rewrite <- H11 in H25.
-      pose (IH2 := H7 (length vvals0) H8 (inr ex) _ H25). inversion IH2. inversion H13.
+      rewrite last_nth_equal, H19, Nat.mul_comm in H22.
+      pose (IH1 := H6 (length vvals0) H9 _ _ _ H22). destruct IH1. destruct H12.
+      inversion H10. subst. rewrite <- H12 in H30.
+      pose (IH2 := H8 (length vvals0) H9 (inr ex) _ _ H30). destruct IH2. congruence.
 
   (* LIST HEAD EXCEPTION *)
   * intros. inversion H0; subst.

--- a/Core_Erlang_Proofs.v
+++ b/Core_Erlang_Proofs.v
@@ -138,7 +138,7 @@ Proof.
                             (concatn eff1 eff5 (Datatypes.length vals0) ++ eff3)).
       pose (EU := @eff_until_i env eff eff5 params vals vals0 eff1 _ _ id _ _ _ H H0 H11 H10 H1 H12 H3 H13 H21). inversion EU.
 
-  (* APPLY *)
+  (* (* APPLY *)
   * intros. inversion H5.
     - subst. apply IHIND1 in H9. inversion H9. apply app_inv_head in H6. inversion H4. subst.
       pose (EQ := list_equality vals vals0 eff eff8 H2 H3 H12 H8 H11 H H1). inversion EQ. subst.
@@ -468,8 +468,8 @@ Proof.
                    eff4 eff6 val val0 ex H5 H7 IHIND1 IHIND2 H H0 H1 (Nat.lt_le_incl _ _ H2) H3 H17 H18
                    H13 H14 (Nat.lt_le_incl _ _ H15) H16 H26). inversion MEQ. inversion H28. inversion H30. subst.
       pose (IH1 := IHIND1 _ _ H19). inversion IH1. inversion H0. apply app_inv_head in H8. subst.
-      pose (IH2 := IHIND2 _ _ H25). assumption.
-Qed.
+      pose (IH2 := IHIND2 _ _ H25). assumption. *)
+Admitted.
 
 (* Theorem env_app_get (env : Environment) (var : Var + FunctionIdentifier) (val : Value):
 get_value (insert_value env var val) var = inl val.
@@ -584,7 +584,7 @@ Qed.*)
 
 (** Last append result *)
 Proposition get_value_here (env : Environment) (var : Var + FunctionIdentifier) (val : Value):
-get_value (insert_original_value env var val) var = inl val.
+get_value (insert_value env var val) var = inl val.
 Proof.
   induction env.
   * simpl. rewrite uequal_refl. reflexivity.
@@ -597,7 +597,7 @@ Qed.
 Proposition get_value_there (env : Environment) (var var' : Var + FunctionIdentifier) 
      (val : Value):
 var <> var' ->
-get_value (insert_original_value env var val) var' = get_value env var'.
+get_value (insert_value env var val) var' = get_value env var'.
 Proof.
   intro. induction env.
   * simpl. apply uequal_neq in H. rewrite uequal_sym in H. rewrite H. reflexivity.

--- a/Core_Erlang_Semantics.v
+++ b/Core_Erlang_Semantics.v
@@ -40,264 +40,274 @@ match fname, length params, params with
 | _, _, _ => (inr (undef (VLiteral (Atom fname))), eff)
 end.
 
-Reserved Notation "| env , e , eff | -e> | e' , eff' |" (at level 70).
-Inductive eval_expr : Environment -> Expression -> SideEffectList -> 
+Reserved Notation "| env , id , e , eff | -e> | id' , e' , eff' |" (at level 70).
+Inductive eval_expr : Environment -> nat -> Expression -> SideEffectList -> nat ->
     (Value + Exception) -> SideEffectList -> Prop :=
-| eval_emptylist (env : Environment) (eff : SideEffectList):
-  |env, EEmptyList, eff| -e> |inl VEmptyList, eff|
+| eval_emptylist (env : Environment) (eff : SideEffectList) (id : nat):
+  |env, id, EEmptyList, eff| -e> |id, inl VEmptyList, eff|
 
 (* literal evaluation rule *)
-| eval_lit (env : Environment) (l : Literal) (eff : SideEffectList):
-  |env, ELiteral l, eff| -e> |inl (VLiteral l), eff|
+| eval_lit (env : Environment) (l : Literal) (eff : SideEffectList) (id : nat):
+  |env, id, ELiteral l, eff| -e> |id, inl (VLiteral l), eff|
 
 (* variable evaluation rule *)
-| eval_var (env:Environment) (s: Var) (eff : SideEffectList):
-  |env, EVar s, eff| -e> |get_value env (inl s), eff|
+| eval_var (env:Environment) (s: Var) (eff : SideEffectList) (id : nat) :
+  |env, id, EVar s, eff| -e> |id, get_value env (inl s), eff|
 
 (* Function Signature evaluation rule *)
-| eval_funid (env:Environment) (fid : FunctionIdentifier) (eff : SideEffectList):
-  |env, EFunId fid, eff| -e> |get_value env (inr fid), eff|
+| eval_funid (env:Environment) (fid : FunctionIdentifier) (eff : SideEffectList) (id : nat):
+  |env, id, EFunId fid, eff| -e> |id, get_value env (inr fid), eff|
 
 (* Function evaluation *)
-| eval_fun (env : Environment) (vl : list Var) (e : Expression) (eff : SideEffectList):
-  |env, EFun vl e, eff| -e> |inl (VClosure env [] (count_closures env) vl e), eff|
+| eval_fun (env : Environment) (vl : list Var) (e : Expression) (eff : SideEffectList) (id : nat):
+  |env, id, EFun vl e, eff| -e> |S id, inl (VClosure env [] id vl e), eff|
 
 (* tuple evaluation rule *)
 | eval_tuple (env: Environment) (exps : list Expression) (vals : list Value) 
-     (eff1 eff2 : SideEffectList) (eff : list SideEffectList):
+     (eff1 eff2 : SideEffectList) (eff : list SideEffectList) (ids : list nat) (id : nat) :
   length exps = length vals ->
   length exps = length eff ->
+  length exps = length ids ->
   (
     forall i, i < length exps ->
-      |env, nth i exps ErrorExp, concatn eff1 eff i| 
+      |env, nth_id ids id i, nth i exps ErrorExp, concatn eff1 eff i| 
      -e> 
-      |inl (nth i vals ErrorValue), concatn eff1 eff (S i)|
+      |nth_id ids id (S i), inl (nth i vals ErrorValue), concatn eff1 eff (S i)|
   ) ->
   eff2 = concatn eff1 eff (length vals)
 ->
-  |env, ETuple exps, eff1| -e> |inl (VTuple vals), eff2|
+  |env, id, ETuple exps, eff1| -e> |last ids 0, inl (VTuple vals), eff2|
 
 (* list evaluation rule *)
 | eval_list (env:Environment) (hd tl: Expression) (hdv tlv : Value) 
-     (eff1 eff2 eff3 eff4 : SideEffectList) :
+     (eff1 eff2 eff3 eff4 : SideEffectList) (id id' id'' : nat) :
   eff4 = eff1 ++ eff2 ++ eff3 ->
-  |env, tl, eff1| -e> |inl tlv, eff1 ++ eff2| ->
-  |env, hd, eff1 ++ eff2| -e> |inl hdv, eff4|
+  |env, id, tl, eff1| -e> |id', inl tlv, eff1 ++ eff2| ->
+  |env, id', hd, eff1 ++ eff2| -e> | id'', inl hdv, eff4|
 ->
-  |env, EList hd tl, eff1| -e> |inl (VList hdv tlv), eff4|
+  |env, id, EList hd tl, eff1| -e> |id'', inl (VList hdv tlv), eff4|
 
 (* case evaluation rules *)
 | eval_case (env: Environment) (e guard exp: Expression) (v : Value) (v' : Value + Exception) 
      (patts : list Pattern) (guards : list Expression) (bodies : list Expression) 
-     (bindings: list (Var * Value)) (i : nat) (eff1 eff2 eff3 eff4 : SideEffectList) :
+     (bindings: list (Var * Value)) (i : nat) (eff1 eff2 eff3 eff4 : SideEffectList) (id id' id'' : nat) :
   length patts = length guards ->
   length patts = length bodies ->
-  |env, e, eff1| -e> |inl v, eff1 ++ eff2| ->
+  |env, id, e, eff1| -e> |id', inl v, eff1 ++ eff2| ->
   i < length patts ->
   match_clause v patts guards bodies i = Some (guard, exp, bindings) ->
   (forall j : nat, j < i -> 
 
     (** THESE GUARDS MUST BE SIDE-EFFECT FREE ACCORDING TO 1.0.3 LANGUAGE SPECIFICATION *)
+    (** These guards cannot define functions currently (id' does not change) *)
     (forall gg ee bb, match_clause v patts guards bodies j = Some (gg, ee, bb) -> 
-      ((|add_bindings bb env, gg, eff1 ++ eff2| -e> |inl ffalse, eff1 ++ eff2| ))
+      ((|add_bindings bb env, id', gg, eff1 ++ eff2| -e> |id', inl ffalse, eff1 ++ eff2| ))
     )
 
   ) ->
   eff4 = eff1 ++ eff2 ++ eff3 ->
-  |add_bindings bindings env, guard, eff1 ++ eff2| -e> |inl ttrue, eff1 ++ eff2| -> 
-  |add_bindings bindings env, exp, eff1 ++ eff2| -e> |v', eff1 ++ eff2 ++ eff3|
+  |add_bindings bindings env, id', guard, eff1 ++ eff2| -e> |id', inl ttrue, eff1 ++ eff2| -> 
+  |add_bindings bindings env, id', exp, eff1 ++ eff2| -e> |id'', v', eff1 ++ eff2 ++ eff3|
 ->
-  |env, ECase e patts guards bodies, eff1| -e> |v', eff4|
+  |env, id, ECase e patts guards bodies, eff1| -e> | id'', v', eff4|
 
 
 (* call evaluation rule *)
 | eval_call (env: Environment) (v : Value + Exception) (params : list Expression) 
-     (vals : list Value) (fname: string) (eff1 eff2: SideEffectList) (eff : list SideEffectList) :
+     (vals : list Value) (fname: string) (eff1 eff2: SideEffectList) (eff : list SideEffectList) (ids : list nat) (id : nat) :
   length params = length vals ->
   length params = length eff ->
+  length params = length ids ->
   (
     forall i, i < length params ->
-      |env, nth i params ErrorExp, concatn eff1 eff i| 
+      |env, nth_id ids id i, nth i params ErrorExp, concatn eff1 eff i| 
      -e>
-      |inl (nth i vals ErrorValue), concatn eff1 eff (S i)|
+      |nth_id ids id (S i), inl (nth i vals ErrorValue), concatn eff1 eff (S i)|
   ) ->
   eval fname vals (concatn eff1 eff (length params)) = (v, eff2)
 ->
-  |env, ECall fname params, eff1| -e> |v, eff2|
+  |env, id, ECall fname params, eff1| -e> |last ids 0, v, eff2|
 
 (* apply functions*)
 | eval_apply (params : list Expression) (vals : list Value) (env : Environment) 
      (exp : Expression) (body : Expression) (v : Value + Exception) (var_list : list Var) 
-     (ref : Environment) (ext : list (FunctionIdentifier * FunctionExpression)) 
-     (eff1 eff2 eff3 eff4 : SideEffectList) (eff : list SideEffectList) (n : nat) :
+     (ref : Environment) (ext : list (nat * FunctionIdentifier * FunctionExpression)) 
+     (eff1 eff2 eff3 eff4 : SideEffectList) (eff : list SideEffectList) (n : nat) (ids : list nat) (id id' id'' : nat) :
   length params = length vals ->
-  |env, exp, eff1| -e> |inl (VClosure ref ext n var_list body), eff1 ++ eff2| ->
+  |env, id, exp, eff1| -e> |id', inl (VClosure ref ext n var_list body), eff1 ++ eff2| ->
   length var_list = length vals
   ->
   length params = length eff ->
+  length params = length ids ->
   (
     forall i, i < length params ->
-      |env, nth i params ErrorExp, concatn (eff1 ++ eff2) eff i|
+      |env, nth_id ids id' i, nth i params ErrorExp, concatn (eff1 ++ eff2) eff i|
      -e>
-      |inl (nth i vals ErrorValue), concatn (eff1 ++ eff2) eff (S i)|
+      |nth_id ids id' (S i), inl (nth i vals ErrorValue), concatn (eff1 ++ eff2) eff (S i)|
   )
   ->
   eff4 = concatn (eff1 ++ eff2) eff (length params) ++ eff3
   ->
-  |append_vars_to_env var_list vals (get_env ref ref ext ext), 
+  |append_vars_to_env var_list vals (get_env ref ext), 
+   last ids 0,
    body, 
    concatn (eff1 ++ eff2) eff (length params)|
   -e>
-   |v, eff4|
+   |id'', v, eff4|
 ->
-  |env, EApply exp params, eff1| -e> |v, eff4|
+  |env, id, EApply exp params, eff1| -e> |id'', v, eff4|
 
 (* let evaluation rule *)
 | eval_let (env: Environment) (exps: list Expression) (vals : list Value) (vars: list Var) 
      (e : Expression) (v : Value + Exception) (eff : list SideEffectList) 
-     (eff1 eff2 eff3 : SideEffectList) :
+     (eff1 eff2 eff3 : SideEffectList) (ids : list nat) (id id' : nat) :
   length exps = length vals ->
   length exps = length eff ->
+  length exps = length ids ->
   (
     forall i, i < length exps ->
-      |env, nth i exps ErrorExp, concatn eff1 eff i|
+      |env, nth_id ids id i, nth i exps ErrorExp, concatn eff1 eff i|
      -e>
-      |inl (nth i vals ErrorValue), concatn eff1 eff (S i)|
+      |nth_id ids id (S i), inl (nth i vals ErrorValue), concatn eff1 eff (S i)|
   )
   ->
     eff3 = concatn eff1 eff (length exps) ++ eff2
   ->
-    |append_vars_to_env vars vals env, e, concatn eff1 eff (length exps)| -e> |v, eff3|
+    |append_vars_to_env vars vals env, last ids 0, e, concatn eff1 eff (length exps)| -e> |id', v, eff3|
 ->
-  |env, ELet vars exps e, eff1| -e> |v, eff3|
+  |env, id, ELet vars exps e, eff1| -e> |id', v, eff3|
 
 (* Letrec evaluation rule *)
 | eval_letrec (env: Environment) (e : Expression)  (fids : list FunctionIdentifier) 
      (paramss: list (list Var)) (bodies : list Expression) (v : Value + Exception) 
-     (eff1 eff2 eff3 : SideEffectList) :
+     (eff1 eff2 eff3 : SideEffectList) (id id' : nat) :
   length fids = length paramss ->
   length fids = length bodies ->
   (
-      |append_funs_to_env fids paramss bodies env env (list_functions fids paramss bodies),
+      |append_funs_to_env fids paramss bodies env id,
+       id + length fids,
        e,
        eff1|
      -e>
-      |v, eff1 ++ eff2|
+      |id', v, eff1 ++ eff2|
   ) ->
   eff3 = eff1 ++ eff2
 ->
-  |env, ELetrec fids paramss bodies e, eff1| -e> |v, eff3|
+  |env, id, ELetrec fids paramss bodies e, eff1| -e> |id', v, eff3|
 
 
 (* map evaluation rule *)
 | eval_map (kl vl: list Expression) (vvals kvals kl' vl' : list Value) (env: Environment) 
-     (eff1 eff2 : SideEffectList) (eff : list SideEffectList) :
+     (eff1 eff2 : SideEffectList) (eff : list SideEffectList) (id : nat) (ids : list nat) :
   length kl = length vl ->
   length kl = length vvals ->
   length kl = length kvals ->
   (length kl) * 2 = length eff ->
+  (length kl) * 2 = length ids ->
   make_value_map kvals vvals = (kl', vl') ->
   (
     forall i : nat, i < length vl ->
-    |env, nth i kl ErrorExp, concatn eff1 eff  (2 * i)|
+    |env, nth_id ids id (2 * i), nth i kl ErrorExp, concatn eff1 eff  (2 * i)|
    -e>
-    |inl (nth i kvals ErrorValue), concatn eff1 eff (S (2*i))|
+    |nth_id ids id (S (2 * i)), inl (nth i kvals ErrorValue), concatn eff1 eff (S (2*i))|
   ) ->
   (
     forall i : nat, i < length vl ->
-    |env, nth i vl ErrorExp, concatn eff1 eff (S (2* i))|
+    |env, nth_id ids id (S (2 * i)),nth i vl ErrorExp, concatn eff1 eff (S (2* i))|
    -e>
-    |inl (nth i vvals ErrorValue), concatn eff1 eff (S (S (2*i)))|
+    |nth_id ids id (S (S (2 * i))),inl (nth i vvals ErrorValue), concatn eff1 eff (S (S (2*i)))|
   ) ->
   eff2 = concatn eff1 eff ((length kvals) * 2)
 ->
-  |env, EMap kl vl, eff1| -e> |inl (VMap kl' vl'), eff2|
+  |env, id, EMap kl vl, eff1| -e> |last ids 0, inl (VMap kl' vl'), eff2|
 
 
   (* EXCEPTIONS *)
 (* list tail exception *)
 | eval_list_ex_tl (env: Environment) (hd tl : Expression) (ex : Exception) 
-      (eff1 eff2 eff3 : SideEffectList) :
+      (eff1 eff2 eff3 : SideEffectList) (id id' : nat) :
   eff3 = eff1 ++ eff2 ->
-  |env, tl, eff1| -e> |inr ex, eff1 ++ eff2|
+  |env, id, tl, eff1| -e> |id', inr ex, eff1 ++ eff2|
 ->
-  |env, EList hd tl, eff1| -e> |inr ex, eff3|
+  |env, id, EList hd tl, eff1| -e> |id', inr ex, eff3|
 
 (* list head exception *)
 | eval_list_ex_hd (env: Environment) (hd tl : Expression) (ex : Exception) (vtl : Value) 
-     (eff1 eff2 eff3 eff4 : SideEffectList) :
+     (eff1 eff2 eff3 eff4 : SideEffectList) (id id' id'' : nat) :
   eff4 = eff1 ++ eff2 ++ eff3 ->
-  |env, tl, eff1| -e> |inl vtl, eff1 ++ eff2| -> 
-  |env, hd, eff1 ++ eff2| -e> |inr ex, eff4|
+  |env, id, tl, eff1| -e> |id', inl vtl, eff1 ++ eff2| -> 
+  |env, id', hd, eff1 ++ eff2| -e> |id'', inr ex, eff4|
 ->
-  |env, EList hd tl, eff1| -e> |inr ex, eff4|
+  |env, id, EList hd tl, eff1| -e> |id'', inr ex, eff4|
 
 (* tuple exception *)
 | eval_tuple_ex (env: Environment) (i : nat) (exps : list Expression) (vals : list Value) 
-     (ex : Exception) (eff1 eff2 eff3 : SideEffectList) (eff : list SideEffectList) :
+     (ex : Exception) (eff1 eff2 eff3 : SideEffectList) (eff : list SideEffectList) (id id' : nat) (ids : list nat) :
   length vals = i ->
   i < length exps ->
   length eff = i ->
+  length ids = i ->
   (forall j, j < i ->
-    |env, nth j exps ErrorExp, concatn eff1 eff j|
+    |env, nth_id ids id j, nth j exps ErrorExp, concatn eff1 eff j|
    -e>
-    |inl (nth j vals ErrorValue), concatn eff1 eff (S j)|) ->
+    |nth_id ids id (S j), inl (nth j vals ErrorValue), concatn eff1 eff (S j)|) ->
   eff3 = concatn eff1 eff i ++ eff2 ->
-  |env, nth i exps ErrorExp, concatn eff1 eff i| -e> |inr ex, eff3|
+  |env, last ids 0, nth i exps ErrorExp, concatn eff1 eff i| -e> |id', inr ex, eff3|
 ->
-  |env, ETuple exps, eff1| -e> |inr ex, eff3|
+  |env, id, ETuple exps, eff1| -e> |id', inr ex, eff3|
 
 
 (* try 2x *)
 | eval_try (env: Environment) (e e1 e2 : Expression) (v vex1 vex2 vex3 : Var) (val : Value + Exception) 
-      (val' : Value) (eff1 eff2 eff3 eff4 : SideEffectList) :
-  |env, e, eff1| -e> |inl val', eff1 ++ eff2| ->
+      (val' : Value) (eff1 eff2 eff3 eff4 : SideEffectList) (id id' id'' : nat) :
+  |env, id, e, eff1| -e> |id', inl val', eff1 ++ eff2| ->
   eff4 = eff1 ++ eff2 ++ eff3 ->
-  |append_vars_to_env [v] [val'] env, e1, eff1 ++ eff2| -e> |val, eff4|
+  |append_vars_to_env [v] [val'] env, id', e1, eff1 ++ eff2| -e> |id'', val, eff4|
 ->
-  |env, ETry e e1 e2 v vex1 vex2 vex3, eff1| -e> |val, eff4|
+  |env, id, ETry e e1 e2 v vex1 vex2 vex3, eff1| -e> |id'', val, eff4|
 
 | eval_try_catch (env: Environment) (e e1 e2 : Expression) (v vex1 vex2 vex3 : Var) 
-      (val : Value + Exception) (ex : Exception) (eff1 eff2 eff3 eff4 : SideEffectList) :
-  |env, e, eff1| -e> |inr ex, eff1 ++ eff2| ->
+      (val : Value + Exception) (ex : Exception) (eff1 eff2 eff3 eff4 : SideEffectList) (id id' id'' : nat) :
+  |env, id, e, eff1| -e> |id', inr ex, eff1 ++ eff2| ->
   eff4 = eff1 ++ eff2 ++ eff3 ->
   |append_vars_to_env [vex1; vex2; vex3] 
                        [exclass_to_value (fst (fst ex)); snd (fst ex); snd ex] 
-                       env, e2, eff1 ++ eff2|
+                       env, id', e2, eff1 ++ eff2|
  -e> 
-  |val, eff4|
+  |id'', val, eff4|
 ->
-  |env, ETry e e1 e2 v vex1 vex2 vex3, eff1| -e> |val, eff4|
+  |env, id, ETry e e1 e2 v vex1 vex2 vex3, eff1| -e> |id'', val, eff4|
 
 
 (* case 2x *)
 (** Pattern matching exception *)
 | eval_case_ex_pat (env: Environment) (e : Expression) (ex : Exception) (patterns : list Pattern) 
-     (guards : list Expression) (bodies : list Expression)  (eff1 eff2 eff3 : SideEffectList):
+     (guards : list Expression) (bodies : list Expression)  (eff1 eff2 eff3 : SideEffectList) (id id' : nat):
   length patterns = length guards ->
   length patterns = length bodies ->
   eff3 = eff1 ++ eff2 ->
-  |env, e, eff1| -e> |inr ex, eff3|
+  |env, id, e, eff1| -e> |id', inr ex, eff3|
 ->
-  |env, ECase e patterns guards bodies, eff1| -e> |inr ex, eff3|
+  |env, id, ECase e patterns guards bodies, eff1| -e> |id', inr ex, eff3|
 
 (** No matching clause *)
 | eval_case_clause_ex (env: Environment) (e : Expression) (patterns : list Pattern) 
-     (guards : list Expression) (bodies : list Expression) (v : Value) (eff1 eff2 eff3 : SideEffectList):
+     (guards : list Expression) (bodies : list Expression) (v : Value) (eff1 eff2 eff3 : SideEffectList) (id id' : nat):
   length patterns = length guards ->
   length patterns = length bodies ->
   eff3 = eff1 ++ eff2 ->
-  |env, e, eff1| -e> |inl v, eff3| ->
+  |env, id, e, eff1| -e> |id', inl v, eff3| ->
   (forall j : nat, j < length patterns -> 
 
     (** THESE GUARDS MUST BE SIDE-EFFECT FREE ACCORDING TO 1.0.3 LANGUAGE SPECIFICATION *)
+    (** These guards cannot define functions currently (id' does not change) *)
     (forall gg ee bb, match_clause v patterns guards bodies j = Some (gg, ee, bb) -> 
-      ((|add_bindings bb env, gg, eff1 ++ eff2| -e> |inl ffalse, eff3| ))
+      ((|add_bindings bb env, id', gg, eff1 ++ eff2| -e> |id', inl ffalse, eff3| ))
     )
 
   )
 ->
-|env, ECase e patterns guards bodies, eff1| -e> |inr (if_clause v), eff3|
+|env, id, ECase e patterns guards bodies, eff1| -e> |id', inr (if_clause v), eff3|
 (** ith guard exception -> guards cannot result in exception, i.e. this rule is not needed *)
 (* | eval_case_ex_guard (env: Environment) (e e'' guard exp: Expression) (v : Value) (ex : Exception) (patterns : list Pattern) (guards : list Expression) (bodies : list Expression) (bindings: list (Var * Value)) (i : nat) (eff1 eff2 eff3 : SideEffectList):
   length patterns = length guards ->
@@ -317,167 +327,174 @@ Inductive eval_expr : Environment -> Expression -> SideEffectList ->
 
 (* call 1x *)
 | eval_call_ex (env: Environment) (i : nat) (fname : string) (params : list Expression) 
-     (vals : list Value) (ex : Exception) (eff1 eff2 eff3 : SideEffectList) (eff : list SideEffectList) :
+     (vals : list Value) (ex : Exception) (eff1 eff2 eff3 : SideEffectList) (eff : list SideEffectList) (id : nat) (ids : list nat) :
   length vals = i ->
   i < length params ->
   length eff = i ->
+  length ids = i ->
   (forall j, j < i ->
-    |env, nth j params ErrorExp, concatn eff1 eff j|
+    |env, nth_id ids id j, nth j params ErrorExp, concatn eff1 eff j|
    -e>
-    |inl (nth j vals ErrorValue), concatn eff1 eff (S j)|
+    |nth_id ids id (S j), inl (nth j vals ErrorValue), concatn eff1 eff (S j)|
   ) ->
   eff3 = concatn eff1 eff i ++ eff2 ->
-  |env, nth i params ErrorExp, concatn eff1 eff i| -e> |inr ex, eff3|
+  |env, id, nth i params ErrorExp, concatn eff1 eff i| -e> |last ids 0, inr ex, eff3|
 
 ->
-  |env, ECall fname params, eff1| -e> |inr ex, eff3|
+  |env, id, ECall fname params, eff1| -e> |last ids 0, inr ex, eff3|
 
 (* apply 4x *)
 (** According to ref. implementation, here it is not needed to check the arg number *)
 
 (** if name expression evaluates to exception *)
 | eval_apply_ex_closure_ex (params : list Expression) (env : Environment) (exp : Expression)  
-     (ex : Exception) (eff1 eff2 eff3 : SideEffectList):
+     (ex : Exception) (eff1 eff2 eff3 : SideEffectList) (id id' : nat):
   eff3 = eff1 ++ eff2 ->
-  |env, exp, eff1| -e> |inr ex, eff3|
+  |env, id, exp, eff1| -e> |id', inr ex, eff3|
 ->
-  |env, EApply exp params, eff1| -e> |inr ex, eff3|
+  |env, id, EApply exp params, eff1| -e> |id', inr ex, eff3|
 
 (** name expression and some parameters evaluate to values *)
 | eval_apply_ex_params (params : list Expression) (vals : list Value) (env : Environment) 
      (exp : Expression) (ex : Exception) (i : nat) (v : Value) (eff1 eff2 eff3 eff4 : SideEffectList) 
-     (eff : list SideEffectList) :
+     (eff : list SideEffectList) (ids : list nat) (id id' id'' : nat) :
   i = length vals ->
   i < length params ->
-  length eff = i
+  length eff = i ->
+  length ids = i
   ->
-  |env, exp, eff1| -e> |inl v, eff1 ++ eff2| ->
+  |env, id, exp, eff1| -e> |id', inl v, eff1 ++ eff2| ->
   (forall j, j < i -> 
-    |env, nth j params ErrorExp, concatn (eff1 ++ eff2) eff j|
+    |env, nth_id ids id' j, nth j params ErrorExp, concatn (eff1 ++ eff2) eff j|
    -e>
-    |inl (nth j vals ErrorValue), concatn (eff1 ++ eff2) eff (S j)|
+    |nth_id ids id' (S j), inl (nth j vals ErrorValue), concatn (eff1 ++ eff2) eff (S j)|
   ) ->
   eff4 = concatn (eff1 ++ eff2) eff i ++ eff3 ->
-  |env, nth i params ErrorExp, concatn (eff1 ++ eff2) eff i| -e> |inr ex, eff4|
+  |env, last ids 0, nth i params ErrorExp, concatn (eff1 ++ eff2) eff i| -e> |id'', inr ex, eff4|
 ->
-  |env, EApply exp params, eff1| -e> |inr ex, eff4|
+  |env, id, EApply exp params, eff1| -e> |id'', inr ex, eff4|
 
 (** Then we check if the name expression evaluates to a closure *)
 | eval_apply_ex_closure (params : list Expression) (vals: list Value) (env : Environment) (v : Value) 
-     (exp : Expression) (eff1 eff2 eff3 : SideEffectList) (eff : list SideEffectList) :
+     (exp : Expression) (eff1 eff2 eff3 : SideEffectList) (eff : list SideEffectList) (ids : list nat) (id id' : nat):
   length params = length vals ->
   length params = length eff ->
-  |env, exp, eff1| -e> |inl v, eff1 ++ eff2| ->
+  length params = length ids ->
+  |env, id, exp, eff1| -e> |id', inl v, eff1 ++ eff2| ->
   (
     forall j : nat, j < length params ->
     (
-      |env, nth j params ErrorExp, concatn (eff1 ++ eff2) eff j|
+      |env, nth_id ids id j, nth j params ErrorExp, concatn (eff1 ++ eff2) eff j|
      -e>
-      |inl (nth j vals ErrorValue), concatn (eff1 ++ eff2) eff (S j)|
+      |nth_id ids id (S j), inl (nth j vals ErrorValue), concatn (eff1 ++ eff2) eff (S j)|
     )
   ) ->
   (forall ref ext var_list body n, 
      v <> VClosure ref ext n var_list body) ->
   eff3 = concatn (eff1 ++ eff2) eff (length params)
 ->
-  |env, EApply exp params, eff1| -e> |inr (badfun v), eff3|
+  |env, id, EApply exp params, eff1| -e> |last ids 0, inr (badfun v), eff3|
 
 (** too few or too many arguments are given *)
 | eval_apply_ex_param_count (params : list Expression) (vals : list Value) (env : Environment) 
      (exp : Expression) (body : Expression) (var_list : list Var) (ref : Environment) 
-     (ext : list (FunctionIdentifier * FunctionExpression)) (eff1 eff2 eff3 : SideEffectList) 
-     (eff : list SideEffectList) (n : nat):
+     (ext : list (nat * FunctionIdentifier * FunctionExpression)) (eff1 eff2 eff3 : SideEffectList) 
+     (eff : list SideEffectList) (n : nat) (ids : list nat) (id id' : nat):
   length params = length vals ->
   length params = length eff ->
-  |env, exp, eff1| -e> |inl (VClosure ref ext n var_list body), eff1 ++ eff2| ->
+  length params = length ids ->
+  |env, id, exp, eff1| -e> |id', inl (VClosure ref ext n var_list body), eff1 ++ eff2| ->
   (
     forall j : nat, j < length params ->
     (
-      |env, nth j params ErrorExp, concatn (eff1 ++ eff2) eff j|
+      |env, nth_id ids id j, nth j params ErrorExp, concatn (eff1 ++ eff2) eff j|
      -e>
-      |inl (nth j vals ErrorValue), concatn (eff1 ++ eff2) eff (S j)|
+      |nth_id ids id (S j), inl (nth j vals ErrorValue), concatn (eff1 ++ eff2) eff (S j)|
     )
   ) ->
   length var_list <> length vals ->
   eff3 = concatn (eff1 ++ eff2) eff (length params)
 ->
-  |env, EApply exp params, eff1| -e> |inr (badarity (VClosure ref ext n var_list body)), eff3|
+  |env, id, EApply exp params, eff1| -e> |last ids 0, inr (badarity (VClosure ref ext n var_list body)), eff3|
 
 (* let 1x *)
 | eval_let_ex_param (env: Environment) (exps: list Expression) (vals : list Value) (vars: list Var) 
       (e : Expression) (ex : Exception) (i : nat) (eff1 eff2 eff3 : SideEffectList) 
-      (eff : list SideEffectList) :
+      (eff : list SideEffectList) (id id' : nat) (ids : list nat) :
   length vals = i ->
   i < length exps ->
   length eff = i ->
+  length ids = i ->
   (forall j, j < i -> 
-    |env, nth j exps ErrorExp, concatn eff1 eff j|
+    |env, nth_id ids id j, nth j exps ErrorExp, concatn eff1 eff j|
    -e>
-    |inl (nth j vals ErrorValue), concatn eff1 eff (S j)|
+    |nth_id ids id (S j), inl (nth j vals ErrorValue), concatn eff1 eff (S j)|
   ) ->
   eff3 = concatn eff1 eff i ++ eff2 ->
-  |env, nth i exps ErrorExp, concatn eff1 eff i| -e> |inr ex, eff3|
+  |env, last ids 0, nth i exps ErrorExp, concatn eff1 eff i| -e> |id', inr ex, eff3|
 ->
-  |env, ELet vars exps e, eff1| -e> |inr ex, eff3|
+  |env, id, ELet vars exps e, eff1| -e> |id', inr ex, eff3|
 
 (* map 2x *)
 (** Exception in key list *)
 | eval_map_ex_key (kl vl: list Expression) (vvals kvals : list Value) (env: Environment) (i : nat) 
-     (ex : Exception) (eff1 eff2 eff3 : SideEffectList) (eff : list SideEffectList):
+     (ex : Exception) (eff1 eff2 eff3 : SideEffectList) (eff : list SideEffectList) (ids : list nat) (id id' : nat):
   length kl = length vl ->
   length vvals = i ->
   length kvals = i ->
   i < length kl ->
   length eff = i * 2 ->
+  length ids = i * 2 ->
   (
     forall j, j < i ->
-    |env, nth j kl ErrorExp, concatn eff1 eff (2 * j)|
+    |env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j)|
    -e>
-    | inl (nth j kvals ErrorValue), concatn eff1 eff (S (2 * j))|
+    |nth_id ids id (S(2*j)), inl (nth j kvals ErrorValue), concatn eff1 eff (S (2 * j))|
   )
   ->
   (
     forall j, j < i ->
-    |env, nth j vl ErrorExp, concatn eff1 eff (S (2 * j))|
+    |env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j))|
    -e>
-    |inl (nth j vvals ErrorValue), concatn eff1 eff (S (S (2 * j)))|
+    |nth_id ids id (S (S (2*j))), inl (nth j vvals ErrorValue), concatn eff1 eff (S (S (2 * j)))|
   )
   ->
   eff3 = concatn eff1 eff (2 * i) ++ eff2 ->
-  |env, nth i kl ErrorExp, concatn eff1 eff (2 * i)| -e> |inr ex, eff3|
+  |env, last ids 0, nth i kl ErrorExp, concatn eff1 eff (2 * i)| -e> |id', inr ex, eff3|
 ->
-  |env, EMap kl vl, eff1| -e> |inr ex, eff3|
+  |env, id, EMap kl vl, eff1| -e> |id', inr ex, eff3|
 
 (** Exception in value list *)
 | eval_map_ex_val (kl vl: list Expression) (vvals kvals : list Value) (env: Environment) (i : nat) 
-     (ex : Exception) (val : Value) (eff1 eff2 eff3 eff4 : SideEffectList) (eff : list SideEffectList) :
+     (ex : Exception) (val : Value) (eff1 eff2 eff3 eff4 : SideEffectList) (eff : list SideEffectList) (ids : list nat) (id id' id'' : nat):
   length kl = length vl ->
   length vvals = i ->
   length kvals = i ->
   i < length kl ->
   length eff = i * 2 ->
+  length ids = 2 * i ->
   (
     forall j, j < i ->
-    |env, nth j kl ErrorExp, concatn eff1 eff (2 * j)|
+    |env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j)|
    -e>
-    | inl (nth j kvals ErrorValue), concatn eff1 eff (S (2 * j))|
+    | nth_id ids id (S (2*j)), inl (nth j kvals ErrorValue), concatn eff1 eff (S (2 * j))|
   ) ->
   (
     forall j, j < i ->
-    |env, nth j vl ErrorExp, concatn eff1 eff (S (2 * j))|
+    |env, nth_id ids id (S (2*j)), nth j vl ErrorExp, concatn eff1 eff (S (2 * j))|
    -e>
-    |inl (nth j vvals ErrorValue), concatn eff1 eff (S (S (2 * j)))|
+    |nth_id ids id (S (S (2*j))), inl (nth j vvals ErrorValue), concatn eff1 eff (S (S (2 * j)))|
   )
   ->
-  |env, nth i kl ErrorExp, concatn eff1 eff (2 * i)| -e> |inl val, concatn eff1 eff (2 * i) ++ eff2|
+  |env, last ids 0, nth i kl ErrorExp, concatn eff1 eff (2 * i)| -e> |id', inl val, concatn eff1 eff (2 * i) ++ eff2|
   ->
   eff4 = concatn eff1 eff (2 * i) ++ eff2 ++ eff3
   ->
-  |env, nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2| -e> |inr ex, eff4|
+  |env, id', nth i vl ErrorExp, concatn eff1 eff (2 * i) ++ eff2| -e> |id'', inr ex, eff4|
 ->
-  |env, EMap kl vl, eff1| -e> |inr ex, eff4|
+  |env, id, EMap kl vl, eff1| -e> |id'', inr ex, eff4|
 
-where "| env , e , eff | -e> | e' , eff' |" := (eval_expr env e eff e' eff')
+where "| env , id , e , eff | -e> | id' , e' , eff' |" := (eval_expr env id e eff id' e' eff')
 .
 
 

--- a/Core_Erlang_Semantics.v
+++ b/Core_Erlang_Semantics.v
@@ -478,7 +478,7 @@ Inductive eval_expr : Environment -> nat -> Expression -> SideEffectList -> nat 
   length kvals = i ->
   i < length kl ->
   length eff = i * 2 ->
-  length ids = 2 * i ->
+  length ids = i * 2 ->
   (
     forall j, j < i ->
     |env, nth_id ids id (2*j), nth j kl ErrorExp, concatn eff1 eff (2 * j)|

--- a/Core_Erlang_Side_Effect_Exception_Tests.v
+++ b/Core_Erlang_Side_Effect_Exception_Tests.v
@@ -17,30 +17,33 @@ Definition side_exception_exp (a : Z) (s : string) :  Expression := ELet
    ["X"%string] [ECall "fwrite" [ELit (Atom s)]]
       (EApp (ELit (Integer a)) []).
 
-Example side_exception (env : Environment) (eff : SideEffectList) (a : Z) (s : string) :
-  | env, side_exception_exp a s , eff| 
+Example side_exception (env : Environment) (eff : SideEffectList) (a : Z)
+                       (s : string) (id : nat) :
+  | env, id, side_exception_exp a s , eff| 
 -e>
-  |inr (badfun (VLit (Integer a))), eff ++ [(Output, [VLit (Atom s)])]|.
+  |id, inr (badfun (VLit (Integer a))), eff ++ [(Output, [VLit (Atom s)])]|.
 Proof.
-  eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLit (Atom s)])]]); auto.
+  eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLit (Atom s)])]])
+                       (ids := [id]); auto.
   * intros. inversion H. 2: inversion H1. simpl. 
-    eapply eval_call with (vals := [VLit (Atom s)]) (eff := [[]]); auto.
+    eapply eval_call with (vals := [VLit (Atom s)]) (eff := [[]]) (ids := [id]); auto.
     - intros. inversion H0. 2: inversion H3. simpl. apply eval_lit.
     - unfold concatn. simpl. rewrite app_nil_r, app_nil_r. reflexivity.
   * unfold concatn. simpl. rewrite app_nil_r. reflexivity.
   * unfold concatn. simpl. 
-    eapply eval_apply_ex_closure with (vals := []) (eff := []) 
+    eapply eval_apply_ex_closure with (vals := []) (eff := []) (ids := [])
                                       (v := VLit (Integer a)) (eff2 := []); auto.
     - rewrite app_nil_r. apply eval_lit.
     - intros. inversion H.
     - intros. congruence.
     - unfold concatn. simpl. rewrite app_nil_r, app_nil_r. reflexivity.
+    - simpl. auto.
 Qed.
 
 Example eval_list_tail :
-  | [], ECons (ECall "fwrite" [ELit (Atom "a")]) (side_exception_exp 0 "b"), []|
+  | [], 0, ECons (ECall "fwrite" [ELit (Atom "a")]) (side_exception_exp 0 "b"), []|
 -e>
-  | inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "b")])]|.
+  | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "b")])]|.
 Proof.
   eapply eval_list_ex_tl.
   * reflexivity.
@@ -48,47 +51,48 @@ Proof.
 Qed.
 
 Example eval_list_head :
-  | [], ECons (EApp (ELit (Integer 0)) []) (ECall "fwrite" [ELit (Atom "a")]), []| 
+  | [], 0, ECons (EApp (ELit (Integer 0)) []) (ECall "fwrite" [ELit (Atom "a")]), []| 
 -e>
-  | inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
+  | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_list_ex_hd with (eff2 := [(Output, [VLit (Atom "a")])]).
   * reflexivity.
-  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
+  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H. 2: inversion H1. simpl. apply eval_lit.
     - unfold concatn. simpl. reflexivity.
-  * simpl. eapply eval_apply_ex_closure with (vals := []) (eff := []); auto.
+  * simpl. eapply eval_apply_ex_closure with (vals := []) (eff := []) (ids := []); auto.
     - apply eval_lit.
     - intros. inversion H.
     - intros. congruence.
     - reflexivity.
+    - simpl. auto.
 Qed.
 
 Example eval_tuple_s_e :
-  | [], ETuple [ECall "fwrite" [ELit (Atom "a")]; side_exception_exp 0 "b"], []|
+  | [], 0, ETuple [ECall "fwrite" [ELit (Atom "a")]; side_exception_exp 0 "b"], []|
 -e>
-  | inr (badfun (VLit (Integer 0))), 
-   [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
+  | 0, inr (badfun (VLit (Integer 0))), 
+          [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
-  eapply eval_tuple_ex with (vals := [ok]) 
+  eapply eval_tuple_ex with (vals := [ok]) (ids := [0])
                             (eff := [[(Output, [VLit (Atom "a")])]]) 
                             (i := 1); auto.
   * intros. inversion H. 2: inversion H1. simpl. 
-    eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
+    eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H0. 2: inversion H3. simpl. apply eval_lit.
   * reflexivity.
   * simpl. apply side_exception.
 Qed.
 
 Example eval_try_s_e :
-  | [], ETry (ECall "fwrite" [ELit (Atom "a")]) (side_exception_exp 0 "b") (ErrorExp)
+  | [], 0, ETry (ECall "fwrite" [ELit (Atom "a")]) (side_exception_exp 0 "b") (ErrorExp)
              "X"%string "Ex1"%string "Ex2"%string "Ex3"%string, []|
 -e>
-  | inr (badfun (VLit (Integer 0))), 
-    [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
+  | 0, inr (badfun (VLit (Integer 0))), 
+       [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
   eapply eval_try.
-  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
+  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
     - unfold concatn. simpl. reflexivity.
   * reflexivity.
@@ -96,25 +100,25 @@ Proof.
 Qed.
 
 Example eval_catch :
-  | [], ETry (side_exception_exp 0 "a") 
+  | [], 0, ETry (side_exception_exp 0 "a") 
              (ECall "fwrite" [ELit (Atom "a")]) (ECall "fwrite" [ELit (Atom "c")])
              "X"%string "Ex1"%string "Ex2"%string "Ex3"%string, []|
 -e>
-  | inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
+  | 0, inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
 Proof.
   eapply eval_try_catch.
   * apply side_exception.
   * reflexivity.
-  * simpl. eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]); auto.
+  * simpl. eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
 Qed.
 
 Example eval_case_pat :
-  | [], ECase (side_exception_exp 0 "a") [PVar "X"%string] 
-          [ELit (Atom "true")] 
-          [ECall "fwrite" [ELit (Atom "b")]], []|
+  | [],0,  ECase (side_exception_exp 0 "a") [PVar "X"%string] 
+              [ELit (Atom "true")] 
+              [ECall "fwrite" [ELit (Atom "b")]], []|
 -e>
-  | inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
+  | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_case_ex_pat; auto.
   * reflexivity.
@@ -122,19 +126,20 @@ Proof.
 Qed.
 
 Example eval_case_clause :
-  | [(inl "Y"%string, VLit (Integer 2))], 
+  | [(inl "Y"%string, VLit (Integer 2))], 0,
      ECase (ELet ["X"%string] [ECall "fwrite" [ELit (Atom "a")]] (EVar "Y"%string)) 
           [PLit (Integer 1); PVar "Z"%string]
           [ELit (Atom "true"); ELit (Atom "false")]
           [ECall "fwrite" [ELit (Atom "b")]; ECall "fwrite" [ELit (Atom "c")]], []|
 -e>
-  | inr (if_clause (VLit (Integer 2))), [(Output, [VLit (Atom "a")])]|.
+  | 0, inr (if_clause (VLit (Integer 2))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_case_clause_ex; auto.
   * reflexivity.
-  * eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]]); auto.
+  * eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]])
+                         (ids := [0]); auto.
     - intros. inversion H. 2: inversion H1.
-      apply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
+      apply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
       + intros. inversion H0. 2: inversion H3. apply eval_lit.
     - reflexivity.
     - apply eval_var.
@@ -144,28 +149,29 @@ Proof.
 Qed.
 
 Example eval_call_s_e :
-  | [], ECall "fwrite" [ECall "fwrite" [ELit (Atom "a")]; EApp (ELit (Integer 0)) []], []|
+  | [], 0, ECall "fwrite" [ECall "fwrite" [ELit (Atom "a")]; EApp (ELit (Integer 0)) []], []|
 -e>
-  | inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
+  | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
-  eapply eval_call_ex with (vals := [ok])
+  eapply eval_call_ex with (vals := [ok])(ids := [0])
                            (eff := [[(Output, [VLit (Atom "a")])]])
                            (i := 1); auto.
   * intros. inversion H. 2: inversion H1.
-    eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
+    eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
   * reflexivity.
-  * simpl. eapply eval_apply_ex_closure with (vals := []) (eff := []); auto.
+  * simpl. eapply eval_apply_ex_closure with (vals := []) (eff := []) (ids := []); auto.
     - apply eval_lit.
     - intros. inversion H.
     - intros. congruence.
     - reflexivity.
+    - auto.
 Qed.
 
 Example eval_apply_closure_ex :
-  | [], EApp (side_exception_exp 0 "a") [], []|
+  | [], 0, EApp (side_exception_exp 0 "a") [], []|
 -e>
-  | inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
+  | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_apply_ex_closure_ex.
   * reflexivity.
@@ -173,13 +179,13 @@ Proof.
 Qed.
 
 Example eval_apply_param :
-  | [], EApp (ECall "fwrite" [ELit (Atom "a")]) [side_exception_exp 0 "b"], []|
+  | [], 0, EApp (ECall "fwrite" [ELit (Atom "a")]) [side_exception_exp 0 "b"], []|
 -e>
-  | inr (badfun (VLit (Integer 0))), 
-    [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
+  | 0, inr (badfun (VLit (Integer 0))), 
+       [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
-  eapply eval_apply_ex_params with (vals := []) (eff := []); auto.
-  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
+  eapply eval_apply_ex_params with (vals := []) (eff := []) (ids := []); auto.
+  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
     - reflexivity.
   * intros. inversion H.
@@ -188,90 +194,92 @@ Proof.
 Qed.
 
 Example eval_apply_closure :
-  | [], EApp (ECall "fwrite" [ELit (Atom "a")]) [ECall "fwrite" [ELit (Atom "b")]], []|
+  | [], 0, EApp (ECall "fwrite" [ELit (Atom "a")]) [ECall "fwrite" [ELit (Atom "b")]], []|
 -e>
-  | inr (badfun ok), 
-   [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
+  | 0, inr (badfun ok), 
+      [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
-  eapply eval_apply_ex_closure with (vals := [ok])
+  eapply eval_apply_ex_closure with (vals := [ok]) (ids := [0])
                                     (eff := [[(Output, [VLit (Atom "b")])]]); auto.
-  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
+  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
     - reflexivity.
   * intros. inversion H. 2: inversion H1.
-    eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]); auto.
+    eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H0. 2: inversion H3. simpl. apply eval_lit.
   * intros. unfold ok. congruence.
   * reflexivity.
 Qed.
 
 Example eval_apply_param_len :
-  | [(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 5)))], 
+  | [(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 5)))], 1,
     EApp (EVar "X"%string) [ECall "fwrite" [ELit (Atom "a")]], []|
 -e>
-  | inr (badarity (VClos [] [] 0 [] (ELit (Integer 5)))), 
-    [(Output, [VLit (Atom "a")])]|.
+  | 1, inr (badarity (VClos [] [] 0 [] (ELit (Integer 5)))), 
+       [(Output, [VLit (Atom "a")])]|.
 Proof.
-  eapply eval_apply_ex_param_count with (vals := [ok]) (n := 0)
+  eapply eval_apply_ex_param_count with (vals := [ok]) (n := 0) (ids := [1])
                                         (eff := [[(Output, [VLit (Atom "a")])]]); auto.
   * apply eval_var.
   * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLit (Atom "a")]) 
-                                                                (eff := [[]]); auto.
+                                                                (eff := [[]]) (ids := [1]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
   * simpl. auto.
   * reflexivity.
 Qed.
 
 Example eval_let:
-  | [], ELet ["X"%string] [side_exception_exp 2 "a"] (EApp (ELit (Integer 0)) []), []|
+  | [], 0, ELet ["X"%string] [side_exception_exp 2 "a"] (EApp (ELit (Integer 0)) []), []|
 -e>
-  | inr (badfun (VLit (Integer 2))), [(Output, [VLit (Atom "a")])]|.
+  | 0, inr (badfun (VLit (Integer 2))), [(Output, [VLit (Atom "a")])]|.
 Proof.
-  eapply eval_let_ex_param with (vals := []) (eff := []) (i := 0); auto.
+  eapply eval_let_ex_param with (vals := []) (eff := []) (i := 0) (ids := []); auto.
   * intros. inversion H.
   * reflexivity.
   * apply side_exception.
 Qed.
 
 Example eval_map_key:
-  | [], EMap [ECall "fwrite" [ELit (Atom "a")]; side_exception_exp 0 "c"] 
+  | [], 0, EMap [ECall "fwrite" [ELit (Atom "a")]; side_exception_exp 0 "c"] 
              [ECall "fwrite" [ELit (Atom "b")]; ECall "fwrite" [ELit (Atom "d")]], []|
 -e>
-  | inr (badfun (VLit (Integer 0))), 
-    [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); 
-     (Output, [VLit (Atom "c")])]|.
+  | 0, inr (badfun (VLit (Integer 0))), 
+       [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); 
+        (Output, [VLit (Atom "c")])]|.
 Proof.
   eapply eval_map_ex_key with (i := 1) (kvals := [ok]) (vvals := [ok]) 
+                              (ids := [0;0])
                               (eff := [[(Output, [VLit (Atom "a")])];
                                        [(Output, [VLit (Atom "b")])]]); auto.
   * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLit (Atom "a")]) 
-                                                                (eff := [[]]); auto.
+                                                                (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
   * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLit (Atom "b")]) 
-                                                                (eff := [[]]); auto.
+                                                                (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
   * reflexivity.
   * apply side_exception.
 Qed.
 
 Example eval_map_value:
-  | [], EMap [ECall "fwrite" [ELit (Atom "a")]; ECall "fwrite" [ELit (Atom "c")]] 
+  | [], 0, EMap [ECall "fwrite" [ELit (Atom "a")]; ECall "fwrite" [ELit (Atom "c")]] 
              [ECall "fwrite" [ELit (Atom "b")]; side_exception_exp 0 "d"], []|
 -e>
-  | inr (badfun (VLit (Integer 0))), 
-    [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); 
-     (Output, [VLit (Atom "c")]); (Output, [VLit (Atom "d")])]|.
+  | 0, inr (badfun (VLit (Integer 0))), 
+        [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); 
+         (Output, [VLit (Atom "c")]); (Output, [VLit (Atom "d")])]|.
 Proof.
-  eapply eval_map_ex_val with (i := 1) (kvals := [ok]) (vvals := [ok]) 
+  eapply eval_map_ex_val with (i := 1) (kvals := [ok]) (vvals := [ok])
+                              (ids := [0;0])
                               (eff := [[(Output, [VLit (Atom "a")])]; 
                                        [(Output, [VLit (Atom "b")])]]); auto.
   * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLit (Atom "a")]) 
-                                                                (eff := [[]]); auto.
+                                                                (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
   * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLit (Atom "b")]) 
-                                                                (eff := [[]]); auto.
+                                                                (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
-  * eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]); auto.
+  * eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
     - reflexivity.
   * reflexivity.

--- a/Core_Erlang_Side_Effect_Exception_Tests.v
+++ b/Core_Erlang_Side_Effect_Exception_Tests.v
@@ -14,23 +14,23 @@ Import Core_Erlang_Side_Effects.
 Import Core_Erlang_Semantics.
 
 Definition side_exception_exp (a : Z) (s : string) :  Expression := ELet
-   ["X"%string] [ECall "fwrite" [ELiteral (Atom s)]]
-      (EApply (ELiteral (Integer a)) []).
+   ["X"%string] [ECall "fwrite" [ELit (Atom s)]]
+      (EApp (ELit (Integer a)) []).
 
 Example side_exception (env : Environment) (eff : SideEffectList) (a : Z) (s : string) :
   | env, side_exception_exp a s , eff| 
 -e>
-  |inr (badfun (VLiteral (Integer a))), eff ++ [(Output, [VLiteral (Atom s)])]|.
+  |inr (badfun (VLit (Integer a))), eff ++ [(Output, [VLit (Atom s)])]|.
 Proof.
-  eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLiteral (Atom s)])]]); auto.
+  eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLit (Atom s)])]]); auto.
   * intros. inversion H. 2: inversion H1. simpl. 
-    eapply eval_call with (vals := [VLiteral (Atom s)]) (eff := [[]]); auto.
+    eapply eval_call with (vals := [VLit (Atom s)]) (eff := [[]]); auto.
     - intros. inversion H0. 2: inversion H3. simpl. apply eval_lit.
     - unfold concatn. simpl. rewrite app_nil_r, app_nil_r. reflexivity.
   * unfold concatn. simpl. rewrite app_nil_r. reflexivity.
   * unfold concatn. simpl. 
     eapply eval_apply_ex_closure with (vals := []) (eff := []) 
-                                      (v := VLiteral (Integer a)) (eff2 := []); auto.
+                                      (v := VLit (Integer a)) (eff2 := []); auto.
     - rewrite app_nil_r. apply eval_lit.
     - intros. inversion H.
     - intros. congruence.
@@ -38,9 +38,9 @@ Proof.
 Qed.
 
 Example eval_list_tail :
-  | [], EList (ECall "fwrite" [ELiteral (Atom "a")]) (side_exception_exp 0 "b"), []|
+  | [], ECons (ECall "fwrite" [ELit (Atom "a")]) (side_exception_exp 0 "b"), []|
 -e>
-  | inr (badfun (VLiteral (Integer 0))), [(Output, [VLiteral (Atom "b")])]|.
+  | inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "b")])]|.
 Proof.
   eapply eval_list_ex_tl.
   * reflexivity.
@@ -48,13 +48,13 @@ Proof.
 Qed.
 
 Example eval_list_head :
-  | [], EList (EApply (ELiteral (Integer 0)) []) (ECall "fwrite" [ELiteral (Atom "a")]), []| 
+  | [], ECons (EApp (ELit (Integer 0)) []) (ECall "fwrite" [ELit (Atom "a")]), []| 
 -e>
-  | inr (badfun (VLiteral (Integer 0))), [(Output, [VLiteral (Atom "a")])]|.
+  | inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
-  eapply eval_list_ex_hd with (eff2 := [(Output, [VLiteral (Atom "a")])]).
+  eapply eval_list_ex_hd with (eff2 := [(Output, [VLit (Atom "a")])]).
   * reflexivity.
-  * eapply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]); auto.
+  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
     - intros. inversion H. 2: inversion H1. simpl. apply eval_lit.
     - unfold concatn. simpl. reflexivity.
   * simpl. eapply eval_apply_ex_closure with (vals := []) (eff := []); auto.
@@ -65,30 +65,30 @@ Proof.
 Qed.
 
 Example eval_tuple_s_e :
-  | [], ETuple [ECall "fwrite" [ELiteral (Atom "a")]; side_exception_exp 0 "b"], []|
+  | [], ETuple [ECall "fwrite" [ELit (Atom "a")]; side_exception_exp 0 "b"], []|
 -e>
-  | inr (badfun (VLiteral (Integer 0))), 
-   [(Output, [VLiteral (Atom "a")]); (Output, [VLiteral (Atom "b")])]|.
+  | inr (badfun (VLit (Integer 0))), 
+   [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
   eapply eval_tuple_ex with (vals := [ok]) 
-                            (eff := [[(Output, [VLiteral (Atom "a")])]]) 
+                            (eff := [[(Output, [VLit (Atom "a")])]]) 
                             (i := 1); auto.
   * intros. inversion H. 2: inversion H1. simpl. 
-    eapply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]); auto.
+    eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
     - intros. inversion H0. 2: inversion H3. simpl. apply eval_lit.
   * reflexivity.
   * simpl. apply side_exception.
 Qed.
 
 Example eval_try_s_e :
-  | [], ETry (ECall "fwrite" [ELiteral (Atom "a")]) (side_exception_exp 0 "b") (ErrorExp)
+  | [], ETry (ECall "fwrite" [ELit (Atom "a")]) (side_exception_exp 0 "b") (ErrorExp)
              "X"%string "Ex1"%string "Ex2"%string "Ex3"%string, []|
 -e>
-  | inr (badfun (VLiteral (Integer 0))), 
-    [(Output, [VLiteral (Atom "a")]); (Output, [VLiteral (Atom "b")])]|.
+  | inr (badfun (VLit (Integer 0))), 
+    [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
   eapply eval_try.
-  * eapply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]); auto.
+  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
     - unfold concatn. simpl. reflexivity.
   * reflexivity.
@@ -97,24 +97,24 @@ Qed.
 
 Example eval_catch :
   | [], ETry (side_exception_exp 0 "a") 
-             (ECall "fwrite" [ELiteral (Atom "a")]) (ECall "fwrite" [ELiteral (Atom "c")])
+             (ECall "fwrite" [ELit (Atom "a")]) (ECall "fwrite" [ELit (Atom "c")])
              "X"%string "Ex1"%string "Ex2"%string "Ex3"%string, []|
 -e>
-  | inl ok, [(Output, [VLiteral (Atom "a")]); (Output, [VLiteral (Atom "c")])]|.
+  | inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
 Proof.
   eapply eval_try_catch.
   * apply side_exception.
   * reflexivity.
-  * simpl. eapply eval_call with (vals := [VLiteral (Atom "c")]) (eff := [[]]); auto.
+  * simpl. eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
 Qed.
 
 Example eval_case_pat :
   | [], ECase (side_exception_exp 0 "a") [PVar "X"%string] 
-          [ELiteral (Atom "true")] 
-          [ECall "fwrite" [ELiteral (Atom "b")]], []|
+          [ELit (Atom "true")] 
+          [ECall "fwrite" [ELit (Atom "b")]], []|
 -e>
-  | inr (badfun (VLiteral (Integer 0))), [(Output, [VLiteral (Atom "a")])]|.
+  | inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_case_ex_pat; auto.
   * reflexivity.
@@ -122,19 +122,19 @@ Proof.
 Qed.
 
 Example eval_case_clause :
-  | [(inl "Y"%string, VLiteral (Integer 2))], 
-     ECase (ELet ["X"%string] [ECall "fwrite" [ELiteral (Atom "a")]] (EVar "Y"%string)) 
-          [PLiteral (Integer 1); PVar "Z"%string]
-          [ELiteral (Atom "true"); ELiteral (Atom "false")]
-          [ECall "fwrite" [ELiteral (Atom "b")]; ECall "fwrite" [ELiteral (Atom "c")]], []|
+  | [(inl "Y"%string, VLit (Integer 2))], 
+     ECase (ELet ["X"%string] [ECall "fwrite" [ELit (Atom "a")]] (EVar "Y"%string)) 
+          [PLit (Integer 1); PVar "Z"%string]
+          [ELit (Atom "true"); ELit (Atom "false")]
+          [ECall "fwrite" [ELit (Atom "b")]; ECall "fwrite" [ELit (Atom "c")]], []|
 -e>
-  | inr (if_clause (VLiteral (Integer 2))), [(Output, [VLiteral (Atom "a")])]|.
+  | inr (if_clause (VLit (Integer 2))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_case_clause_ex; auto.
   * reflexivity.
-  * eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLiteral (Atom "a")])]]); auto.
+  * eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]]); auto.
     - intros. inversion H. 2: inversion H1.
-      apply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]); auto.
+      apply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
       + intros. inversion H0. 2: inversion H3. apply eval_lit.
     - reflexivity.
     - apply eval_var.
@@ -144,15 +144,15 @@ Proof.
 Qed.
 
 Example eval_call_s_e :
-  | [], ECall "fwrite" [ECall "fwrite" [ELiteral (Atom "a")]; EApply (ELiteral (Integer 0)) []], []|
+  | [], ECall "fwrite" [ECall "fwrite" [ELit (Atom "a")]; EApp (ELit (Integer 0)) []], []|
 -e>
-  | inr (badfun (VLiteral (Integer 0))), [(Output, [VLiteral (Atom "a")])]|.
+  | inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_call_ex with (vals := [ok])
-                           (eff := [[(Output, [VLiteral (Atom "a")])]])
+                           (eff := [[(Output, [VLit (Atom "a")])]])
                            (i := 1); auto.
   * intros. inversion H. 2: inversion H1.
-    eapply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]); auto.
+    eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
   * reflexivity.
   * simpl. eapply eval_apply_ex_closure with (vals := []) (eff := []); auto.
@@ -163,9 +163,9 @@ Proof.
 Qed.
 
 Example eval_apply_closure_ex :
-  | [], EApply (side_exception_exp 0 "a") [], []|
+  | [], EApp (side_exception_exp 0 "a") [], []|
 -e>
-  | inr (badfun (VLiteral (Integer 0))), [(Output, [VLiteral (Atom "a")])]|.
+  | inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_apply_ex_closure_ex.
   * reflexivity.
@@ -173,13 +173,13 @@ Proof.
 Qed.
 
 Example eval_apply_param :
-  | [], EApply (ECall "fwrite" [ELiteral (Atom "a")]) [side_exception_exp 0 "b"], []|
+  | [], EApp (ECall "fwrite" [ELit (Atom "a")]) [side_exception_exp 0 "b"], []|
 -e>
-  | inr (badfun (VLiteral (Integer 0))), 
-    [(Output, [VLiteral (Atom "a")]); (Output, [VLiteral (Atom "b")])]|.
+  | inr (badfun (VLit (Integer 0))), 
+    [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
   eapply eval_apply_ex_params with (vals := []) (eff := []); auto.
-  * eapply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]); auto.
+  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
     - reflexivity.
   * intros. inversion H.
@@ -188,34 +188,34 @@ Proof.
 Qed.
 
 Example eval_apply_closure :
-  | [], EApply (ECall "fwrite" [ELiteral (Atom "a")]) [ECall "fwrite" [ELiteral (Atom "b")]], []|
+  | [], EApp (ECall "fwrite" [ELit (Atom "a")]) [ECall "fwrite" [ELit (Atom "b")]], []|
 -e>
   | inr (badfun ok), 
-   [(Output, [VLiteral (Atom "a")]); (Output, [VLiteral (Atom "b")])]|.
+   [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
   eapply eval_apply_ex_closure with (vals := [ok])
-                                    (eff := [[(Output, [VLiteral (Atom "b")])]]); auto.
-  * eapply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]); auto.
+                                    (eff := [[(Output, [VLit (Atom "b")])]]); auto.
+  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
     - reflexivity.
   * intros. inversion H. 2: inversion H1.
-    eapply eval_call with (vals := [VLiteral (Atom "b")]) (eff := [[]]); auto.
+    eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]); auto.
     - intros. inversion H0. 2: inversion H3. simpl. apply eval_lit.
   * intros. unfold ok. congruence.
   * reflexivity.
 Qed.
 
 Example eval_apply_param_len :
-  | [(inl "X"%string, VClosure [] [] 0 [] (ELiteral (Integer 5)))], 
-    EApply (EVar "X"%string) [ECall "fwrite" [ELiteral (Atom "a")]], []|
+  | [(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 5)))], 
+    EApp (EVar "X"%string) [ECall "fwrite" [ELit (Atom "a")]], []|
 -e>
-  | inr (badarity (VClosure [] [] 0 [] (ELiteral (Integer 5)))), 
-    [(Output, [VLiteral (Atom "a")])]|.
+  | inr (badarity (VClos [] [] 0 [] (ELit (Integer 5)))), 
+    [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_apply_ex_param_count with (vals := [ok]) (n := 0)
-                                        (eff := [[(Output, [VLiteral (Atom "a")])]]); auto.
+                                        (eff := [[(Output, [VLit (Atom "a")])]]); auto.
   * apply eval_var.
-  * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLiteral (Atom "a")]) 
+  * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLit (Atom "a")]) 
                                                                 (eff := [[]]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
   * simpl. auto.
@@ -223,9 +223,9 @@ Proof.
 Qed.
 
 Example eval_let:
-  | [], ELet ["X"%string] [side_exception_exp 2 "a"] (EApply (ELiteral (Integer 0)) []), []|
+  | [], ELet ["X"%string] [side_exception_exp 2 "a"] (EApp (ELit (Integer 0)) []), []|
 -e>
-  | inr (badfun (VLiteral (Integer 2))), [(Output, [VLiteral (Atom "a")])]|.
+  | inr (badfun (VLit (Integer 2))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_let_ex_param with (vals := []) (eff := []) (i := 0); auto.
   * intros. inversion H.
@@ -234,20 +234,20 @@ Proof.
 Qed.
 
 Example eval_map_key:
-  | [], EMap [ECall "fwrite" [ELiteral (Atom "a")]; side_exception_exp 0 "c"] 
-             [ECall "fwrite" [ELiteral (Atom "b")]; ECall "fwrite" [ELiteral (Atom "d")]], []|
+  | [], EMap [ECall "fwrite" [ELit (Atom "a")]; side_exception_exp 0 "c"] 
+             [ECall "fwrite" [ELit (Atom "b")]; ECall "fwrite" [ELit (Atom "d")]], []|
 -e>
-  | inr (badfun (VLiteral (Integer 0))), 
-    [(Output, [VLiteral (Atom "a")]); (Output, [VLiteral (Atom "b")]); 
-     (Output, [VLiteral (Atom "c")])]|.
+  | inr (badfun (VLit (Integer 0))), 
+    [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); 
+     (Output, [VLit (Atom "c")])]|.
 Proof.
   eapply eval_map_ex_key with (i := 1) (kvals := [ok]) (vvals := [ok]) 
-                              (eff := [[(Output, [VLiteral (Atom "a")])];
-                                       [(Output, [VLiteral (Atom "b")])]]); auto.
-  * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLiteral (Atom "a")]) 
+                              (eff := [[(Output, [VLit (Atom "a")])];
+                                       [(Output, [VLit (Atom "b")])]]); auto.
+  * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLit (Atom "a")]) 
                                                                 (eff := [[]]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
-  * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLiteral (Atom "b")]) 
+  * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLit (Atom "b")]) 
                                                                 (eff := [[]]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
   * reflexivity.
@@ -255,23 +255,23 @@ Proof.
 Qed.
 
 Example eval_map_value:
-  | [], EMap [ECall "fwrite" [ELiteral (Atom "a")]; ECall "fwrite" [ELiteral (Atom "c")]] 
-             [ECall "fwrite" [ELiteral (Atom "b")]; side_exception_exp 0 "d"], []|
+  | [], EMap [ECall "fwrite" [ELit (Atom "a")]; ECall "fwrite" [ELit (Atom "c")]] 
+             [ECall "fwrite" [ELit (Atom "b")]; side_exception_exp 0 "d"], []|
 -e>
-  | inr (badfun (VLiteral (Integer 0))), 
-    [(Output, [VLiteral (Atom "a")]); (Output, [VLiteral (Atom "b")]); 
-     (Output, [VLiteral (Atom "c")]); (Output, [VLiteral (Atom "d")])]|.
+  | inr (badfun (VLit (Integer 0))), 
+    [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); 
+     (Output, [VLit (Atom "c")]); (Output, [VLit (Atom "d")])]|.
 Proof.
   eapply eval_map_ex_val with (i := 1) (kvals := [ok]) (vvals := [ok]) 
-                              (eff := [[(Output, [VLiteral (Atom "a")])]; 
-                                       [(Output, [VLiteral (Atom "b")])]]); auto.
-  * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLiteral (Atom "a")]) 
+                              (eff := [[(Output, [VLit (Atom "a")])]; 
+                                       [(Output, [VLit (Atom "b")])]]); auto.
+  * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLit (Atom "a")]) 
                                                                 (eff := [[]]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
-  * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLiteral (Atom "b")]) 
+  * intros. inversion H. 2: inversion H1. eapply eval_call with (vals := [VLit (Atom "b")]) 
                                                                 (eff := [[]]); auto.
     - intros. inversion H0. 2: inversion H3. apply eval_lit.
-  * eapply eval_call with (vals := [VLiteral (Atom "c")]) (eff := [[]]); auto.
+  * eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
     - reflexivity.
   * reflexivity.

--- a/Core_Erlang_Side_Effect_Tests.v
+++ b/Core_Erlang_Side_Effect_Tests.v
@@ -15,23 +15,23 @@ Import Core_Erlang_Semantics.
 
 
 Example tuple_eff :
-  |[], ETuple [ECall "fwrite"%string [ELiteral (Atom "a"%string)];
-               ECall "fwrite"%string [ELiteral (Atom "b"%string)];
-               ECall "fread"%string [ELiteral (Atom ""%string) ; ELiteral (Atom "c"%string)]], []|
+  |[], ETuple [ECall "fwrite"%string [ELit (Atom "a"%string)];
+               ECall "fwrite"%string [ELit (Atom "b"%string)];
+               ECall "fread"%string [ELit (Atom ""%string) ; ELit (Atom "c"%string)]], []|
 -e>
-  |inl (VTuple [ok;ok; VTuple [ok; VLiteral (Atom "c"%string)]]), 
-   [(Output, [VLiteral (Atom "a"%string)]); (Output, [VLiteral (Atom "b"%string)]);
-    (Input, [VLiteral (Atom ""%string); VLiteral (Atom "c"%string)])]|.
+  |inl (VTuple [ok;ok; VTuple [ok; VLit (Atom "c"%string)]]), 
+   [(Output, [VLit (Atom "a"%string)]); (Output, [VLit (Atom "b"%string)]);
+    (Input, [VLit (Atom ""%string); VLit (Atom "c"%string)])]|.
 Proof.
-  apply eval_tuple with (eff := [[(Output, [VLiteral (Atom "a"%string)])]; 
-                                 [(Output, [VLiteral (Atom "b"%string)])]; 
-                                 [(Input, [VLiteral (Atom ""%string); 
-                                           VLiteral (Atom "c"%string)])]]).
+  apply eval_tuple with (eff := [[(Output, [VLit (Atom "a"%string)])]; 
+                                 [(Output, [VLit (Atom "b"%string)])]; 
+                                 [(Input, [VLit (Atom ""%string); 
+                                           VLit (Atom "c"%string)])]]).
   * reflexivity.
   * simpl. reflexivity.
   * intros. inversion H.
-    - subst. simpl. apply eval_call with (vals := [VLiteral (Atom ""%string); 
-                                                   VLiteral (Atom "c"%string)])
+    - subst. simpl. apply eval_call with (vals := [VLit (Atom ""%string); 
+                                                   VLit (Atom "c"%string)])
                                          (eff := [ []; [] ]).
       + reflexivity.
       + reflexivity.
@@ -41,7 +41,7 @@ Proof.
           -- apply eval_lit.
           -- inversion H4.
       + unfold concatn. simpl. reflexivity.
-    - inversion H1. simpl. apply eval_call with (vals := [VLiteral (Atom "b"%string)])
+    - inversion H1. simpl. apply eval_call with (vals := [VLit (Atom "b"%string)])
                                                 (eff := [[]]).
       + reflexivity.
       + reflexivity.
@@ -49,7 +49,7 @@ Proof.
         ** apply eval_lit.
         ** inversion H5.
       + simpl. reflexivity.
-      + inversion H3. simpl. apply eval_call with (vals := [VLiteral (Atom "a"%string)])
+      + inversion H3. simpl. apply eval_call with (vals := [VLit (Atom "a"%string)])
                                                   (eff := [[]]).
         ** reflexivity.
         ** reflexivity.
@@ -62,20 +62,20 @@ Proof.
 Qed.
 
 Example list_eff :
-  |[], EList (ECall "fwrite"%string [ELiteral (Atom "a")])
-             (EList (ECall "fwrite"%string [ELiteral (Atom "b")]) EEmptyList), []|
+  |[], ECons (ECall "fwrite"%string [ELit (Atom "a")])
+             (ECons (ECall "fwrite"%string [ELit (Atom "b")]) ENil), []|
 -e> 
-  |inl (VList ok (VList ok VEmptyList)), 
-   [(Output, [VLiteral (Atom "b")]); (Output, [VLiteral (Atom "a")])]|.
+  |inl (VCons ok (VCons ok VNil)), 
+   [(Output, [VLit (Atom "b")]); (Output, [VLit (Atom "a")])]|.
 Proof.
-  eapply eval_list with (eff2 := [(Output, [VLiteral (Atom "b")])]).
+  eapply eval_list with (eff2 := [(Output, [VLit (Atom "b")])]).
   * simpl. reflexivity.
   * simpl. eapply eval_list with (eff2 := []).
     - simpl. reflexivity.
     - apply eval_emptylist.
-    - eapply eval_call with (vals := [VLiteral (Atom "b")]) (eff := [[]]); auto.
+    - eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]); auto.
       + intros. inversion H. 2: inversion H1. apply eval_lit.
-  * simpl. eapply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]).
+  * simpl. eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]).
     - reflexivity.
     - reflexivity.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
@@ -83,19 +83,19 @@ Proof.
 Qed.
 
 Example case_eff : 
-  |[], ECase (ECall "fwrite"%string [ELiteral (Atom "a")])
-           [PVar "X"%string; PLiteral (Integer 5); PVar "Y"%string]
-           [ELiteral (Atom "false"); ELiteral (Atom "true"); 
-            ELiteral (Atom "true")]
-           [(ECall "fwrite"%string [ELiteral (Atom "b")]); 
-            ELiteral (Integer 2); 
-            (ECall "fwrite"%string [ELiteral (Atom "c")])]
+  |[], ECase (ECall "fwrite"%string [ELit (Atom "a")])
+           [PVar "X"%string; PLit (Integer 5); PVar "Y"%string]
+           [ELit (Atom "false"); ELit (Atom "true"); 
+            ELit (Atom "true")]
+           [(ECall "fwrite"%string [ELit (Atom "b")]); 
+            ELit (Integer 2); 
+            (ECall "fwrite"%string [ELit (Atom "c")])]
   , []|
 -e>
-  |inl ok, [(Output, [VLiteral (Atom "a")]); (Output, [VLiteral (Atom "c")])]|.
+  |inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
 Proof.
   eapply eval_case with (i := 2); auto.
-  * eapply eval_call with (vals := [VLiteral (Atom "a")]) (eff :=[[]]); auto.
+  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff :=[[]]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
     - simpl. reflexivity.
   * simpl. reflexivity.
@@ -104,116 +104,116 @@ Proof.
     - subst. inversion H0. apply eval_lit.
   * simpl. reflexivity.
   * simpl. apply eval_lit.
-  * simpl. eapply eval_call with (vals := [VLiteral (Atom "c")]) (eff := [[]]); auto.
+  * simpl. eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]); auto.
     - intros. inversion H. 2: inversion H1. unfold concatn. simpl. apply eval_lit.
 Qed.
 
 Example call_eff :
-  |[], ECall "fwrite"%string [ECall "fwrite"%string [ELiteral (Atom "a")]], []|
+  |[], ECall "fwrite"%string [ECall "fwrite"%string [ELit (Atom "a")]], []|
 -e>
-  |inl ok, [(Output, [VLiteral (Atom "a")]); (Output, [ok])]|.
+  |inl ok, [(Output, [VLit (Atom "a")]); (Output, [ok])]|.
 Proof.
-  eapply eval_call with (vals := [ok]) (eff := [[(Output, [VLiteral (Atom "a")])]]); auto.
+  eapply eval_call with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]]); auto.
   * intros. inversion H. 2: inversion H1. simpl. 
-    eapply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]); auto.
+    eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
     - intros. inversion H0. 2: inversion H3. unfold concatn. simpl. apply eval_lit.
 Qed.
 
 Example apply_eff : 
-  |[(inl "Y"%string, VClosure [] [] 0 ["Z"%string] (ECall "fwrite"%string [ELiteral (Atom "c")]))], 
-    EApply (ELet ["X"%string] [ECall "fwrite"%string [ELiteral (Atom "a")]] 
+  |[(inl "Y"%string, VClos [] [] 0 ["Z"%string] (ECall "fwrite"%string [ELit (Atom "c")]))], 
+    EApp (ELet ["X"%string] [ECall "fwrite"%string [ELit (Atom "a")]] 
              (EVar "Y"%string))
-           [ECall "fwrite" [ELiteral (Atom "b")] ], []|
+           [ECall "fwrite" [ELit (Atom "b")] ], []|
 -e>
   |inl ok, 
-   [(Output, [VLiteral (Atom "a")]);
-    (Output, [VLiteral (Atom "b")]);
-    (Output, [VLiteral (Atom "c")])]|.
+   [(Output, [VLit (Atom "a")]);
+    (Output, [VLit (Atom "b")]);
+    (Output, [VLit (Atom "c")])]|.
 Proof.
-  eapply eval_apply with (vals := [ok]) (eff := [[(Output, [VLiteral (Atom "b")])]]) 
+  eapply eval_apply with (vals := [ok]) (eff := [[(Output, [VLit (Atom "b")])]]) 
                          (ref := []) (ext := []) (var_list := ["Z"%string]) (n := 0)
-                         (body := ECall "fwrite"%string [ELiteral (Atom "c")]).
+                         (body := ECall "fwrite"%string [ELit (Atom "c")]).
   * reflexivity.
-  * eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLiteral (Atom "a")])]]).
+  * eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]]).
     - reflexivity.
     - reflexivity.
     - intros. inversion H. 2: inversion H1. 
-      eapply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]); auto.
+      eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
       + intros. inversion H0. 2: inversion H3. apply eval_lit.
     - unfold concatn. simpl. reflexivity.
     - simpl. apply eval_var.
   * reflexivity.
   * reflexivity.
   * intros. inversion H. 2: inversion H1. unfold concatn. simpl. 
-    apply eval_call with (vals := [VLiteral (Atom "b")]) (eff := [[]]); auto.
+    apply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]); auto.
     - intros. inversion H0. 2: inversion H3. simpl. apply eval_lit.
   * unfold concatn. simpl. reflexivity.
-  * simpl. eapply eval_call with (vals := [VLiteral (Atom "c")]) (eff := [[]]); auto.
+  * simpl. eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
 Qed.
 
 Example let_eff : 
-  |[], ELet ["X"%string; "Y"%string] [ECall "fwrite"%string [ELiteral (Atom "a")]; 
-                                      EFun [] (ECall "fwrite"%string [ELiteral (Atom "b")])]
-          (EApply (EVar "Y"%string) []), []|
+  |[], ELet ["X"%string; "Y"%string] [ECall "fwrite"%string [ELit (Atom "a")]; 
+                                      EFun [] (ECall "fwrite"%string [ELit (Atom "b")])]
+          (EApp (EVar "Y"%string) []), []|
 -e>
-  |inl ok, [(Output, [VLiteral (Atom "a")]); (Output, [VLiteral (Atom "b")])]|.
+  |inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
   eapply eval_let with (vals := [ok;
-                                 VClosure [] [] 0 [] (ECall "fwrite"%string [ELiteral (Atom "b")])])
-                       (eff := [[(Output, [VLiteral (Atom "a")])]; []]); auto.
+                                 VClos [] [] 0 [] (ECall "fwrite"%string [ELit (Atom "b")])])
+                       (eff := [[(Output, [VLit (Atom "a")])]; []]); auto.
   * intros. inversion H. 2: inversion H1. 3: inversion H3.
     - simpl. apply eval_fun.
-    - simpl. eapply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]); auto.
+    - simpl. eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
       + intros. inversion H2. 2: inversion H5. apply eval_lit. 
   * unfold concatn. simpl. reflexivity.
   * eapply eval_apply with (vals := []) (var_list := []) 
                            (ref := []) (ext := []) (n := 0)
-                           (body := ECall "fwrite"%string [ELiteral (Atom "b")]) 
+                           (body := ECall "fwrite"%string [ELit (Atom "b")]) 
                            (eff := []); auto.
     - simpl. apply eval_var.
     - intros. inversion H.
     - simpl. reflexivity.
-    - simpl. eapply eval_call with (vals := [VLiteral (Atom "b")]) (eff := [[]]); auto.
+    - simpl. eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]); auto.
       + intros. inversion H. 2: inversion H1. apply eval_lit.
 Qed.
 
 Example letrec_eff : 
-  |[], ELetrec [("f1"%string, 0)] [[]] 
-              [ECall "fwrite"%string [ELiteral (Atom "a")]]
-        (EApply (EFunId ("f1"%string, 0)) []), []|
+  |[], ELetRec [("f1"%string, 0)] [[]] 
+              [ECall "fwrite"%string [ELit (Atom "a")]]
+        (EApp (EFunId ("f1"%string, 0)) []), []|
 -e>
-  |inl ok, [(Output, [VLiteral (Atom "a")])]|.
+  |inl ok, [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_letrec; auto.
   2 : reflexivity.
   * simpl. eapply eval_apply with (vals := []) (eff := []) (ref := []) 
                                   (ext := [("f1"%string, 0, ([], ECall "fwrite" 
-                                                                 [ELiteral (Atom "a")]))]) 
+                                                                 [ELit (Atom "a")]))]) 
                                   (var_list := []) (n := 0)
-                                  (body := ECall "fwrite"%string [ELiteral (Atom "a")]); auto.
+                                  (body := ECall "fwrite"%string [ELit (Atom "a")]); auto.
     - apply eval_funid.
     - intros. inversion H.
     - simpl. reflexivity.
-    - simpl. apply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]); auto.
+    - simpl. apply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
       + intros. inversion H. 2: inversion H1. apply eval_lit.
 Qed.
 
 Example map_eff : 
-  |[], EMap [ECall "fwrite"%string [ELiteral (Atom "a"%string)];
-             ECall "fwrite"%string [ELiteral (Atom "c"%string)]]
-            [ECall "fwrite"%string [ELiteral (Atom "b"%string)];
-             ELiteral (Integer 5)], []| 
+  |[], EMap [ECall "fwrite"%string [ELit (Atom "a"%string)];
+             ECall "fwrite"%string [ELit (Atom "c"%string)]]
+            [ECall "fwrite"%string [ELit (Atom "b"%string)];
+             ELit (Integer 5)], []| 
 -e> 
-  | inl (VMap [ok] [VLiteral (Integer 5)]),
-    [(Output, [VLiteral (Atom "a"%string)]);
-     (Output, [VLiteral (Atom "b"%string)]);
-     (Output, [VLiteral (Atom "c"%string)])]|.
+  | inl (VMap [ok] [VLit (Integer 5)]),
+    [(Output, [VLit (Atom "a"%string)]);
+     (Output, [VLit (Atom "b"%string)]);
+     (Output, [VLit (Atom "c"%string)])]|.
 Proof.
-  apply eval_map with (kvals := [ok; ok]) (vvals := [ok; VLiteral (Integer 5)])
-                      (eff := [[(Output, [VLiteral (Atom "a")])]; 
-                               [(Output, [VLiteral (Atom "b")])]; 
-                               [(Output, [VLiteral (Atom "c")])]; 
+  apply eval_map with (kvals := [ok; ok]) (vvals := [ok; VLit (Integer 5)])
+                      (eff := [[(Output, [VLit (Atom "a")])]; 
+                               [(Output, [VLit (Atom "b")])]; 
+                               [(Output, [VLit (Atom "c")])]; 
                                []]).
   * reflexivity.
   * reflexivity.
@@ -221,7 +221,7 @@ Proof.
   * reflexivity.
   * simpl. reflexivity.
   * unfold concatn. intros. inversion H.
-    - apply eval_call with (vals := [VLiteral (Atom "c")]) (eff := [[]]).
+    - apply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]).
       + reflexivity.
       + reflexivity.
       + intros. inversion H0.
@@ -229,7 +229,7 @@ Proof.
         ** inversion H3.
       + unfold concatn. simpl. reflexivity.
     - inversion H1.
-      + simpl. apply eval_call with (vals := [VLiteral (Atom "a")]) (eff := [[]]).
+      + simpl. apply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]).
         ** reflexivity.
         ** reflexivity.
         ** intros. inversion H2. 2: inversion H5. simpl. apply eval_lit.
@@ -238,7 +238,7 @@ Proof.
   * intros. inversion H.
     - simpl. apply eval_lit.
     - inversion H1.
-      + apply eval_call with (vals := [VLiteral (Atom "b")]) (eff := [[]]).
+      + apply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]).
         ** reflexivity.
         ** reflexivity.
         ** intros. inversion H2. 2: inversion H5. simpl. apply eval_lit.

--- a/Core_Erlang_Side_Effect_Tests.v
+++ b/Core_Erlang_Side_Effect_Tests.v
@@ -15,87 +15,74 @@ Import Core_Erlang_Semantics.
 
 
 Example tuple_eff :
-  |[], ETuple [ECall "fwrite"%string [ELit (Atom "a"%string)];
+  |[], 0, ETuple [ECall "fwrite"%string [ELit (Atom "a"%string)];
                ECall "fwrite"%string [ELit (Atom "b"%string)];
                ECall "fread"%string [ELit (Atom ""%string) ; ELit (Atom "c"%string)]], []|
 -e>
-  |inl (VTuple [ok;ok; VTuple [ok; VLit (Atom "c"%string)]]), 
-   [(Output, [VLit (Atom "a"%string)]); (Output, [VLit (Atom "b"%string)]);
-    (Input, [VLit (Atom ""%string); VLit (Atom "c"%string)])]|.
+  |0, inl (VTuple [ok;ok; VTuple [ok; VLit (Atom "c"%string)]]), 
+     [(Output, [VLit (Atom "a"%string)]); (Output, [VLit (Atom "b"%string)]);
+      (Input, [VLit (Atom ""%string); VLit (Atom "c"%string)])]|.
 Proof.
   apply eval_tuple with (eff := [[(Output, [VLit (Atom "a"%string)])]; 
                                  [(Output, [VLit (Atom "b"%string)])]; 
                                  [(Input, [VLit (Atom ""%string); 
-                                           VLit (Atom "c"%string)])]]).
-  * reflexivity.
-  * simpl. reflexivity.
+                                           VLit (Atom "c"%string)])]])
+                        (ids := [0;0;0]); auto.
   * intros. inversion H.
     - subst. simpl. apply eval_call with (vals := [VLit (Atom ""%string); 
                                                    VLit (Atom "c"%string)])
-                                         (eff := [ []; [] ]).
-      + reflexivity.
-      + reflexivity.
+                                         (eff := [ []; [] ])
+                                         (ids := [0 ; 0]); auto.
       + intros. inversion H0.
         ** subst. unfold concatn. simpl. apply eval_lit. 
         ** inversion H2.
           -- apply eval_lit.
           -- inversion H4.
-      + unfold concatn. simpl. reflexivity.
     - inversion H1. simpl. apply eval_call with (vals := [VLit (Atom "b"%string)])
-                                                (eff := [[]]).
-      + reflexivity.
-      + reflexivity.
+                                                (eff := [[]]) (ids := [0]); auto.
       + intros. inversion H2.
         ** apply eval_lit.
         ** inversion H5.
-      + simpl. reflexivity.
       + inversion H3. simpl. apply eval_call with (vals := [VLit (Atom "a"%string)])
-                                                  (eff := [[]]).
-        ** reflexivity.
-        ** reflexivity.
+                                                  (eff := [[]]) (ids := [0]); auto.
         ** intros. inversion H4.
           -- apply eval_lit.
           -- inversion H7.
-        ** simpl. reflexivity.
         ** inversion H5.
-  * unfold concatn. simpl. reflexivity.
 Qed.
 
 Example list_eff :
-  |[], ECons (ECall "fwrite"%string [ELit (Atom "a")])
+  |[], 0, ECons (ECall "fwrite"%string [ELit (Atom "a")])
              (ECons (ECall "fwrite"%string [ELit (Atom "b")]) ENil), []|
 -e> 
-  |inl (VCons ok (VCons ok VNil)), 
-   [(Output, [VLit (Atom "b")]); (Output, [VLit (Atom "a")])]|.
+  | 0, inl (VCons ok (VCons ok VNil)), 
+     [(Output, [VLit (Atom "b")]); (Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_list with (eff2 := [(Output, [VLit (Atom "b")])]).
   * simpl. reflexivity.
   * simpl. eapply eval_list with (eff2 := []).
     - simpl. reflexivity.
     - apply eval_emptylist.
-    - eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]); auto.
+    - eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]) (ids := [0]); auto.
       + intros. inversion H. 2: inversion H1. apply eval_lit.
-  * simpl. eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]).
-    - reflexivity.
-    - reflexivity.
+  * simpl. eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
-    - reflexivity.
 Qed.
 
 Example case_eff : 
-  |[], ECase (ECall "fwrite"%string [ELit (Atom "a")])
-           [PVar "X"%string; PLit (Integer 5); PVar "Y"%string]
-           [ELit (Atom "false"); ELit (Atom "true"); 
-            ELit (Atom "true")]
-           [(ECall "fwrite"%string [ELit (Atom "b")]); 
-            ELit (Integer 2); 
-            (ECall "fwrite"%string [ELit (Atom "c")])]
+  |[], 0, ECase (ECall "fwrite"%string [ELit (Atom "a")])
+               [PVar "X"%string; PLit (Integer 5); PVar "Y"%string]
+               [ELit (Atom "false"); ELit (Atom "true"); 
+                ELit (Atom "true")]
+               [(ECall "fwrite"%string [ELit (Atom "b")]); 
+                ELit (Integer 2); 
+               (ECall "fwrite"%string [ELit (Atom "c")])]
   , []|
 -e>
-  |inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
+  |0, inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
 Proof.
   eapply eval_case with (i := 2); auto.
-  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff :=[[]]); auto.
+  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff :=[[]]) (ids := [0]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
     - simpl. reflexivity.
   * simpl. reflexivity.
@@ -104,147 +91,130 @@ Proof.
     - subst. inversion H0. apply eval_lit.
   * simpl. reflexivity.
   * simpl. apply eval_lit.
-  * simpl. eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]); auto.
+  * simpl. eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H. 2: inversion H1. unfold concatn. simpl. apply eval_lit.
 Qed.
 
 Example call_eff :
-  |[], ECall "fwrite"%string [ECall "fwrite"%string [ELit (Atom "a")]], []|
+  |[], 0, ECall "fwrite"%string [ECall "fwrite"%string [ELit (Atom "a")]], []|
 -e>
-  |inl ok, [(Output, [VLit (Atom "a")]); (Output, [ok])]|.
+  | 0, inl ok, [(Output, [VLit (Atom "a")]); (Output, [ok])]|.
 Proof.
-  eapply eval_call with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]]); auto.
+  eapply eval_call with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [0]); auto.
   * intros. inversion H. 2: inversion H1. simpl. 
-    eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
+    eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
     - intros. inversion H0. 2: inversion H3. unfold concatn. simpl. apply eval_lit.
 Qed.
 
 Example apply_eff : 
-  |[(inl "Y"%string, VClos [] [] 0 ["Z"%string] (ECall "fwrite"%string [ELit (Atom "c")]))], 
+  |[(inl "Y"%string, VClos [] [] 0 ["Z"%string] (ECall "fwrite"%string [ELit (Atom "c")]))], 1, 
     EApp (ELet ["X"%string] [ECall "fwrite"%string [ELit (Atom "a")]] 
              (EVar "Y"%string))
            [ECall "fwrite" [ELit (Atom "b")] ], []|
 -e>
-  |inl ok, 
+  |1, inl ok, 
    [(Output, [VLit (Atom "a")]);
     (Output, [VLit (Atom "b")]);
     (Output, [VLit (Atom "c")])]|.
 Proof.
   eapply eval_apply with (vals := [ok]) (eff := [[(Output, [VLit (Atom "b")])]]) 
                          (ref := []) (ext := []) (var_list := ["Z"%string]) (n := 0)
-                         (body := ECall "fwrite"%string [ELit (Atom "c")]).
-  * reflexivity.
-  * eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]]).
-    - reflexivity.
-    - reflexivity.
+                         (body := ECall "fwrite"%string [ELit (Atom "c")]) (ids := [1]); auto.
+  * eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [1]); auto.
     - intros. inversion H. 2: inversion H1. 
-      eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
+      eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [1]); auto.
       + intros. inversion H0. 2: inversion H3. apply eval_lit.
     - unfold concatn. simpl. reflexivity.
     - simpl. apply eval_var.
-  * reflexivity.
-  * reflexivity.
   * intros. inversion H. 2: inversion H1. unfold concatn. simpl. 
-    apply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]); auto.
+    apply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]) (ids := [1]); auto.
     - intros. inversion H0. 2: inversion H3. simpl. apply eval_lit.
   * unfold concatn. simpl. reflexivity.
-  * simpl. eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]); auto.
+  * simpl. eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]) (ids := [1]); auto.
     - intros. inversion H. 2: inversion H1. apply eval_lit.
 Qed.
 
 Example let_eff : 
-  |[], ELet ["X"%string; "Y"%string] [ECall "fwrite"%string [ELit (Atom "a")]; 
-                                      EFun [] (ECall "fwrite"%string [ELit (Atom "b")])]
+  |[], 0, ELet ["X"%string; "Y"%string] [ECall "fwrite"%string [ELit (Atom "a")]; 
+                                        EFun [] (ECall "fwrite"%string [ELit (Atom "b")])]
           (EApp (EVar "Y"%string) []), []|
 -e>
-  |inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
+  |1, inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
   eapply eval_let with (vals := [ok;
                                  VClos [] [] 0 [] (ECall "fwrite"%string [ELit (Atom "b")])])
-                       (eff := [[(Output, [VLit (Atom "a")])]; []]); auto.
+                       (eff := [[(Output, [VLit (Atom "a")])]; []])
+                       (ids := [0;1]); auto.
   * intros. inversion H. 2: inversion H1. 3: inversion H3.
     - simpl. apply eval_fun.
-    - simpl. eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
+    - simpl. eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
       + intros. inversion H2. 2: inversion H5. apply eval_lit. 
   * unfold concatn. simpl. reflexivity.
-  * eapply eval_apply with (vals := []) (var_list := []) 
+  * eapply eval_apply with (vals := []) (var_list := []) (ids := [])
                            (ref := []) (ext := []) (n := 0)
                            (body := ECall "fwrite"%string [ELit (Atom "b")]) 
                            (eff := []); auto.
     - simpl. apply eval_var.
     - intros. inversion H.
     - simpl. reflexivity.
-    - simpl. eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]); auto.
+    - simpl. eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]) (ids := [1]); auto.
       + intros. inversion H. 2: inversion H1. apply eval_lit.
 Qed.
 
 Example letrec_eff : 
-  |[], ELetRec [("f1"%string, 0)] [[]] 
+  |[], 0, ELetRec [("f1"%string, 0)] [[]] 
               [ECall "fwrite"%string [ELit (Atom "a")]]
-        (EApp (EFunId ("f1"%string, 0)) []), []|
+           (EApp (EFunId ("f1"%string, 0)) []), []|
 -e>
-  |inl ok, [(Output, [VLit (Atom "a")])]|.
+  |1, inl ok, [(Output, [VLit (Atom "a")])]|.
 Proof.
   eapply eval_letrec; auto.
   2 : reflexivity.
-  * simpl. eapply eval_apply with (vals := []) (eff := []) (ref := []) 
-                                  (ext := [("f1"%string, 0, ([], ECall "fwrite" 
-                                                                 [ELit (Atom "a")]))]) 
+  * simpl. eapply eval_apply with (vals := []) (eff := []) (ref := []) (ids := [])
+                                  (ext := [(0, ("f1"%string, 0),
+                                            ([], ECall "fwrite" [ELit (Atom "a")]))]) 
                                   (var_list := []) (n := 0)
                                   (body := ECall "fwrite"%string [ELit (Atom "a")]); auto.
     - apply eval_funid.
     - intros. inversion H.
     - simpl. reflexivity.
-    - simpl. apply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]); auto.
+    - simpl. apply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [1]); auto.
       + intros. inversion H. 2: inversion H1. apply eval_lit.
 Qed.
 
 Example map_eff : 
-  |[], EMap [ECall "fwrite"%string [ELit (Atom "a"%string)];
-             ECall "fwrite"%string [ELit (Atom "c"%string)]]
-            [ECall "fwrite"%string [ELit (Atom "b"%string)];
-             ELit (Integer 5)], []| 
+  |[], 0, EMap [ECall "fwrite"%string [ELit (Atom "a"%string)];
+                ECall "fwrite"%string [ELit (Atom "c"%string)]]
+               [ECall "fwrite"%string [ELit (Atom "b"%string)];
+                ELit (Integer 5)], []| 
 -e> 
-  | inl (VMap [ok] [VLit (Integer 5)]),
-    [(Output, [VLit (Atom "a"%string)]);
-     (Output, [VLit (Atom "b"%string)]);
-     (Output, [VLit (Atom "c"%string)])]|.
+  | 0, inl (VMap [ok] [VLit (Integer 5)]),
+      [(Output, [VLit (Atom "a"%string)]);
+       (Output, [VLit (Atom "b"%string)]);
+       (Output, [VLit (Atom "c"%string)])]|.
 Proof.
   apply eval_map with (kvals := [ok; ok]) (vvals := [ok; VLit (Integer 5)])
                       (eff := [[(Output, [VLit (Atom "a")])]; 
                                [(Output, [VLit (Atom "b")])]; 
                                [(Output, [VLit (Atom "c")])]; 
-                               []]).
-  * reflexivity.
-  * reflexivity.
-  * reflexivity.
-  * reflexivity.
-  * simpl. reflexivity.
+                               []])
+                      (ids := [0;0;0;0]); auto.
   * unfold concatn. intros. inversion H.
-    - apply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]).
-      + reflexivity.
-      + reflexivity.
+    - apply eval_call with (vals := [VLit (Atom "c")]) (eff := [[]]) (ids := [0]); auto.
       + intros. inversion H0.
         ** unfold concatn. simpl. apply eval_lit.
         ** inversion H3.
-      + unfold concatn. simpl. reflexivity.
     - inversion H1.
-      + simpl. apply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]).
-        ** reflexivity.
-        ** reflexivity.
+      + simpl. apply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]])
+                                    (ids := [0]); auto.
         ** intros. inversion H2. 2: inversion H5. simpl. apply eval_lit.
-        ** unfold concatn. simpl. reflexivity.
       + inversion H3.
   * intros. inversion H.
     - simpl. apply eval_lit.
     - inversion H1.
-      + apply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]).
-        ** reflexivity.
-        ** reflexivity.
+      + apply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]) (ids := [0]); auto.
         ** intros. inversion H2. 2: inversion H5. simpl. apply eval_lit.
-        ** simpl. reflexivity.
       + inversion H3.
-  * unfold concatn. simpl. reflexivity.
 Qed.
 
 End Core_Erlang_Side_Effect_Tests.

--- a/Core_Erlang_Side_Effects.v
+++ b/Core_Erlang_Side_Effects.v
@@ -24,10 +24,10 @@ Definition concatn (def : SideEffectList) (l : list SideEffectList) (n : nat) : 
    def ++ concat (firstn n l).
 
 
-Compute concatn [(Input, [VLiteral (Atom "a"%string)] )] 
-                [ [(Input, [VLiteral (Atom "a"%string)] )];
-                  [(Input, [VLiteral (Atom "b"%string)] )]; 
-                  [(Input, [VLiteral (Atom "c"%string)] )] ] 
+Compute concatn [(Input, [VLit (Atom "a"%string)] )] 
+                [ [(Input, [VLit (Atom "a"%string)] )];
+                  [(Input, [VLit (Atom "b"%string)] )]; 
+                  [(Input, [VLit (Atom "c"%string)] )] ] 
                 0.
 
 End Core_Erlang_Side_Effects.

--- a/Core_Erlang_Side_Effects.v
+++ b/Core_Erlang_Side_Effects.v
@@ -30,4 +30,12 @@ Compute concatn [(Input, [VLiteral (Atom "a"%string)] )]
                   [(Input, [VLiteral (Atom "c"%string)] )] ] 
                 0.
 
+Definition nth_id (ids : list nat) (def i : nat) :=
+match i with
+| 0 => def
+| S i' => nth i' ids 0
+end.
+
+Compute nth_id [4; 7; 8] 3 2 = 7.
+
 End Core_Erlang_Side_Effects.

--- a/Core_Erlang_Side_Effects.v
+++ b/Core_Erlang_Side_Effects.v
@@ -30,12 +30,4 @@ Compute concatn [(Input, [VLiteral (Atom "a"%string)] )]
                   [(Input, [VLiteral (Atom "c"%string)] )] ] 
                 0.
 
-Definition nth_id (ids : list nat) (def i : nat) :=
-match i with
-| 0 => def
-| S i' => nth i' ids 0
-end.
-
-Compute nth_id [4; 7; 8] 3 2 = 7.
-
 End Core_Erlang_Side_Effects.

--- a/Core_Erlang_Syntax.v
+++ b/Core_Erlang_Syntax.v
@@ -22,9 +22,6 @@ Inductive Literal : Type :=
 (* | Float (q : R) *).
 
 
-
-(** Patterns are not expressions, because there are expressions that 
-    are not patterns and patters that are not expressions (these are not implemented yet) *)
 Inductive Pattern : Type :=
 | PVar     (v : Var)
 | PLit (l : Literal)
@@ -44,7 +41,7 @@ Inductive Expression : Type :=
 | EFun     (vl : list Var) (e : Expression)
 | ECons    (hd tl : Expression)
 | ETuple   (l : list Expression)
-(** For built-in functions and primitive operations : *)
+(** Initially: for built-in functions and primitive operations : *)
 | ECall    (f: string)              (l : list Expression)
 (** For function applications: *)
 | EApp     (exp: Expression)        (l : list Expression)

--- a/Core_Erlang_Syntax.v
+++ b/Core_Erlang_Syntax.v
@@ -27,32 +27,32 @@ Inductive Literal : Type :=
     are not patterns and patters that are not expressions (these are not implemented yet) *)
 Inductive Pattern : Type :=
 | PVar     (v : Var)
-| PLiteral (l : Literal)
-| PList  (hd tl : Pattern)
+| PLit (l : Literal)
+| PCons  (hd tl : Pattern)
 | PTuple (l : list Pattern)
-| PEmptyList.
+| PNil.
 
 Definition PEmptyTuple : Pattern := PTuple [].
 
 Definition FunctionIdentifier : Type := string * nat.
 
 Inductive Expression : Type :=
-| EEmptyList
-| ELiteral (l : Literal)
+| ENil
+| ELit (l : Literal)
 | EVar     (v : Var)
 | EFunId   (f : FunctionIdentifier)
 | EFun     (vl : list Var) (e : Expression)
-| EList    (hd tl : Expression)
+| ECons    (hd tl : Expression)
 | ETuple   (l : list Expression)
 (** For built-in functions and primitive operations : *)
 | ECall    (f: string)              (l : list Expression)
 (** For function applications: *)
-| EApply   (exp: Expression)        (l : list Expression)
+| EApp     (exp: Expression)        (l : list Expression)
 | ECase    (e: Expression)          (pl : list Pattern) (** The case pattern list *)
                                     (gl : list Expression) (** guard list *)
                                     (bl : list Expression) (** body list *)
 | ELet     (s : list Var)           (el : list Expression) (e : Expression)
-| ELetrec  (fids : list FunctionIdentifier) (** defined identifiers *)
+| ELetRec  (fids : list FunctionIdentifier) (** defined identifiers *)
            (varlists : list (list Var))     (** variable lists *)
            (bodylists : list Expression)    (** body list *)
            (e : Expression)
@@ -72,14 +72,14 @@ Definition FunctionExpression : Type := list Var * Expression.
 
 (** What expressions are in normal form *)
 Inductive Value : Type :=
-| VEmptyList
-| VLiteral (l : Literal)
-| VClosure (env : list ((Var + FunctionIdentifier) * Value))
+| VNil
+| VLit (l : Literal)
+| VClos (env : list ((Var + FunctionIdentifier) * Value))
            (ext : list (nat * FunctionIdentifier * FunctionExpression))
            (id : nat)
            (vl : list Var)
            (e : Expression)
-| VList    (vhd vtl : Value)
+| VCons    (vhd vtl : Value)
 | VTuple   (vl : list Value)
 | VMap     (kl vl : list Value).
 
@@ -87,12 +87,12 @@ Inductive Value : Type :=
 Definition VEmptyMap : Value := VMap [] [].
 Definition VEmptyTuple : Value := VTuple [].
 
-Definition ErrorValue : Value := (VLiteral (Atom "error"%string)).
-Definition ErrorExp : Expression := (ELiteral (Atom "error"%string)).
-Definition ErrorPat : Pattern := PLiteral (Atom "error"%string).
-Definition ttrue : Value := VLiteral (Atom "true").
-Definition ffalse : Value := VLiteral (Atom "false").
-Definition ok : Value := VLiteral (Atom "ok").
+Definition ErrorValue : Value := (VLit (Atom "error"%string)).
+Definition ErrorExp : Expression := (ELit (Atom "error"%string)).
+Definition ErrorPat : Pattern := PLit (Atom "error"%string).
+Definition ttrue : Value := VLit (Atom "true").
+Definition ffalse : Value := VLit (Atom "false").
+Definition ok : Value := VLit (Atom "ok").
 
 (** Exception representation *)
 Inductive ExceptionClass : Type :=
@@ -101,9 +101,9 @@ Inductive ExceptionClass : Type :=
 (** Exception class to value converter *)
 Fixpoint exclass_to_value (ex : ExceptionClass) : Value :=
 match ex with
-| Error => VLiteral (Atom "Error"%string)
-| Throw => VLiteral (Atom "Throw"%string)
-| Exit => VLiteral (Atom "Exit"%string)
+| Error => VLit (Atom "Error"%string)
+| Throw => VLit (Atom "Throw"%string)
+| Exit => VLit (Atom "Exit"%string)
 end.
 
 
@@ -111,18 +111,18 @@ end.
 Definition Exception : Type := ExceptionClass * Value * Value.
 
 Definition badarith (v : Value) : Exception :=
-  (Error, VLiteral (Atom "badarith"%string), v).
+  (Error, VLit (Atom "badarith"%string), v).
 Definition badarg (v : Value) : Exception :=
-  (Error, VLiteral (Atom "badarg"%string), v).
-Definition novar : Exception := (Throw, VLiteral (Atom "novar"%string), ErrorValue).
+  (Error, VLit (Atom "badarg"%string), v).
+Definition novar : Exception := (Throw, VLit (Atom "novar"%string), ErrorValue).
 Definition undef (v : Value) : Exception :=
-  (Error, VLiteral (Atom "undef"%string), v).
+  (Error, VLit (Atom "undef"%string), v).
 Definition badfun (v : Value) : Exception := 
-  (Error,VLiteral (Atom "badfun"%string), v).
+  (Error,VLit (Atom "badfun"%string), v).
 Definition badarity (v : Value) : Exception := 
-  (Error,VLiteral (Atom "badarity"%string), v).
+  (Error,VLit (Atom "badarity"%string), v).
 Definition if_clause (v : Value) : Exception := 
-  (Error, VLiteral (Atom "if_clause"%string), v).
+  (Error, VLit (Atom "if_clause"%string), v).
 
 
 End Core_Erlang_Syntax.

--- a/Core_Erlang_Syntax.v
+++ b/Core_Erlang_Syntax.v
@@ -75,8 +75,8 @@ Inductive Value : Type :=
 | VEmptyList
 | VLiteral (l : Literal)
 | VClosure (env : list ((Var + FunctionIdentifier) * Value))
-           (ext : list (FunctionIdentifier * FunctionExpression))
-           (num : nat)
+           (ext : list (nat * FunctionIdentifier * FunctionExpression))
+           (id : nat)
            (vl : list Var)
            (e : Expression)
 | VList    (vhd vtl : Value)

--- a/Core_Erlang_Tests.v
+++ b/Core_Erlang_Tests.v
@@ -15,19 +15,19 @@ Import Core_Erlang_Side_Effects.
 
 (** This is an edless recursion *)
 Example eval_letrec1 : 
-  |[], 0, ELetrec [("x"%string, 1)] [["X"%string]] 
-         [EApply (EFunId ("x"%string, 1)) [EVar "X"%string]] 
-            (EApply (EFunId ("x"%string, 1)) [EEmptyTuple]), []|
+  |[], 0, ELetRec [("x"%string, 1)] [["X"%string]] 
+         [EApp (EFunId ("x"%string, 1)) [EVar "X"%string]] 
+            (EApp (EFunId ("x"%string, 1)) [EEmptyTuple]), []|
 -e> 
   |1, inl ErrorValue, []|.
 Proof.
   eapply eval_letrec; try (reflexivity).
   * simpl. eapply eval_apply with (vals := [VEmptyTuple]) 
-                                  (body := (EApply (EFunId ("x"%string, 1)) [EVar "X"%string])) (n := 0) (ids := [1])
+                                  (body := (EApp (EFunId ("x"%string, 1)) [EVar "X"%string])) (n := 0) (ids := [1])
                                   (var_list := ["X"%string]) 
                                   (ref := [])
                                   (ext := [(0, ("x"%string, 1), 
-                                        (["X"%string], EApply (EFunId ("x"%string, 1)) [EVar "X"%string]))]) 
+                                        (["X"%string], EApp (EFunId ("x"%string, 1)) [EVar "X"%string]))]) 
                                   (eff := [[]]); try (reflexivity).
     - unfold append_funs_to_env. simpl. eapply eval_funid.
     - intros. inversion H.
@@ -37,11 +37,11 @@ Proof.
       + inversion H1.
     - simpl. reflexivity.
     - eapply eval_apply with (vals := [VEmptyTuple]) 
-                             (body := (EApply (EFunId ("x"%string, 1)) [EVar "X"%string])) 
+                             (body := (EApp (EFunId ("x"%string, 1)) [EVar "X"%string])) 
                              (var_list := ["X"%string]) 
                              (ref := []) (ids := [1])
                              (ext := [(0, ("x"%string, 1),
-                                     (["X"%string], EApply (EFunId ("x"%string, 1)) [EVar "X"%string]))]) (n := 0)
+                                     (["X"%string], EApp (EFunId ("x"%string, 1)) [EVar "X"%string]))]) (n := 0)
                              (eff := [[]]); try (reflexivity).
     + apply eval_funid.
     + intros. inversion H.
@@ -49,23 +49,23 @@ Proof.
       ** inversion H1.
     + simpl. reflexivity.
     + eapply eval_apply with (vals := [VEmptyTuple]) 
-                             (body := (EApply (EFunId ("x"%string, 1)) [EVar "X"%string])) (n := 0)
+                             (body := (EApp (EFunId ("x"%string, 1)) [EVar "X"%string])) (n := 0)
                              (var_list := ["X"%string]) 
                              (ref := []) (ids := [1])
                              (ext := [(1, ("x"%string, 1), 
-                                     (["X"%string], EApply (EFunId ("x"%string, 1)) [EVar "X"%string]))]) 
+                                     (["X"%string], EApp (EFunId ("x"%string, 1)) [EVar "X"%string]))]) 
                              (eff := [[]]); try (reflexivity).
 Admitted.
 
 (* This is not accepted by the compiler in Core Erlang *)
 Example eval_letrec2 : 
   |[], 0, ELet ["F"%string] [EFun ["X"%string] 
-         (EApply (EVar "F"%string) [EVar "X"%string])] 
-            (EApply (EVar "F"%string) [EEmptyTuple]), []| 
+         (EApp (EVar "F"%string) [EVar "X"%string])] 
+            (EApp (EVar "F"%string) [EEmptyTuple]), []| 
 -e>
 |1, inr novar, []|.
 Proof.
-  eapply eval_let with (vals := [VClosure [] [] 0 ["X"%string] (EApply (EVar "F"%string) [EVar "X"%string])]) 
+  eapply eval_let with (vals := [VClos [] [] 0 ["X"%string] (EApp (EVar "F"%string) [EVar "X"%string])]) 
                        (ids := [1])
                        (eff := [[]]); auto.
   * simpl. intros. inversion H.
@@ -74,7 +74,7 @@ Proof.
   * reflexivity.
   * simpl. eapply eval_apply with (vals := [VEmptyTuple]) (n := 0)
                                   (var_list := ["X"%string]) (ids := [1])
-                                  (body := (EApply (EVar "F"%string) [EVar "X"%string])) 
+                                  (body := (EApp (EVar "F"%string) [EVar "X"%string])) 
                                   (ref := []) (ext := []) (eff := [[]]); try(reflexivity).
     - apply eval_var.
     - intros. inversion H.
@@ -88,146 +88,146 @@ Proof.
 Qed.
 
 (* Top level functions, and their closures must be added initially *)
-Example multiple_top_level_funs : |[(inr ("fun1"%string, 0), VClosure [] [
-    (0, ("fun1"%string, 0), ([], (EApply (EFunId ("fun3"%string, 0)) [])));
-    (1, ("fun2"%string, 0), ([], (ELiteral (Integer 42))));
-    (2, ("fun3"%string, 0), ([], (EApply (EFunId ("fun2"%string, 0)) [])))
-  ] 0 [] (EApply (EFunId ("fun3"%string, 0)) [])) ; 
-                                      (inr ("fun2"%string, 0), VClosure [] [
-    (0, ("fun1"%string, 0), ([], (EApply (EFunId ("fun3"%string, 0)) [])));
-    (1, ("fun2"%string, 0), ([], (ELiteral (Integer 42))));
-    (2, ("fun3"%string, 0), ([], (EApply (EFunId ("fun2"%string, 0)) [])))
-  ] 1 [] (ELiteral (Integer 42))) ;
-                                      (inr ("fun3"%string, 0), VClosure [] [
-    (0, ("fun1"%string, 0), ([], (EApply (EFunId ("fun3"%string, 0)) [])));
-    (1, ("fun2"%string, 0), ([], (ELiteral (Integer 42))));
-    (2, ("fun3"%string, 0), ([], (EApply (EFunId ("fun2"%string, 0)) [])))
-  ] 2 [] (EApply (EFunId ("fun2"%string, 0)) []))], 3
-                                      , EApply (EFunId ("fun1"%string,0)) [], []| 
+Example multiple_top_level_funs : |[(inr ("fun1"%string, 0), VClos [] [
+    (0, ("fun1"%string, 0), ([], (EApp (EFunId ("fun3"%string, 0)) [])));
+    (1, ("fun2"%string, 0), ([], (ELit (Integer 42))));
+    (2, ("fun3"%string, 0), ([], (EApp (EFunId ("fun2"%string, 0)) [])))
+  ] 0 [] (EApp (EFunId ("fun3"%string, 0)) [])) ; 
+                                      (inr ("fun2"%string, 0), VClos [] [
+    (0, ("fun1"%string, 0), ([], (EApp (EFunId ("fun3"%string, 0)) [])));
+    (1, ("fun2"%string, 0), ([], (ELit (Integer 42))));
+    (2, ("fun3"%string, 0), ([], (EApp (EFunId ("fun2"%string, 0)) [])))
+  ] 1 [] (ELit (Integer 42))) ;
+                                      (inr ("fun3"%string, 0), VClos [] [
+    (0, ("fun1"%string, 0), ([], (EApp (EFunId ("fun3"%string, 0)) [])));
+    (1, ("fun2"%string, 0), ([], (ELit (Integer 42))));
+    (2, ("fun3"%string, 0), ([], (EApp (EFunId ("fun2"%string, 0)) [])))
+  ] 2 [] (EApp (EFunId ("fun2"%string, 0)) []))], 3
+                                      , EApp (EFunId ("fun1"%string,0)) [], []| 
 -e> 
-  |3, inl (VLiteral (Integer 42)), []|.
+  |3, inl (VLit (Integer 42)), []|.
 Proof.
   remember [
-  (0, ("fun1"%string, 0), ([], (EApply (EFunId ("fun3"%string, 0)) [])));
-  (1, ("fun2"%string, 0), ([], (ELiteral (Integer 42))));
-  (2, ("fun3"%string, 0), ([], (EApply (EFunId ("fun2"%string, 0)) [])))
+  (0, ("fun1"%string, 0), ([], (EApp (EFunId ("fun3"%string, 0)) [])));
+  (1, ("fun2"%string, 0), ([], (ELit (Integer 42))));
+  (2, ("fun3"%string, 0), ([], (EApp (EFunId ("fun2"%string, 0)) [])))
 ] as ext.
   eapply eval_apply with (vals := []) (ref := []) (ext := ext) (eff := [])
-                         (body := (EApply (EFunId ("fun3"%string, 0)) [])) 
+                         (body := (EApp (EFunId ("fun3"%string, 0)) [])) 
                          (var_list := []) (n := 0) (ids := []); auto.
   * apply eval_funid.
   * simpl. intros. inversion H.
   * reflexivity.
   * simpl. eapply eval_apply with (vals := []) (n := 2) (ref := []) (ext := ext) (eff := [])
-                                 (body := (EApply (EFunId ("fun2"%string, 0)) [])) 
+                                 (body := (EApp (EFunId ("fun2"%string, 0)) [])) 
                                  (var_list := []) (ids := []); auto.
     - rewrite Heqext. simpl. apply eval_funid.
     - intros. inversion H.
     - simpl. reflexivity.
     - simpl. eapply eval_apply with (vals := []) (n := 1) (ref := []) (ext := ext) (eff := [])
-                                    (body := (ELiteral (Integer 42))) (var_list := []) (ids := []); auto.
+                                    (body := (ELit (Integer 42))) (var_list := []) (ids := []); auto.
       + rewrite Heqext. apply eval_funid.
       + intros. inversion H.
       + reflexivity.
       + apply eval_lit.
 Qed.
 
-Example weird_apply : |[], 0, ELetrec [("f"%string, 1)] [["X"%string]]
+Example weird_apply : |[], 0, ELetRec [("f"%string, 1)] [["X"%string]]
    [ECase (EVar "X"%string)
-          [PLiteral (Integer 0) ; PLiteral (Integer 1); PVar "X"%string]
-          [ELiteral (Atom "true"%string); ELiteral (Atom "true"%string); ELiteral (Atom "true"%string)]
-          [ELiteral (Integer 5);
-           EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-           EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]
+          [PLit (Integer 0) ; PLit (Integer 1); PVar "X"%string]
+          [ELit (Atom "true"%string); ELit (Atom "true"%string); ELit (Atom "true"%string)]
+          [ELit (Integer 5);
+           EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+           EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]
           ]
    ]
    (ELet ["X"%string] [EFun ["F"%string]
-       (ELetrec [("f"%string, 1)] [["X"%string]] [ELiteral (Integer 0)] 
-          (EApply (EVar "F"%string) [ELiteral (Integer 2)])
+       (ELetRec [("f"%string, 1)] [["X"%string]] [ELit (Integer 0)] 
+          (EApp (EVar "F"%string) [ELit (Integer 2)])
        )
      ]
-    (EApply (EVar "X"%string) [EFunId ("f"%string, 1)])
+    (EApp (EVar "X"%string) [EFunId ("f"%string, 1)])
    ), []|
 -e> 
-  |3, inl (VLiteral (Integer 5)), []|.
+  |3, inl (VLit (Integer 5)), []|.
 Proof.
   eapply eval_letrec; auto.
   simpl. eapply eval_let with (vals := [
- VClosure 
+ VClos 
   [(inr ("f"%string, 1),
-   VClosure []
+   VClos []
      [(0, ("f"%string, 1),
       (["X"%string],
       ECase (EVar "X"%string)
-        [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-        [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-        [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-        EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]]))] 0 ["X"%string]
+        [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+        [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+        [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+        EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]]))] 0 ["X"%string]
      (ECase (EVar "X"%string)
-        [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-        [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-        [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-        EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]]))
+        [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+        [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+        [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+        EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]]))
   ]
   [] 1
   ["F"%string]
-  (ELetrec [("f"%string, 1)] [["X"%string]] [ELiteral (Integer 0)]
-        (EApply (EVar "F"%string) [ELiteral (Integer 2)]))
+  (ELetRec [("f"%string, 1)] [["X"%string]] [ELit (Integer 0)]
+        (EApp (EVar "F"%string) [ELit (Integer 2)]))
  ]
   ) (eff := [[]]) (ids := [2]); auto.
   * intros. inversion H; inversion H1. unfold append_funs_to_env. simpl. apply eval_fun.
   * simpl. eapply eval_apply with (var_list := ["F"%string]) (n := 1) (eff := [[]]) (ids := [2])
-  (vals := [VClosure []
+  (vals := [VClos []
      [(0, ("f"%string, 1),
       (["X"%string],
       ECase (EVar "X"%string)
-        [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-        [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-        [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-        EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]]))] 0 ["X"%string]
+        [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+        [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+        [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+        EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]]))] 0 ["X"%string]
      (ECase (EVar "X"%string)
-        [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-        [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-        [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-        EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]])])
-  (body := (ELetrec [("f"%string, 1)] [["X"%string]] [ELiteral (Integer 0)]
-       (EApply (EVar "F"%string) [ELiteral (Integer 2)])))
+        [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+        [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+        [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+        EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]])])
+  (body := (ELetRec [("f"%string, 1)] [["X"%string]] [ELit (Integer 0)]
+       (EApp (EVar "F"%string) [ELit (Integer 2)])))
   (ref := [(inr ("f"%string, 1),
-     VClosure []
+     VClos []
        [(0, ("f"%string, 1),
         (["X"%string],
         ECase (EVar "X"%string)
-          [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-          [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-          [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-          EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]]))] 0 ["X"%string]
+          [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+          [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+          [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+          EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]]))] 0 ["X"%string]
        (ECase (EVar "X"%string)
-          [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-          [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-          [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-          EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]]))])
+          [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+          [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+          [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+          EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]]))])
   (ext := []); auto.
     - apply eval_var.
     - intros. inversion H; inversion H1. simpl. apply eval_funid.
     - simpl. eapply eval_letrec; auto. simpl.
       eapply eval_apply with (var_list := ["X"%string]) (eff := [[]])
-        (vals := [VLiteral (Integer 2)])
+        (vals := [VLit (Integer 2)])
         (ref := []) (n := 0) (ids := [3])
         (body := (ECase (EVar "X"%string)
-       [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-       [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-       [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-       EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]]))
+       [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+       [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+       [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+       EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]]))
         (ext := [(0, ("f"%string, 1),
      (["X"%string],
      ECase (EVar "X"%string)
-       [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-       [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-       [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-       EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]]))]); auto.
+       [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+       [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+       [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+       EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]]))]); auto.
       + apply eval_var.
       + intros. inversion H; inversion H1. apply eval_lit.
-      + simpl. eapply eval_case with (i := 2) (v := VLiteral (Integer 2)); auto.
+      + simpl. eapply eval_case with (i := 2) (v := VLit (Integer 2)); auto.
         ** apply eval_var.
         ** simpl. reflexivity.
         ** intros. inversion H.
@@ -238,23 +238,23 @@ Proof.
         ** simpl. apply eval_lit.
         ** simpl. eapply eval_apply with (var_list := ["X"%string])
                      (eff := [[]]) (n := 0) (ids := [3])
-                     (vals := [VLiteral (Integer 1)])
+                     (vals := [VLit (Integer 1)])
                      (body := (ECase (EVar "X"%string)
-                                [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-                                [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-                                [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-                                EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]]))
+                                [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+                                [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+                                [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+                                EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]]))
                      (ref := [])
                      (ext := [(0, ("f"%string, 1),
                               (["X"%string],
                               ECase (EVar "X"%string)
-                                [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-                                [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-                                [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-                                EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]]))]); auto.
+                                [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+                                [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+                                [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+                                EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]]))]); auto.
          -- apply eval_funid.
          -- intros. inversion H; inversion H1. apply eval_lit.
-         -- simpl. eapply eval_case with (i := 1) (v := VLiteral (Integer 1)); auto.
+         -- simpl. eapply eval_case with (i := 1) (v := VLit (Integer 1)); auto.
            ++ apply eval_var.
            ++ simpl. auto.
            ++ simpl. reflexivity.
@@ -263,25 +263,25 @@ Proof.
              *** inversion H2.
            ++ simpl. apply eval_lit.
            ++ eapply eval_apply with (var_list := ["X"%string])
-                     (vals := [VLiteral (Integer 0)])
+                     (vals := [VLit (Integer 0)])
                      (eff := [[]]) (n := 0) (ids := [3])
                      (body := (ECase (EVar "X"%string)
-                                [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-                                [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-                                [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-                                EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]]))
+                                [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+                                [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+                                [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+                                EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]]))
                      (ref := [])
                      (ext := [(0, ("f"%string, 1),
                               (["X"%string],
                               ECase (EVar "X"%string)
-                                [PLiteral (Integer 0); PLiteral (Integer 1); PVar "X"%string]
-                                [ELiteral (Atom "true"); ELiteral (Atom "true"); ELiteral (Atom "true")]
-                                [ELiteral (Integer 5); EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 0)];
-                                EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 1)]]))]); auto.
+                                [PLit (Integer 0); PLit (Integer 1); PVar "X"%string]
+                                [ELit (Atom "true"); ELit (Atom "true"); ELit (Atom "true")]
+                                [ELit (Integer 5); EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)];
+                                EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)]]))]); auto.
              *** simpl. apply eval_funid.
              *** intros. inversion H; inversion H1. apply eval_lit.
              *** reflexivity.
-             *** simpl. eapply eval_case with (i := 0) (v := VLiteral (Integer 0)); auto.
+             *** simpl. eapply eval_case with (i := 0) (v := VLit (Integer 0)); auto.
                --- apply eval_var.
                --- simpl. auto.
                --- simpl. reflexivity.
@@ -293,20 +293,20 @@ Qed.
 
 Example top_overwrite : 
   |[(inr ("fun2"%string, 0), 
-       VClosure [] [(0, ("fun2"%string, 0),([],  (ELiteral (Integer 42)) ))] 0 [] (ELiteral (Integer 42)))], 1,
-  ELetrec [("fun2"%string, 0)] [[]] [ELiteral (Integer 40)] 
-     (EApply (EFunId ("fun2"%string, 0)) []), [] | 
+       VClos [] [(0, ("fun2"%string, 0),([],  (ELit (Integer 42)) ))] 0 [] (ELit (Integer 42)))], 1,
+  ELetRec [("fun2"%string, 0)] [[]] [ELit (Integer 40)] 
+     (EApp (EFunId ("fun2"%string, 0)) []), [] | 
 -e>
-  |2, inl (VLiteral (Integer 40)), []|.
+  |2, inl (VLit (Integer 40)), []|.
 Proof.
   eapply eval_letrec; auto.
   * unfold append_funs_to_env. simpl. eapply eval_apply with (vals := []) (eff := []) (n := 1) (ids := [])
-                                  (ref := [(inr ("fun2"%string, 0), VClosure [] 
+                                  (ref := [(inr ("fun2"%string, 0), VClos [] 
                                                                     [(0, ("fun2"%string, 0), 
-                                                                    ([], ELiteral (Integer 42)))] 0 []
-                                                                    (ELiteral (Integer 42)))]) 
-                                  (ext := [(1, ("fun2"%string, 0), ([],  (ELiteral (Integer 40)) ))]) 
-                                  (body := (ELiteral (Integer 40))) (var_list := []); auto.
+                                                                    ([], ELit (Integer 42)))] 0 []
+                                                                    (ELit (Integer 42)))]) 
+                                  (ext := [(1, ("fun2"%string, 0), ([],  (ELit (Integer 40)) ))]) 
+                                  (body := (ELit (Integer 40))) (var_list := []); auto.
     - unfold append_funs_to_env. simpl. apply eval_funid.
     - intros. inversion H.
     - apply eval_lit.
@@ -315,17 +315,17 @@ Qed.
 
 Example top_no_overwrite : 
   |[(inr ("fun2"%string, 0), 
-     VClosure [] [(("fun2"%string, 0), ([], ELiteral (Integer 42)))] 0 [] (ELiteral (Integer 42)))],
-   ELetrec [("fun2"%string, 1)] [["X"%string]] [(ELiteral (Integer 40))] 
-     (EApply (EFunId ("fun2"%string, 0)) []), [] |
+     VClos [] [(("fun2"%string, 0), ([], ELit (Integer 42)))] 0 [] (ELit (Integer 42)))],
+   ELetRec [("fun2"%string, 1)] [["X"%string]] [(ELit (Integer 40))] 
+     (EApp (EFunId ("fun2"%string, 0)) []), [] |
 -e> 
-  |inl (VLiteral (Integer 42)), []|.
+  |inl (VLit (Integer 42)), []|.
 Proof.
   eapply eval_letrec; auto.
   * simpl. eapply eval_apply with (vals := []) (n := 0)
                                   (ref := [])
-                                  (ext := [("fun2"%string, 0, ([], ELiteral (Integer 42)))]) 
-                                  (body := ELiteral (Integer 42)) 
+                                  (ext := [("fun2"%string, 0, ([], ELit (Integer 42)))]) 
+                                  (body := ELit (Integer 42)) 
                                   (var_list := [])
                                   (eff := []); auto.
     - apply eval_funid.
@@ -336,14 +336,14 @@ Qed.
 
 (** This is not accepted by the compiler in Core Erlang *)
 Example eval_let_func : 
-  |[(inl "X"%string, VLiteral (Integer 42))], 
-   ELet ["X"%string; "X"%string] [EFun [] (EEmptyList); EFun [] (EEmptyMap)] 
+  |[(inl "X"%string, VLit (Integer 42))], 
+   ELet ["X"%string; "X"%string] [EFun [] (ENil); EFun [] (EEmptyMap)] 
      (EEmptyMap), []| 
 -e> 
   |inl (VEmptyMap), []|.
 Proof.
-  eapply eval_let with (vals := [VClosure [(inl "X"%string, VLiteral (Integer 42))] [] 0 [] (EEmptyList); 
-                                 VClosure [(inl "X"%string, VLiteral (Integer 42))] [] 0 [] (EEmptyMap)])
+  eapply eval_let with (vals := [VClos [(inl "X"%string, VLit (Integer 42))] [] 0 [] (ENil); 
+                                 VClos [(inl "X"%string, VLit (Integer 42))] [] 0 [] (EEmptyMap)])
                        (eff := [[]; []]); auto.
   * simpl. intros. inversion H.
     - apply eval_fun.
@@ -357,13 +357,13 @@ Proof.
 Qed.
 
 Example eval_let_apply : 
-  |[(inl "X"%string, VLiteral (Integer 42))], 
+  |[(inl "X"%string, VLit (Integer 42))], 
    ELet ["Y"%string] [EFun [] (EVar "X"%string)] 
-     (EApply (EVar "Y"%string) []), []| 
+     (EApp (EVar "Y"%string) []), []| 
 -e> 
-  |inl (VLiteral (Integer 42)), []|.
+  |inl (VLit (Integer 42)), []|.
 Proof.
-  eapply eval_let with (vals := [VClosure [(inl "X"%string, VLiteral (Integer 42))] [] 0 [] 
+  eapply eval_let with (vals := [VClos [(inl "X"%string, VLit (Integer 42))] [] 0 [] 
                                           (EVar "X"%string)])
                        (eff := [[]]); auto.
   * simpl. intros. inversion H.
@@ -371,7 +371,7 @@ Proof.
     - inversion H1.
   * reflexivity.
   * simpl. eapply eval_apply with (vals := []) (n := 0)
-                                  (ref := [(inl "X"%string, VLiteral (Integer 42))]) 
+                                  (ref := [(inl "X"%string, VLit (Integer 42))]) 
                                   (ext := []) 
                                   (body := (EVar "X"%string)) 
                                   (var_list := [])
@@ -383,18 +383,18 @@ Proof.
 Qed.
 
 Example eval_muliple_let : 
-  |[], ELet ["X"%string] [ELiteral (Integer 1)] 
-         (ELet ["X"%string] [ELiteral (Integer 2)] 
+  |[], ELet ["X"%string] [ELit (Integer 1)] 
+         (ELet ["X"%string] [ELit (Integer 2)] 
             (EVar "X"%string)), []| 
 -e> 
-  |inl (VLiteral (Integer 2)), []|.
+  |inl (VLit (Integer 2)), []|.
 Proof.
-  eapply eval_let with (vals := [VLiteral (Integer 1)]) (eff := [[]]); auto.
+  eapply eval_let with (vals := [VLit (Integer 1)]) (eff := [[]]); auto.
   * intros. inversion H.
     - apply eval_lit.
     - inversion H1.
   * simpl. reflexivity.
-  * eapply eval_let with (vals := [VLiteral (Integer 2)]) (eff := [[]]); auto.
+  * eapply eval_let with (vals := [VLit (Integer 2)]) (eff := [[]]); auto.
     - simpl. intros. inversion H.
       + apply eval_lit.
       + inversion H1.
@@ -435,12 +435,12 @@ Qed.
 (** This shouldn't compile in Core Erlang *)
 Example eval_let_3 : 
   |[(inl "X"%string, VEmptyMap)],
-   ELet ["X"%string; "X"%string; "Y"%string] [EEmptyTuple; EEmptyList; EVar "X"%string] 
+   ELet ["X"%string; "X"%string; "Y"%string] [EEmptyTuple; ENil; EVar "X"%string] 
      (EVar "Y"%string), []|
 -e>
   |inl (VEmptyMap), []|.
 Proof.
-  eapply eval_let with (vals := [(VEmptyTuple) ; (VEmptyList); (VEmptyMap)]) 
+  eapply eval_let with (vals := [(VEmptyTuple) ; (VNil); (VEmptyMap)]) 
                        (eff := [[];[];[]]); auto.
   * simpl. intros. inversion H.
     - apply eval_var.
@@ -454,11 +454,11 @@ Proof.
 Qed.
 
 Example let_eval_4 : 
-  |[], ELet ["X"%string] [ELiteral (Integer 5)] (EVar "X"%string), []| 
+  |[], ELet ["X"%string] [ELit (Integer 5)] (EVar "X"%string), []| 
 -e> 
-  | inl (VLiteral (Integer 5)), []|.
+  | inl (VLit (Integer 5)), []|.
 Proof.
-  eapply eval_let with (vals := [VLiteral (Integer 5)]) (eff := [[]]); auto.
+  eapply eval_let with (vals := [VLit (Integer 5)]) (eff := [[]]); auto.
   * intros. simpl in *. inversion H.
     - apply eval_lit.
     - inversion H1.
@@ -467,11 +467,11 @@ Proof.
 Qed.
 
 Example tuple_eval : 
-  |[(inl "X"%string, VLiteral (Atom "asd"%string)); 
+  |[(inl "X"%string, VLit (Atom "asd"%string)); 
     (inl "Y"%string, VEmptyTuple)], 
-   ETuple [ELiteral (Integer 5); EVar "X"%string; EVar "Y"%string], []| 
+   ETuple [ELit (Integer 5); EVar "X"%string; EVar "Y"%string], []| 
 -e>
-  |inl (VTuple [VLiteral (Integer 5); VLiteral (Atom "asd"%string); VEmptyTuple]), []|.
+  |inl (VTuple [VLit (Integer 5); VLit (Atom "asd"%string); VEmptyTuple]), []|.
 Proof.
   eapply eval_tuple with (eff := [[];[];[]]); auto.
   * intros. inversion H.
@@ -485,20 +485,20 @@ Qed.
 
 Example apply_top_eval : 
   |[(inr ("Plus"%string, 2), 
-       VClosure [] [(("Plus"%string, 2),
-                     (["X"%string ; "Y"%string], ELiteral (Integer 3)))] 
+       VClos [] [(("Plus"%string, 2),
+                     (["X"%string ; "Y"%string], ELit (Integer 3)))] 
                 0 ["X"%string ; "Y"%string] 
-                (ELiteral (Integer 3)))], 
-   EApply (EFunId ("Plus"%string, 2)) [ELiteral (Integer 2); ELiteral (Integer 3)], []|
+                (ELit (Integer 3)))], 
+   EApp (EFunId ("Plus"%string, 2)) [ELit (Integer 2); ELit (Integer 3)], []|
 -e>
-  |inl ((VLiteral (Integer 3))), []|.
+  |inl ((VLit (Integer 3))), []|.
 Proof.
-  eapply eval_apply with (vals := [VLiteral (Integer 2) ; VLiteral (Integer 3)])
+  eapply eval_apply with (vals := [VLit (Integer 2) ; VLit (Integer 3)])
                          (var_list := ["X"%string; "Y"%string]) 
-                         (body := ELiteral (Integer 3)) 
+                         (body := ELit (Integer 3)) 
                          (ref := []) (n := 0)
                          (ext := [(("Plus"%string, 2),
-                                   (["X"%string ; "Y"%string], ELiteral (Integer 3)))])
+                                   (["X"%string ; "Y"%string], ELit (Integer 3)))])
                          (eff := [[];[]]); auto.
   * apply eval_funid.
   * simpl. intros. inversion H.
@@ -512,15 +512,15 @@ Qed.
 
 Example apply_eval : 
   |[(inl "Minus"%string,
-      VClosure [] [] 0 ["X"%string; "Y"%string] (ELiteral (Integer 42))) ; 
+      VClos [] [] 0 ["X"%string; "Y"%string] (ELit (Integer 42))) ; 
     (inl "X"%string, VEmptyMap)], 
-   EApply (EVar "Minus"%string) [EVar "X"%string; EVar "X"%string], []|
+   EApp (EVar "Minus"%string) [EVar "X"%string; EVar "X"%string], []|
 -e>
-  |inl (VLiteral (Integer 42)), []|.
+  |inl (VLit (Integer 42)), []|.
 Proof.
   eapply eval_apply with (vals := [VEmptyMap; VEmptyMap]) 
                          (var_list := ["X"%string; "Y"%string]) 
-                         (body := (ELiteral (Integer 42))) (n := 0)
+                         (body := (ELit (Integer 42))) (n := 0)
                          (ref := []) (ext := []) (eff := [[];[]]); auto.
   * apply eval_var.
   * simpl. intros. inversion H.
@@ -534,10 +534,10 @@ Qed.
 
 
 Example list_eval : 
-  |[(inl "X"%string, VLiteral (Integer 5))],
-   EList (EVar "X"%string) (EEmptyList), []| 
+  |[(inl "X"%string, VLit (Integer 5))],
+   ECons (EVar "X"%string) (ENil), []| 
 -e>
-  | inl (VList (VLiteral (Integer 5)) (VEmptyList)), []|.
+  | inl (VCons (VLit (Integer 5)) (VNil)), []|.
 Proof.
   eapply eval_list.
   * instantiate (1 := []). rewrite app_nil_r. reflexivity.
@@ -546,14 +546,14 @@ Proof.
 Qed.
 
 Example list_eval2 : 
-  |[(inl "X"%string, VLiteral (Integer 5))], 
-   EList (EVar "X"%string) 
-         (EList (EVar "X"%string) 
-                (EEmptyList)), []| 
+  |[(inl "X"%string, VLit (Integer 5))], 
+   ECons (EVar "X"%string) 
+         (ECons (EVar "X"%string) 
+                (ENil)), []| 
 -e> 
-  |inl (VList (VLiteral (Integer 5)) 
-              (VList (VLiteral (Integer 5)) 
-                     (VEmptyList))), []|.
+  |inl (VCons (VLit (Integer 5)) 
+              (VCons (VLit (Integer 5)) 
+                     (VNil))), []|.
 Proof.
   eapply eval_list with (eff2 := []).
   * reflexivity.
@@ -566,17 +566,17 @@ Qed.
 
 Example let_eval_overwrite : 
   |[], ELet ["X"%string] [EFun [] (EEmptyTuple)] 
-         (ELet ["X"%string] [ELiteral (Integer 5)] 
+         (ELet ["X"%string] [ELit (Integer 5)] 
             (EVar "X"%string)), []|
 -e>
-  |inl (VLiteral (Integer 5)), []|.
+  |inl (VLit (Integer 5)), []|.
 Proof.
-  eapply eval_let with (vals := [VClosure [] [] 0 [] (EEmptyTuple)]) (eff := [[]]); auto.
+  eapply eval_let with (vals := [VClos [] [] 0 [] (EEmptyTuple)]) (eff := [[]]); auto.
   * simpl. intros. inversion H.
     - apply eval_fun.
     - inversion H1.
   * reflexivity.
-  * simpl. eapply eval_let with (vals := [VLiteral (Integer 5)]) (eff := [[]]); auto.
+  * simpl. eapply eval_let with (vals := [VLit (Integer 5)]) (eff := [[]]); auto.
     - simpl. intros. inversion H.
       + apply eval_lit.
       + inversion H1.
@@ -585,12 +585,12 @@ Proof.
 Qed.
 
 Example map_eval :
-  |[(inl "X"%string, VLiteral (Integer 42))], 
-    EMap [ELiteral (Integer 5)] [EVar "X"%string], []|
+  |[(inl "X"%string, VLit (Integer 42))], 
+    EMap [ELit (Integer 5)] [EVar "X"%string], []|
 -e>
-  |inl (VMap [VLiteral (Integer 5)] [VLiteral (Integer 42)]), []|.
+  |inl (VMap [VLit (Integer 5)] [VLit (Integer 42)]), []|.
 Proof.
-  eapply eval_map with (kvals := [VLiteral (Integer 5)]) (vvals := [VLiteral (Integer 42)]) 
+  eapply eval_map with (kvals := [VLit (Integer 5)]) (vvals := [VLit (Integer 42)]) 
                        (eff := [[];[]]); auto.
   * intros. inversion H.
     - subst. apply eval_lit.
@@ -601,15 +601,15 @@ Proof.
 Qed.
 
 Example map_eval2 : 
-  |[(inl "X"%string, VLiteral (Integer 42))], 
-   EMap [ELiteral (Integer 54); EVar "X"%string] 
+  |[(inl "X"%string, VLit (Integer 42))], 
+   EMap [ELit (Integer 54); EVar "X"%string] 
         [EVar "X"%string; EVar "X"%string], []|
 -e> 
-  |inl (VMap [VLiteral (Integer 42); VLiteral (Integer 54)] 
-             [VLiteral (Integer 42); VLiteral (Integer 42)]), []|.
+  |inl (VMap [VLit (Integer 42); VLit (Integer 54)] 
+             [VLit (Integer 42); VLit (Integer 42)]), []|.
 Proof.
-  eapply eval_map with (kvals := [VLiteral (Integer 54); VLiteral (Integer 42)])
-                       (vvals := [VLiteral (Integer 42); VLiteral (Integer 42)])
+  eapply eval_map with (kvals := [VLit (Integer 54); VLit (Integer 42)])
+                       (vvals := [VLit (Integer 42); VLit (Integer 42)])
                        (eff := [[];[];[];[]]); auto.
   * intros. inversion H.
     - apply eval_var.
@@ -624,15 +624,15 @@ Proof.
 Qed.
 
 Example map_eval3 : 
-  |[(inl "X"%string, VLiteral (Integer 5))], 
-   EMap [ELiteral (Integer 5); EVar "X"%string] 
+  |[(inl "X"%string, VLit (Integer 5))], 
+   EMap [ELit (Integer 5); EVar "X"%string] 
         [EVar "X"%string; ECall "plus" 
-                              [ELiteral (Integer 1); (EVar "X"%string)]], []| 
+                              [ELit (Integer 1); (EVar "X"%string)]], []| 
 -e> 
-  |inl (VMap [VLiteral (Integer 5)] [VLiteral (Integer 6)]), []|.
+  |inl (VMap [VLit (Integer 5)] [VLit (Integer 6)]), []|.
 Proof.
-  apply eval_map with (kvals := [VLiteral (Integer 5); VLiteral (Integer 5)])
-                      (vvals := [VLiteral (Integer 5); VLiteral (Integer 6)])
+  apply eval_map with (kvals := [VLit (Integer 5); VLit (Integer 5)])
+                      (vvals := [VLit (Integer 5); VLit (Integer 6)])
                       (eff := [[];[];[];[]]); auto.
   * intros. inversion H.
     - apply eval_var.
@@ -640,7 +640,7 @@ Proof.
       + apply eval_lit.
       + inversion H3.
   * intros. inversion H.
-    - eapply eval_call with (vals := [VLiteral (Integer 1); VLiteral (Integer 5)])
+    - eapply eval_call with (vals := [VLit (Integer 1); VLit (Integer 5)])
                             (eff := [[];[]]); auto.
       + intros. inversion H0.
         ** apply eval_var.
@@ -655,34 +655,34 @@ Qed.
 (** Function parameter always overwrites everything *)
 Example let_closure_apply_eval_without_overwrite :
   |[], 
-   ELet ["X"%string] [ELiteral (Integer 42)] 
+   ELet ["X"%string] [ELit (Integer 42)] 
      (ELet ["Y"%string] [EFun ["X"%string] (EVar "X"%string)] 
-       (ELet ["X"%string] [ELiteral (Integer 5)] 
-         (EApply (EVar "Y"%string) [ELiteral (Integer 7)]))), []|
+       (ELet ["X"%string] [ELit (Integer 5)] 
+         (EApp (EVar "Y"%string) [ELit (Integer 7)]))), []|
 -e>
-  |inl (VLiteral (Integer 7)), []|.
+  |inl (VLit (Integer 7)), []|.
 Proof.
-  eapply eval_let with (vals := [VLiteral (Integer 42)]) (eff := [[]]); auto.
+  eapply eval_let with (vals := [VLit (Integer 42)]) (eff := [[]]); auto.
   * simpl. intros. inversion H.
     - apply eval_lit.
     - inversion H1.
   * reflexivity.
   * simpl. eapply eval_let with 
-             (vals := [VClosure [(inl "X"%string, VLiteral (Integer 42))] [] 
+             (vals := [VClos [(inl "X"%string, VLit (Integer 42))] [] 
                           0 ["X"%string] (EVar "X"%string)])
              (eff := [[]]); auto.
     - simpl. intros. inversion H.
       + apply eval_fun.
       + inversion H1.
     - reflexivity.
-    - simpl. eapply eval_let with (vals := [VLiteral (Integer 5)]) (eff := [[]]); auto.
+    - simpl. eapply eval_let with (vals := [VLit (Integer 5)]) (eff := [[]]); auto.
       + simpl. intros. inversion H.
         ** apply eval_lit.
         ** inversion H1.
       + reflexivity.
       + simpl. eapply eval_apply with 
-                    (vals := [VLiteral (Integer 7)]) (n := 0)
-                    (ref := [(inl "X"%string, VLiteral (Integer 42))]) 
+                    (vals := [VLit (Integer 7)]) (n := 0)
+                    (ref := [(inl "X"%string, VLit (Integer 42))]) 
                     (ext := []) (body := (EVar "X"%string)) 
                     (var_list := ["X"%string]) (eff := [[]]); auto.
         ** simpl. intros. apply eval_var.
@@ -697,30 +697,30 @@ Qed.
 (** Example to test that value overwriting does not affect the value in the closure *)
 Example let_closure_apply_eval_without_overwrite2 :
   |[],
-   ELet ["X"%string] [ELiteral (Integer 42)] 
+   ELet ["X"%string] [ELit (Integer 42)] 
      (ELet ["Y"%string] [EFun [] (EVar "X"%string)] 
-       (ELet ["X"%string] [ELiteral (Integer 5)] 
-         (EApply (EVar "Y"%string) []))), []|
+       (ELet ["X"%string] [ELit (Integer 5)] 
+         (EApp (EVar "Y"%string) []))), []|
 -e> 
-  |inl (VLiteral (Integer 42)), []|.
+  |inl (VLit (Integer 42)), []|.
 Proof.
-  eapply eval_let with (vals := [VLiteral (Integer 42)]) (eff := [[]]); auto.
+  eapply eval_let with (vals := [VLit (Integer 42)]) (eff := [[]]); auto.
   * intros. inversion H; inversion H1.
     - apply eval_lit.
   * reflexivity.
   * simpl. eapply eval_let with 
-               (vals := [VClosure [(inl "X"%string, VLiteral (Integer 42))] []
+               (vals := [VClos [(inl "X"%string, VLit (Integer 42))] []
                             0 [] (EVar "X"%string)]) (eff := [[]]); auto.
     - intros. inversion H; inversion H1.
       + apply eval_fun.
     - reflexivity.
-    - eapply eval_let with (vals := [VLiteral (Integer 5)]) (eff := [[]]); auto.
+    - eapply eval_let with (vals := [VLit (Integer 5)]) (eff := [[]]); auto.
       + intros. inversion H; inversion H1.
         ** apply eval_lit.
       + reflexivity.
       + simpl. eapply eval_apply with (vals := []) (var_list := []) 
                                       (body := (EVar "X"%string)) (n := 0)
-                                      (ref := [(inl "X"%string, VLiteral (Integer 42))]) 
+                                      (ref := [(inl "X"%string, VLit (Integer 42))]) 
                                       (ext := []) (eff := []); auto.
         ** apply eval_var.
         ** intros. inversion H.
@@ -729,12 +729,12 @@ Proof.
 Qed.
 
 Example call_eval : 
-  |[(inl "X"%string, VLiteral (Integer 5))], 
-   ECall "plus"%string [EVar "X"%string ; ELiteral (Integer 2)], []|
+  |[(inl "X"%string, VLit (Integer 5))], 
+   ECall "plus"%string [EVar "X"%string ; ELit (Integer 2)], []|
 -e> 
-  |inl (VLiteral (Integer 7)), []|.
+  |inl (VLit (Integer 7)), []|.
 Proof.
-  eapply eval_call with (vals := ([VLiteral (Integer 5) ; VLiteral (Integer 2)]))
+  eapply eval_call with (vals := ([VLit (Integer 5) ; VLit (Integer 2)]))
                         (eff := [[];[]]); auto.
   * simpl. intros. inversion H.
     - apply eval_lit.
@@ -745,16 +745,16 @@ Qed.
 
 Example mutliple_function_let : 
   |[], 
-   ELet ["Z"%string] [ECall "plus"%string [ELiteral (Integer 2) ; ELiteral (Integer 2)] ] 
+   ELet ["Z"%string] [ECall "plus"%string [ELit (Integer 2) ; ELit (Integer 2)] ] 
      (ELet ["Y"%string] [EFun [] (EVar "Z"%string)] 
-        (ELet ["X"%string] [EFun [] (EApply (EVar "Y"%string) [])] 
-          (EApply (EVar "X"%string) []))), []|
+        (ELet ["X"%string] [EFun [] (EApp (EVar "Y"%string) [])] 
+          (EApp (EVar "X"%string) []))), []|
 -e>
-  | inl (VLiteral (Integer 4)), []|.
+  | inl (VLit (Integer 4)), []|.
 Proof.
-  eapply eval_let with (vals := [VLiteral (Integer 4)]) (eff := [[]]); auto.
+  eapply eval_let with (vals := [VLit (Integer 4)]) (eff := [[]]); auto.
   * simpl. intros. inversion H.
-    - eapply eval_call with (vals := [VLiteral (Integer 2); VLiteral (Integer 2)])
+    - eapply eval_call with (vals := [VLit (Integer 2); VLit (Integer 2)])
                             (eff := [[];[]]); auto.
       + simpl. intros. inversion H0.
         ** apply eval_lit.
@@ -763,7 +763,7 @@ Proof.
           -- inversion H5.
     - inversion H1.
   * reflexivity.
-  * simpl. eapply eval_let with (vals := [VClosure [(inl "Z"%string, VLiteral (Integer 4))] [] 
+  * simpl. eapply eval_let with (vals := [VClos [(inl "Z"%string, VLit (Integer 4))] [] 
                                              0 [] (EVar "Z"%string)])
                                 (eff := [[]]); auto.
     - simpl. intros. inversion H.
@@ -771,20 +771,20 @@ Proof.
       + inversion H1.
     - reflexivity.
     - simpl. eapply eval_let with 
-              (vals := [VClosure [(inl "Z"%string, VLiteral (Integer 4));
+              (vals := [VClos [(inl "Z"%string, VLit (Integer 4));
                                     (inl "Y"%string,
-                                    VClosure [(inl "Z"%string, VLiteral (Integer 4))] [] 0 []
-                                      (EVar "Z"%string))] [] 1 [] (EApply (EVar "Y"%string) [])])
+                                    VClos [(inl "Z"%string, VLit (Integer 4))] [] 0 []
+                                      (EVar "Z"%string))] [] 1 [] (EApp (EVar "Y"%string) [])])
               (eff := [[]]); auto.
       + simpl. intros. inversion H.
         ** apply eval_fun.
         ** inversion H1.
       + reflexivity.
       + simpl. eapply eval_apply with (vals := []) (var_list := []) 
-                                      (body := (EApply (EVar "Y"%string) [])) 
-                                      (ref := [(inl "Z"%string, VLiteral (Integer 4));
+                                      (body := (EApp (EVar "Y"%string) [])) 
+                                      (ref := [(inl "Z"%string, VLit (Integer 4));
                                                (inl "Y"%string,
-                                                VClosure [(inl "Z"%string, VLiteral (Integer 4))] 
+                                                VClos [(inl "Z"%string, VLit (Integer 4))] 
                                                        [] 0 [] (EVar "Z"%string))])
                                       (ext := []) (n := 1)
                                       (eff := []); auto.
@@ -793,7 +793,7 @@ Proof.
         ** reflexivity.
         ** simpl. eapply eval_apply with (vals := []) (var_list := []) 
                                          (body := (EVar "Z"%string)) (n := 0)
-                                         (ref := [(inl "Z"%string, VLiteral (Integer 4))]) 
+                                         (ref := [(inl "Z"%string, VLit (Integer 4))]) 
                                          (ext := []) (eff := []); auto.
           -- apply eval_var.
           -- intros. inversion H.
@@ -804,9 +804,9 @@ Qed.
 Example case_eval : 
   |[(inl "X"%string, VEmptyTuple)],
    ECase (EVar "X"%string)
-         [(PLiteral (Integer 5)); (PLiteral (Integer 6)); (PVar "Z"%string) ]
-         [(ELiteral (Atom "true"%string)); (ELiteral (Atom "true"%string)); (ELiteral (Atom "true"%string))]
-         [(ELiteral (Integer 5)); (ELiteral (Integer 6)); (EVar "Z"%string)], []| 
+         [(PLit (Integer 5)); (PLit (Integer 6)); (PVar "Z"%string) ]
+         [(ELit (Atom "true"%string)); (ELit (Atom "true"%string)); (ELit (Atom "true"%string))]
+         [(ELit (Integer 5)); (ELit (Integer 6)); (EVar "Z"%string)], []| 
 -e> 
   |inl (VEmptyTuple), []|.
 Proof.
@@ -826,10 +826,10 @@ Qed.
 Example case_eval2 :
   |[(inl "X"%string, VEmptyTuple)],
    ECase (EVar "X"%string) 
-         [(PLiteral (Integer 5)); (PLiteral (Integer 6)); (PVar "Z"%string); (PVar "Z"%string)]
-         [(ELiteral (Atom "true"%string)); (ELiteral (Atom "true"%string)); 
-          (ELiteral (Atom "false"%string)); (ELiteral (Atom "true"%string))]
-         [(ELiteral (Integer 5)); (ELiteral (Integer 6)); (EVar "Z"%string); (EEmptyMap)], []|
+         [(PLit (Integer 5)); (PLit (Integer 6)); (PVar "Z"%string); (PVar "Z"%string)]
+         [(ELit (Atom "true"%string)); (ELit (Atom "true"%string)); 
+          (ELit (Atom "false"%string)); (ELit (Atom "true"%string))]
+         [(ELit (Integer 5)); (ELit (Integer 6)); (EVar "Z"%string); (EEmptyMap)], []|
 -e> 
   |inl (VEmptyMap), []|.
 Proof.
@@ -851,14 +851,14 @@ Proof.
 Qed.
 
 Example case_eval_fun : 
-  |[(inl "X"%string, VClosure [(inl "Y"%string, ttrue)] [] 0 [] (EVar "Y"%string))], 
+  |[(inl "X"%string, VClos [(inl "Y"%string, ttrue)] [] 0 [] (EVar "Y"%string))], 
    ECase (EVar "X"%string) 
-         [(PLiteral (Integer 5)); (PLiteral (Integer 6)); (PVar "Z"%string)] 
-         [(ELiteral (Atom "true"%string)); (ELiteral (Atom "true"%string)); (ELiteral (Atom "true"%string))] 
-         [(ELiteral (Integer 5)); (ELiteral (Integer 6)); (EApply (EVar "Z"%string) [])], []| 
+         [(PLit (Integer 5)); (PLit (Integer 6)); (PVar "Z"%string)] 
+         [(ELit (Atom "true"%string)); (ELit (Atom "true"%string)); (ELit (Atom "true"%string))] 
+         [(ELit (Integer 5)); (ELit (Integer 6)); (EApp (EVar "Z"%string) [])], []| 
 -e> |inl (ttrue), []|.
 Proof.
-  eapply eval_case with (i := 2) (v := VClosure [(inl "Y"%string, ttrue)] [] 0 [] (EVar "Y"%string)); auto.
+  eapply eval_case with (i := 2) (v := VClos [(inl "Y"%string, ttrue)] [] 0 [] (EVar "Y"%string)); auto.
   * apply eval_var.
   * simpl. reflexivity.
   * intros. inversion H.
@@ -880,10 +880,10 @@ Qed.
 
 
 Example letrec_eval : 
-  |[(inr ("fun4"%string, 0), VClosure [] [(("fun4"%string, 0), ([], EEmptyMap))] 0 [] (EEmptyMap)) ; 
-    (inl "X"%string, VLiteral (Integer 42))],
-   ELetrec [("fun2"%string, 0); ("fun4"%string, 1)] [[]; ["Z"%string]] [(EVar "X"%string) ; (EVar "Z"%string)] 
-     (EApply (EFunId ("fun4"%string, 0)) []), []|
+  |[(inr ("fun4"%string, 0), VClos [] [(("fun4"%string, 0), ([], EEmptyMap))] 0 [] (EEmptyMap)) ; 
+    (inl "X"%string, VLit (Integer 42))],
+   ELetRec [("fun2"%string, 0); ("fun4"%string, 1)] [[]; ["Z"%string]] [(EVar "X"%string) ; (EVar "Z"%string)] 
+     (EApp (EFunId ("fun4"%string, 0)) []), []|
 -e>
   |inl (VEmptyMap), []|.
 Proof.
@@ -901,15 +901,15 @@ Qed.
 
 
 Example unnamed_eval : 
-  |[(inl "X"%string, VLiteral (Integer 5))], 
-   EApply (EFun ["Y"%string] (EVar "Y"%string)) [EVar "X"%string], []|
+  |[(inl "X"%string, VLit (Integer 5))], 
+   EApp (EFun ["Y"%string] (EVar "Y"%string)) [EVar "X"%string], []|
 -e> 
-  |inl (VLiteral (Integer 5)), []|.
+  |inl (VLit (Integer 5)), []|.
 Proof.
-  eapply eval_apply with (vals := [VLiteral (Integer 5)]) 
+  eapply eval_apply with (vals := [VLit (Integer 5)]) 
                          (var_list := ["Y"%string]) 
                          (body := (EVar "Y"%string)) 
-                         (ref := [(inl "X"%string, VLiteral (Integer 5))]) 
+                         (ref := [(inl "X"%string, VLit (Integer 5))]) 
                          (ext := []) (eff := [[]]); auto.
   * apply eval_fun.
   * intros. inversion H; inversion H1. apply eval_var.
@@ -921,37 +921,37 @@ Qed.
 Section B_Core.
 
 Definition B : ErlModule := ErlMod "b"%string [
-  TopLevelFun ("fun1"%string, 0) ([], (ELiteral (Integer 6))) ;
-  TopLevelFun ("fun2"%string, 0) ([], (ELet ["X"%string] [(EFun [] (ELiteral (Integer 5)))] (
-                                         ELet ["X"%string] [(EFun [] (ELiteral (Integer 6)))] 
-                                           (EApply (EVar "X"%string) []))) )
+  TopLevelFun ("fun1"%string, 0) ([], (ELit (Integer 6))) ;
+  TopLevelFun ("fun2"%string, 0) ([], (ELet ["X"%string] [(EFun [] (ELit (Integer 5)))] (
+                                         ELet ["X"%string] [(EFun [] (ELit (Integer 6)))] 
+                                           (EApp (EVar "X"%string) []))) )
 ].
 
 
 Example fun2 : 
   |[], 
-   ELet ["X"%string] [(EFun [] (ELiteral (Integer 5)))] 
-     (ELet ["X"%string] [(EFun [] (ELiteral (Integer 6)))] 
-       (EApply (EVar "X"%string) [])), []|
+   ELet ["X"%string] [(EFun [] (ELit (Integer 5)))] 
+     (ELet ["X"%string] [(EFun [] (ELit (Integer 6)))] 
+       (EApp (EVar "X"%string) [])), []|
 -e>
-  | inl (VLiteral (Integer 6)), []|.
+  | inl (VLit (Integer 6)), []|.
 Proof.
-  eapply eval_let with (vals := [VClosure [] [] 0 [] (ELiteral (Integer 5))]) (eff := [[]]); auto.
+  eapply eval_let with (vals := [VClos [] [] 0 [] (ELit (Integer 5))]) (eff := [[]]); auto.
   * simpl. intros. inversion H.
     - apply eval_fun.
     - inversion H1.
   * reflexivity.
-  * simpl. eapply eval_let with (vals := [VClosure [(inl "X"%string, 
-                                             VClosure [] [] 0 [] (ELiteral (Integer 5)))] 
-                                           [] 1 [] (ELiteral (Integer 6))])
+  * simpl. eapply eval_let with (vals := [VClos [(inl "X"%string, 
+                                             VClos [] [] 0 [] (ELit (Integer 5)))] 
+                                           [] 1 [] (ELit (Integer 6))])
                                 (eff := [[]]); auto.
     - simpl. intros. inversion H.
       + apply eval_fun.
       + inversion H1.
     - reflexivity.
     - simpl. eapply eval_apply with (vals := []) (var_list := []) 
-                                    (body := (ELiteral (Integer 6))) 
-                                    (ref := [(inl "X"%string, VClosure [] [] 0 [] (ELiteral (Integer 5)))]) (n := 1)
+                                    (body := (ELit (Integer 6))) 
+                                    (ref := [(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 5)))]) (n := 1)
                                     (ext := []) (eff := []); auto.
       + apply eval_var.
       + intros. inversion H.
@@ -968,11 +968,11 @@ End B_Core.
 Section Documentation_Examples.
 
 Example ex1 : 
-  |[], ELet ["X"%string] [ELiteral (Integer 5)] (EVar "X"%string), []|
+  |[], ELet ["X"%string] [ELit (Integer 5)] (EVar "X"%string), []|
 -e>
-  |inl (VLiteral (Integer 5)), []|.
+  |inl (VLit (Integer 5)), []|.
 Proof.
-  eapply eval_let with (vals := [VLiteral (Integer 5)]) (eff := [[]]).
+  eapply eval_let with (vals := [VLit (Integer 5)]) (eff := [[]]).
   * reflexivity.
   * reflexivity.
   * intros. inversion H.
@@ -984,19 +984,19 @@ Qed.
 
 Example ex2 : 
   |[],
-   ELet ["X"%string] [EFun [] (EApply (EVar "X"%string) [])] 
-     (EApply (EVar "X"%string) []), []|
+   ELet ["X"%string] [EFun [] (EApp (EVar "X"%string) [])] 
+     (EApp (EVar "X"%string) []), []|
 -e>
   |inr novar, []|.
 Proof.
-  eapply eval_let with (vals := [VClosure [] [] 0 [] (EApply ( EVar "X"%string) [])])
+  eapply eval_let with (vals := [VClos [] [] 0 [] (EApp ( EVar "X"%string) [])])
                        (eff := [[]]); auto.
   * intros. inversion H.
     - subst. apply eval_fun.
     - inversion H1.
   * reflexivity.
   * simpl. eapply eval_apply with (vals := []) (var_list := []) 
-                                  (body := (EApply (EVar "X"%string) [])) 
+                                  (body := (EApp (EVar "X"%string) [])) 
                                   (ref := []) (ext := []) (n := 0) (eff := []); auto.
     - apply eval_var.
     - intros. inversion H.
@@ -1007,30 +1007,30 @@ Proof.
 Qed.
 
 Example ex3 :
-  |[], ELetrec [("X"%string, 0)] [[]] [(EApply (EFunId ("X"%string, 0)) [])] 
-         (EApply (EFunId ("X"%string, 0)) []), []|
+  |[], ELetRec [("X"%string, 0)] [[]] [(EApp (EFunId ("X"%string, 0)) [])] 
+         (EApp (EFunId ("X"%string, 0)) []), []|
 -e>
   |inl (VEmptyTuple), []|.
 Proof.
   eapply eval_letrec; try (reflexivity).
   * simpl. eapply eval_apply with (vals := []) (var_list := []) (ref := []) (n := 0) (eff := [])
-                                  (body := (EApply (EFunId ("X"%string, 0)) []))
-                                  (ext := [("X"%string, 0, ([], EApply (EFunId ("X"%string, 0)) []))]); 
+                                  (body := (EApp (EFunId ("X"%string, 0)) []))
+                                  (ext := [("X"%string, 0, ([], EApp (EFunId ("X"%string, 0)) []))]); 
         try (reflexivity).
     - apply eval_funid.
     - intros. inversion H.
     - reflexivity.
     - simpl. eapply eval_apply with (vals := []) (n := 0) (var_list := []) (ref := []) (eff := [])
-                                    (body := (EApply (EFunId ("X"%string, 0)) []))
-                                    (ext := [("X"%string, 0, ([], EApply (EFunId ("X"%string, 0)) []))]); 
+                                    (body := (EApp (EFunId ("X"%string, 0)) []))
+                                    (ext := [("X"%string, 0, ([], EApp (EFunId ("X"%string, 0)) []))]); 
          try (reflexivity).
       + apply eval_funid.
       + intros. inversion H.
       + reflexivity.
       + simpl. eapply eval_apply with (vals := []) (var_list := []) (n := 0) (ref := []) (eff := [])
-                                      (body := (EApply (EFunId ("X"%string, 0)) [])) 
+                                      (body := (EApp (EFunId ("X"%string, 0)) [])) 
                                       (ext := [("X"%string, 0, 
-                                               ([], EApply (EFunId ("X"%string, 0)) []))]); 
+                                               ([], EApp (EFunId ("X"%string, 0)) []))]); 
              try (reflexivity).
         ** apply eval_funid.
         ** intros. inversion H.
@@ -1038,31 +1038,31 @@ Proof.
 Admitted.
 
 Example ex4 : 
-|[], ELet ["X"%string] [ELiteral (Integer 4)] 
+|[], ELet ["X"%string] [ELit (Integer 4)] 
        (ELet ["X"%string] [EFun [] (EVar "X"%string)] 
-          (ELet ["X"%string] [EFun [] (EApply (EVar "X"%string) [])] 
-             (EApply (EVar "X"%string) []))), []|
+          (ELet ["X"%string] [EFun [] (EApp (EVar "X"%string) [])] 
+             (EApp (EVar "X"%string) []))), []|
 -e>
-  |inl (VLiteral (Integer 4)), []|.
+  |inl (VLit (Integer 4)), []|.
 Proof.
-  eapply eval_let with (vals := [VLiteral (Integer 4)]) (eff := [[]]); auto.
+  eapply eval_let with (vals := [VLit (Integer 4)]) (eff := [[]]); auto.
   * intros. inversion H; inversion H1. apply eval_lit.
   * reflexivity.
-  * simpl. eapply eval_let with (vals := [VClosure [(inl "X"%string, VLiteral (Integer 4))] [] 0 [] 
+  * simpl. eapply eval_let with (vals := [VClos [(inl "X"%string, VLit (Integer 4))] [] 0 [] 
                                             (EVar "X"%string)])
                                 (eff := [[]]); auto.
     - intros. inversion H; inversion H1. apply eval_fun.
     - reflexivity.
-    - simpl. eapply eval_let with (vals := [VClosure [(inl "X"%string,
-                                              VClosure [(inl "X"%string, VLiteral (Integer 4))] [] 0 []
-                                                (EVar "X"%string))] [] 1 [] (EApply (EVar "X"%string) []) ])
+    - simpl. eapply eval_let with (vals := [VClos [(inl "X"%string,
+                                              VClos [(inl "X"%string, VLit (Integer 4))] [] 0 []
+                                                (EVar "X"%string))] [] 1 [] (EApp (EVar "X"%string) []) ])
                                   (eff := [[]]); auto.
        + intros. inversion H; inversion H1. apply eval_fun.
        + reflexivity.
        + simpl. eapply eval_apply with (vals := []) (var_list := []) 
-                                       (body := EApply (EVar "X"%string) []) 
+                                       (body := EApp (EVar "X"%string) []) 
                                        (ref := [(inl "X"%string,
-                                                 VClosure [(inl "X"%string, VLiteral (Integer 4))] [] 0 []
+                                                 VClos [(inl "X"%string, VLit (Integer 4))] [] 0 []
                                                    (EVar "X"%string))]) (n := 1)
                                        (ext := []) (eff := []); auto.
          ** apply eval_var.
@@ -1070,7 +1070,7 @@ Proof.
          ** reflexivity.
          ** simpl. eapply eval_apply with (vals := []) (var_list := []) 
                                           (body := EVar "X"%string) 
-                                          (ref := [(inl "X"%string, VLiteral (Integer 4))]) (n := 0)
+                                          (ref := [(inl "X"%string, VLit (Integer 4))]) (n := 0)
                                           (ext := []) (eff := []); auto.
            -- apply eval_var.
            -- intros. inversion H.
@@ -1082,19 +1082,19 @@ End Documentation_Examples.
 
 Example returned_function :
   |[], 
-   ELet ["X"%string] [EFun [] (EFun [] (ELiteral (Integer 5)))] 
-     (EApply (EApply (EVar "X"%string) []) []), []|
+   ELet ["X"%string] [EFun [] (EFun [] (ELit (Integer 5)))] 
+     (EApp (EApp (EVar "X"%string) []) []), []|
 -e>
-  |inl (VLiteral (Integer 5)), []|.
+  |inl (VLit (Integer 5)), []|.
 Proof.
-  eapply eval_let with (vals := [VClosure [] [] 0 [] (EFun [] (ELiteral (Integer 5)))])
+  eapply eval_let with (vals := [VClos [] [] 0 [] (EFun [] (ELit (Integer 5)))])
                        (eff := [[]]); auto.
   * intros. inversion H; inversion H1. apply eval_fun.
   * reflexivity.
   * simpl. eapply eval_apply with (vals := []) (ref := []) (ext := []) (eff := [])
-                                  (body := ELiteral (Integer 5)) (var_list := []); auto.
+                                  (body := ELit (Integer 5)) (var_list := []); auto.
     - eapply eval_apply with (vals := []) (var_list := []) (n := 0)
-                             (body := EFun [] (ELiteral (Integer 5))) 
+                             (body := EFun [] (ELit (Integer 5))) 
                              (ref := []) (ext := []) (eff := []); auto.
       + apply eval_var.
       + intros. inversion H.
@@ -1107,22 +1107,22 @@ Qed.
 
 Example returned_recursive_function : 
   |[], 
-   ELetrec [("fun1"%string, 0)] [[]] [(EFun [] (ELiteral (Integer 5)))] 
-     (EApply (EApply (EFunId ("fun1"%string, 0)) []) []), []|
+   ELetRec [("fun1"%string, 0)] [[]] [(EFun [] (ELit (Integer 5)))] 
+     (EApp (EApp (EFunId ("fun1"%string, 0)) []) []), []|
 -e>
-  |inl (VLiteral (Integer 5)), []|.
+  |inl (VLit (Integer 5)), []|.
 Proof.
   eapply eval_letrec; try (reflexivity).
   * simpl. eapply eval_apply with (vals := []) (ref := [(inr ("fun1"%string, 0),
-                                                         VClosure [] [("fun1"%string, 0, ([], 
-                                                            EFun [] (ELiteral (Integer 5))))] 0 []
-                                                            (EFun [] (ELiteral (Integer 5))))]) 
-                                  (ext := []) (body := ELiteral (Integer 5)) 
+                                                         VClos [] [("fun1"%string, 0, ([], 
+                                                            EFun [] (ELit (Integer 5))))] 0 []
+                                                            (EFun [] (ELit (Integer 5))))]) 
+                                  (ext := []) (body := ELit (Integer 5)) 
                                   (var_list := []) (eff := []); try (reflexivity).
     - eapply eval_apply with (vals := []) (var_list := []) 
-                             (body := EFun [] (ELiteral (Integer 5))) 
+                             (body := EFun [] (ELit (Integer 5))) 
                              (ref := []) (eff := []) (n := 0)
-                             (ext := [("fun1"%string, 0, ([], EFun [] (ELiteral (Integer 5))))]);
+                             (ext := [("fun1"%string, 0, ([], EFun [] (ELit (Integer 5))))]);
           try (reflexivity).
       + apply eval_funid.
       + intros. inversion H.
@@ -1133,22 +1133,22 @@ Proof.
 Qed.
 
 Example returned_function2 :
-  |[(inl "X"%string, VLiteral (Integer 7))],
+  |[(inl "X"%string, VLit (Integer 7))],
    ELet ["X"%string] [EFun [] (EFun [] (EVar "X"%string))] 
-     (EApply (EApply (EVar "X"%string) []) []), []|
+     (EApp (EApp (EVar "X"%string) []) []), []|
 -e>
-  |inl (VLiteral (Integer 7)), []|.
+  |inl (VLit (Integer 7)), []|.
 Proof.
-  eapply eval_let with (vals := [VClosure [(inl "X"%string, VLiteral (Integer 7))] [] 
+  eapply eval_let with (vals := [VClos [(inl "X"%string, VLit (Integer 7))] [] 
                                   0 [] (EFun [] (EVar "X"%string))])
                        (eff := [[]]); auto.
   * intros. inversion H; inversion H1. apply eval_fun.
   * reflexivity.
-  * simpl. eapply eval_apply with (vals := []) (ref := [(inl "X"%string, VLiteral (Integer 7))]) 
+  * simpl. eapply eval_apply with (vals := []) (ref := [(inl "X"%string, VLit (Integer 7))]) 
                                  (ext := []) (body := EVar "X"%string) (var_list := []) (eff := []) (n := 0); auto.
     - eapply eval_apply with (vals := []) (var_list := []) 
                              (body := EFun [] (EVar "X"%string)) 
-                             (ref := [(inl "X"%string, VLiteral (Integer 7))]) 
+                             (ref := [(inl "X"%string, VLit (Integer 7))]) 
                              (ext := []) (n := 0) (eff := []); auto.
       + apply eval_var.
       + intros. inversion H.
@@ -1160,17 +1160,17 @@ Proof.
 Qed.
 
 Example returned_recursive_function2 :
-  |[(inl "X"%string, VLiteral (Integer 7))], 
-   ELetrec [("fun1"%string, 0)] [[]] [(EFun [] (EVar "X"%string))] 
-     (EApply (EApply (EFunId ("fun1"%string, 0)) []) []), []|
+  |[(inl "X"%string, VLit (Integer 7))], 
+   ELetRec [("fun1"%string, 0)] [[]] [(EFun [] (EVar "X"%string))] 
+     (EApp (EApp (EFunId ("fun1"%string, 0)) []) []), []|
 -e>
-  |inl (VLiteral (Integer 7)), []|.
+  |inl (VLit (Integer 7)), []|.
 Proof.
   eapply eval_letrec; try (reflexivity).
   * simpl. eapply eval_apply with (vals := []) (eff := [])
-                                 (ref := [(inl "X"%string, VLiteral (Integer 7)) ; 
+                                 (ref := [(inl "X"%string, VLit (Integer 7)) ; 
                                           (inr ("fun1"%string, 0),
-                                             VClosure [(inl "X"%string, VLiteral (Integer 7))] 
+                                             VClos [(inl "X"%string, VLit (Integer 7))] 
                                                       [("fun1"%string, 0, 
                                                           ([], EFun [] (EVar "X"%string)))] 
                                                       0 [] 
@@ -1179,7 +1179,7 @@ Proof.
                                  (var_list := []) (ext := []); try (reflexivity).
     - eapply eval_apply with (vals := []) (var_list := []) (eff := [])
                              (body := EFun [] (EVar "X"%string)) (n := 0)
-                             (ref := [(inl "X"%string, VLiteral (Integer 7))]) 
+                             (ref := [(inl "X"%string, VLit (Integer 7))]) 
                              (ext := [("fun1"%string, 0, ([], EFun [] (EVar "X"%string)))]); 
           try (reflexivity).
       + apply eval_funid.
@@ -1195,18 +1195,18 @@ Example returned_function3 :
    ELet ["F"%string] [
      EFun ["X"%string] 
         (ELet ["Y"%string] 
-              [ECall "plus"%string [EVar "X"%string; ELiteral (Integer 3)] ] 
+              [ECall "plus"%string [EVar "X"%string; ELit (Integer 3)] ] 
               (EFun ["Z"%string] 
                     (ECall "plus"%string 
                           [ECall "plus"%string [EVar "X"%string; EVar "Y"%string]
                      ; EVar "Z"%string])))]
-  (EApply (EApply (EVar "F"%string) [ELiteral (Integer 1)]) [ELiteral (Integer 1)]), []|
+  (EApp (EApp (EVar "F"%string) [ELit (Integer 1)]) [ELit (Integer 1)]), []|
 -e>
-  |inl (VLiteral (Integer 6)), []|.
+  |inl (VLit (Integer 6)), []|.
 Proof.
-  eapply eval_let with (vals := [VClosure [] [] 0 ["X"%string] (ELet ["Y"%string]
+  eapply eval_let with (vals := [VClos [] [] 0 ["X"%string] (ELet ["Y"%string]
                                         [ECall "plus"
-                                           [EVar "X"%string; ELiteral (Integer 3)] ]
+                                           [EVar "X"%string; ELit (Integer 3)] ]
                                         (EFun ["Z"%string]
                                            (ECall "plus"
                                               [ECall "plus"
@@ -1220,13 +1220,13 @@ Proof.
                                               [ECall "plus"
                                                  [EVar "X"%string; EVar "Y"%string];
                                               EVar "Z"%string]))
-                                  (ref := [(inl "X"%string, VLiteral (Integer 1)); 
-                                           (inl "Y"%string, VLiteral (Integer 4))])
-                                  (ext := []) (vals := [VLiteral (Integer 1)]); auto.
-    - eapply eval_apply with (vals := [VLiteral (Integer 1)]) (var_list := ["X"%string]) 
+                                  (ref := [(inl "X"%string, VLit (Integer 1)); 
+                                           (inl "Y"%string, VLit (Integer 4))])
+                                  (ext := []) (vals := [VLit (Integer 1)]); auto.
+    - eapply eval_apply with (vals := [VLit (Integer 1)]) (var_list := ["X"%string]) 
                              (body := ELet ["Y"%string]
                                         [ECall "plus"
-                                           [EVar "X"%string; ELiteral (Integer 3)] ]
+                                           [EVar "X"%string; ELit (Integer 3)] ]
                                         (EFun ["Z"%string]
                                            (ECall "plus"
                                               [ECall "plus"
@@ -1236,9 +1236,9 @@ Proof.
       + apply eval_var.
       + intros. inversion H; inversion H1. apply eval_lit.
       + reflexivity.
-      + eapply eval_let with (vals := [VLiteral (Integer 4)]) (eff := [[]]); auto.
+      + eapply eval_let with (vals := [VLit (Integer 4)]) (eff := [[]]); auto.
         ** intros. inversion H; inversion H1. 
-           apply eval_call with (vals := [VLiteral (Integer 1); VLiteral (Integer 3)])
+           apply eval_call with (vals := [VLit (Integer 1); VLit (Integer 3)])
                                 (eff := [[];[]]); auto.
           -- intros. inversion H2.
             ++ apply eval_lit.
@@ -1246,12 +1246,12 @@ Proof.
         ** simpl. apply eval_fun.
     - intros. inversion H; inversion H1. apply eval_lit.
     - reflexivity.
-    - eapply eval_call with (vals := [VLiteral (Integer 5) ; VLiteral (Integer 1)])
+    - eapply eval_call with (vals := [VLit (Integer 5) ; VLit (Integer 1)])
                             (eff := [[];[]]); auto.
       + intros. inversion H.
         ** inversion H1. apply eval_var.
         ** inversion H1.
-          -- eapply eval_call with (vals := [VLiteral (Integer 1) ; VLiteral (Integer 4)])
+          -- eapply eval_call with (vals := [VLit (Integer 1) ; VLit (Integer 4)])
                                                (eff := [[];[]]); auto.
             ++ intros. inversion H2.
               *** apply eval_var.
@@ -1261,112 +1261,112 @@ Qed.
 
 Example sum :
   | [],
-    ELetrec [("f"%string, 1)] [["X"%string]] 
+    ELetRec [("f"%string, 1)] [["X"%string]] 
       [
-      ECase (EVar "X"%string) [PLiteral (Integer 0); PVar "Y"%string]
-                              [ELiteral (Atom "true"%string); ELiteral (Atom "true"%string)]
+      ECase (EVar "X"%string) [PLit (Integer 0); PVar "Y"%string]
+                              [ELit (Atom "true"%string); ELit (Atom "true"%string)]
                               [
-                              ELiteral (Integer 0)
+                              ELit (Integer 0)
                               ;
                               ECall "plus"%string [
                                      EVar "Y"%string; 
-                                     EApply (EFunId ("f"%string, 1)) [ECall "plus"%string [EVar "Y"%string; ELiteral (Integer (Z.pred 0))] ]
+                                     EApp (EFunId ("f"%string, 1)) [ECall "plus"%string [EVar "Y"%string; ELit (Integer (Z.pred 0))] ]
                               ]
-     ] ] (EApply (EFunId ("f"%string, 1)) [ELiteral (Integer 2)]), []| -e> |inl (VLiteral (Integer 3)), []|.
+     ] ] (EApp (EFunId ("f"%string, 1)) [ELit (Integer 2)]), []| -e> |inl (VLit (Integer 3)), []|.
 Proof.
   eapply eval_letrec; auto.
   2: reflexivity.
-  * simpl. eapply eval_apply with (vals := [VLiteral (Integer 2)]) (eff := [[]]) (eff2 := []) (n := 0)
+  * simpl. eapply eval_apply with (vals := [VLit (Integer 2)]) (eff := [[]]) (eff2 := []) (n := 0)
                                   (var_list := ["X"%string]) (ref := []) 
                                   (body := 
-      (ECase (EVar "X"%string) [PLiteral (Integer 0); PVar "Y"%string]
-        [ELiteral (Atom "true"); ELiteral (Atom "true")]
-        [ELiteral (Integer 0);
+      (ECase (EVar "X"%string) [PLit (Integer 0); PVar "Y"%string]
+        [ELit (Atom "true"); ELit (Atom "true")]
+        [ELit (Integer 0);
         ECall "plus"
           [EVar "Y"%string;
-          EApply (EFunId ("f"%string, 1))
-            [ECall "plus" [EVar "Y"%string; ELiteral (Integer (-1))]]]]))
+          EApp (EFunId ("f"%string, 1))
+            [ECall "plus" [EVar "Y"%string; ELit (Integer (-1))]]]]))
                                   (ext := [("f"%string, 1,
                                       (["X"%string],
-                                      ECase (EVar "X"%string) [PLiteral (Integer 0); PVar "Y"%string]
-                                        [ELiteral (Atom "true"); ELiteral (Atom "true")]
-                                        [ELiteral (Integer 0);
+                                      ECase (EVar "X"%string) [PLit (Integer 0); PVar "Y"%string]
+                                        [ELit (Atom "true"); ELit (Atom "true")]
+                                        [ELit (Integer 0);
                                         ECall "plus"
                                           [EVar "Y"%string;
-                                          EApply (EFunId ("f"%string, 1))
+                                          EApp (EFunId ("f"%string, 1))
                                             [ECall "plus" [EVar "Y"%string; 
-                                                ELiteral (Integer (-1))]]]]))]); simpl; auto.
+                                                ELit (Integer (-1))]]]]))]); simpl; auto.
     - apply eval_funid.
     - intros. inversion H; inversion H1. apply eval_lit.
-    - unfold concatn. simpl. eapply eval_case with (i := 1) (v := VLiteral (Integer 2)); auto.
+    - unfold concatn. simpl. eapply eval_case with (i := 1) (v := VLit (Integer 2)); auto.
       + apply eval_var.
       + simpl. reflexivity.
       + intros. inversion H; inversion H2. subst. inversion H0.
       + reflexivity.
       + simpl. apply eval_lit.
-      + eapply eval_call with (vals := [VLiteral (Integer 2); VLiteral (Integer 1)]) (eff := [[]; []]); auto.
+      + eapply eval_call with (vals := [VLit (Integer 2); VLit (Integer 1)]) (eff := [[]; []]); auto.
         ** intros. inversion H; inversion H1. 3: inversion H3.
-          -- simpl. eapply eval_apply with (vals := [VLiteral (Integer 1)]) (eff := [[]]) (eff2 := [])
+          -- simpl. eapply eval_apply with (vals := [VLit (Integer 1)]) (eff := [[]]) (eff2 := [])
                                   (var_list := ["X"%string]) (ref := []) 
                                   (body := 
-      (ECase (EVar "X"%string) [PLiteral (Integer 0); PVar "Y"%string]
-        [ELiteral (Atom "true"); ELiteral (Atom "true")]
-        [ELiteral (Integer 0);
+      (ECase (EVar "X"%string) [PLit (Integer 0); PVar "Y"%string]
+        [ELit (Atom "true"); ELit (Atom "true")]
+        [ELit (Integer 0);
         ECall "plus"
           [EVar "Y"%string;
-          EApply (EFunId ("f"%string, 1))
-            [ECall "plus" [EVar "Y"%string; ELiteral (Integer (-1))]]]]))
+          EApp (EFunId ("f"%string, 1))
+            [ECall "plus" [EVar "Y"%string; ELit (Integer (-1))]]]]))
                                   (ext := [("f"%string, 1,
                                       (["X"%string],
-                                      ECase (EVar "X"%string) [PLiteral (Integer 0); PVar "Y"%string]
-                                        [ELiteral (Atom "true"); ELiteral (Atom "true")]
-                                        [ELiteral (Integer 0);
+                                      ECase (EVar "X"%string) [PLit (Integer 0); PVar "Y"%string]
+                                        [ELit (Atom "true"); ELit (Atom "true")]
+                                        [ELit (Integer 0);
                                         ECall "plus"
                                           [EVar "Y"%string;
-                                          EApply (EFunId ("f"%string, 1))
+                                          EApp (EFunId ("f"%string, 1))
                                             [ECall "plus" [EVar "Y"%string; 
-                                                ELiteral (Integer (-1))]]]]))]) (n := 0); simpl; auto.
+                                                ELit (Integer (-1))]]]]))]) (n := 0); simpl; auto.
             ++ apply eval_funid.
-            ++ intros. inversion H2; inversion H4. eapply eval_call with (vals := [VLiteral (Integer 2); VLiteral (Integer (-1))]) (eff := [[];[]]); auto.
+            ++ intros. inversion H2; inversion H4. eapply eval_call with (vals := [VLit (Integer 2); VLit (Integer (-1))]) (eff := [[];[]]); auto.
               *** simpl. intros. inversion H5; inversion H7. 3: inversion H9.
                 --- apply eval_lit.
                 --- apply eval_var.
             ++ {
-            eapply eval_case with (i := 1) (v := VLiteral (Integer 1)); auto.
+            eapply eval_case with (i := 1) (v := VLit (Integer 1)); auto.
               + apply eval_var.
               + simpl. reflexivity.
               + intros. inversion H2; inversion H5. subst. inversion H3.
               + reflexivity.
               + simpl. apply eval_lit.
-              + subst. simpl. eapply eval_call with (vals := [VLiteral (Integer 1); VLiteral (Integer (0))]) (eff := [[];[]]); auto.
+              + subst. simpl. eapply eval_call with (vals := [VLit (Integer 1); VLit (Integer (0))]) (eff := [[];[]]); auto.
                 * simpl. intros. inversion H1; inversion H3. 3: inversion H5. 
-                  - eapply eval_apply with (vals := [VLiteral (Integer 0)]) (eff := [[]]) (eff2 := [])
+                  - eapply eval_apply with (vals := [VLit (Integer 0)]) (eff := [[]]) (eff2 := [])
                                   (var_list := ["X"%string]) (ref := []) (n := 0)
                                   (body := 
-      (ECase (EVar "X"%string) [PLiteral (Integer 0); PVar "Y"%string]
-        [ELiteral (Atom "true"); ELiteral (Atom "true")]
-        [ELiteral (Integer 0);
+      (ECase (EVar "X"%string) [PLit (Integer 0); PVar "Y"%string]
+        [ELit (Atom "true"); ELit (Atom "true")]
+        [ELit (Integer 0);
         ECall "plus"
           [EVar "Y"%string;
-          EApply (EFunId ("f"%string, 1))
-            [ECall "plus" [EVar "Y"%string; ELiteral (Integer (-1))]]]]))
+          EApp (EFunId ("f"%string, 1))
+            [ECall "plus" [EVar "Y"%string; ELit (Integer (-1))]]]]))
                                   (ext := [("f"%string, 1,
                                       (["X"%string],
-                                      ECase (EVar "X"%string) [PLiteral (Integer 0); PVar "Y"%string]
-                                        [ELiteral (Atom "true"); ELiteral (Atom "true")]
-                                        [ELiteral (Integer 0);
+                                      ECase (EVar "X"%string) [PLit (Integer 0); PVar "Y"%string]
+                                        [ELit (Atom "true"); ELit (Atom "true")]
+                                        [ELit (Integer 0);
                                         ECall "plus"
                                           [EVar "Y"%string;
-                                          EApply (EFunId ("f"%string, 1))
+                                          EApp (EFunId ("f"%string, 1))
                                             [ECall "plus" [EVar "Y"%string; 
-                                                ELiteral (Integer (-1))]]]]))]); simpl; auto.
+                                                ELit (Integer (-1))]]]]))]); simpl; auto.
                   ** apply eval_funid.
-                  ** intros. inversion H4. 2: inversion H6. eapply eval_call with (vals := [VLiteral (Integer 1); VLiteral (Integer (-1))]) (eff := [[];[]]); auto.
+                  ** intros. inversion H4. 2: inversion H6. eapply eval_call with (vals := [VLit (Integer 1); VLit (Integer (-1))]) (eff := [[];[]]); auto.
                     -- intros. inversion H5; inversion H8.
                       ++ simpl. apply eval_lit.
                       ++ simpl. apply eval_var.
                       ++ inversion H10.
-                  ** eapply eval_case with (i := 0) (v := VLiteral (Integer 0)); auto.
+                  ** eapply eval_case with (i := 0) (v := VLit (Integer 0)); auto.
                     -- apply eval_var.
                     -- simpl. omega.
                     -- reflexivity.
@@ -1381,25 +1381,25 @@ Qed.
 
 Example letrec_no_replace :
   |[], 
-   ELet ["X"%string] [ELiteral (Integer 42)] 
-     (ELetrec [("f"%string, 0)] [[]] [EVar "X"%string]
-       (ELet ["X"%string] [ELiteral (Integer 5)] 
-         (EApply (EFunId ("f"%string, 0)) []))), []|
+   ELet ["X"%string] [ELit (Integer 42)] 
+     (ELetRec [("f"%string, 0)] [[]] [EVar "X"%string]
+       (ELet ["X"%string] [ELit (Integer 5)] 
+         (EApp (EFunId ("f"%string, 0)) []))), []|
 -e>
-  |inl (VLiteral (Integer 42)), []|.
+  |inl (VLit (Integer 42)), []|.
 Proof.
-  eapply eval_let with (vals := [VLiteral (Integer 42)]) (eff := [[]]); auto.
+  eapply eval_let with (vals := [VLit (Integer 42)]) (eff := [[]]); auto.
   * intros. inversion H; inversion H1.
     - apply eval_lit.
   * reflexivity.
   * simpl. eapply eval_letrec; auto.
     2: reflexivity.
-    - eapply eval_let with (vals := [VLiteral (Integer 5)]) (eff := [[]]); auto.
+    - eapply eval_let with (vals := [VLit (Integer 5)]) (eff := [[]]); auto.
       + intros. inversion H; inversion H1.
         ** apply eval_lit.
       + simpl. eapply eval_apply with (vals := []) (var_list := []) 
                                       (body := (EVar "X"%string)) 
-                                      (ref := [(inl "X"%string, VLiteral (Integer 42))]) 
+                                      (ref := [(inl "X"%string, VLit (Integer 42))]) 
                                       (ext := [("f"%string, 0, ([], EVar "X"%string))]) (eff := []) (n := 0); auto.
         ** apply eval_funid.
         ** intros. inversion H.

--- a/Erl_codes/attempt.core
+++ b/Erl_codes/attempt.core
@@ -37,16 +37,17 @@ module 'attempt' ['alma'/0,
 			<Z> when 'true' -> Z
 		end
 
-'ex2'/0 =
-    %% Line 4
-    fun () ->
-	let <_1> =
-	    fun () ->
-		%% Line 5
-		5
-	in  %% Line 6
-	    apply _1
-		()
+'ex2'/0 = fun() ->
+	letrec 'f1'/0 = fun() -> 5
+           'f2'/0 = fun() -> 6  
+           'f3'/0 = fun() -> 6  
+		   'f4'/0 = fun() -> 6
+		   'f5'/0 = fun() -> 6
+		   'f6'/0 = fun() -> 6
+		   in
+		   {'f1'/0, 'f2'/0, 'f3'/0, 'f4'/0, 'f5'/0, 'f6'/0}
+    
+
 'list_ex'/0 =
     %% Line 8
     fun () ->

--- a/Erl_codes/attempt.core
+++ b/Erl_codes/attempt.core
@@ -17,7 +17,7 @@ module 'attempt' ['alma'/0,
 		  'module_info'/0,
 		  'module_info'/1,
 		  'sums'/3,
-		  'case_eval'/0,
+		  'case_eval'/1,
 		  'tuplemod'/0]
     attributes [%% Line 1
 		'file' =
@@ -28,14 +28,12 @@ module 'attempt' ['alma'/0,
 		    %% Line 2
 		    ['export_all']]
 
-'case_eval'/0 = fun() ->
-	let Y = fun() -> 'true' in
-	let X = {} in
-		case X of
-			<5> when 'true' -> 5
-			<6> when 'true' -> 6
-			<Z> when 'true' -> Z
-		end
+'case_eval'/1 = fun(X) ->
+	case X of
+		<5> when 'true' -> 5
+		<6> when 'true' -> 6
+		<7> when 'true' -> 7
+	end
 
 'ex2'/0 = fun() ->
 	letrec 'f1'/0 = fun() -> 5

--- a/Erl_codes/attempt.core
+++ b/Erl_codes/attempt.core
@@ -110,7 +110,7 @@ module 'attempt' ['alma'/0,
 'f1'/0 =
     %% Line 34
     fun () ->
-	5
+	let <X, Y> = <4, 5> in 5
 'f1'/1 =
     %% Line 35
     fun (_0) ->

--- a/Erl_codes/attempt.core
+++ b/Erl_codes/attempt.core
@@ -17,6 +17,7 @@ module 'attempt' ['alma'/0,
 		  'module_info'/0,
 		  'module_info'/1,
 		  'sums'/3,
+		  'case_eval'/0,
 		  'tuplemod'/0]
     attributes [%% Line 1
 		'file' =
@@ -26,6 +27,16 @@ module 'attempt' ['alma'/0,
 		'compile' =
 		    %% Line 2
 		    ['export_all']]
+
+'case_eval'/0 = fun() ->
+	let Y = fun() -> 'true' in
+	let X = {} in
+		case X of
+			<5> when 'true' -> 5
+			<6> when 'true' -> 6
+			<Z> when 'true' -> Z
+		end
+
 'ex2'/0 =
     %% Line 4
     fun () ->

--- a/Erl_codes/tests.core
+++ b/Erl_codes/tests.core
@@ -3,6 +3,7 @@ module 'tests' ['module_info'/0,
 		'eval_letrec1'/0,
 		%'eval_letrec2'/0,
 		'eval_multiple_top_level_funs'/0,
+		'eval_multiple_top_level_funs2'/0,
 		'top_overwrite'/0,
 		'top_no_overwrite'/0,
 		%'eval_let_func'/0,
@@ -21,6 +22,7 @@ module 'tests' ['module_info'/0,
 		'map_eval'/0,
 		'map_eval2'/0,
 		'map_eval3'/0,
+		'map_eval4'/0,
 		'let_closure_apply_eval_without_overwrite'/0,	
 		'let_closure_apply_eval_without_overwrite2'/0,
 		'call_eval'/0,
@@ -70,6 +72,12 @@ module 'tests' ['module_info'/0,
 'eval_multiple_top_level_funs'/0 = fun() ->
 	apply 'fun1'/0()
 
+'eval_multiple_top_level_funs2'/0 = fun() ->
+	letrec  'fun1'/0 = fun() -> apply 'fun3'/0()
+			'fun2'/0 = fun() -> 42
+			'fun3'/0 = fun() -> apply 'fun2'/0() in 
+      apply 'fun1'/0()
+
 'top_overwrite'/0 = fun() ->
 	letrec 'fun2'/0 = fun() -> 40 in apply 'fun2'/0()
 	
@@ -103,7 +111,7 @@ module 'tests' ['module_info'/0,
 	let X = 5 in X
 
 'tuple_eval'/0 = fun() ->
-	let <X, Y> = <'asd', {}> in {5, X, Y}
+	let <X, Y> = <'foo', {}> in {5, X, Y}
 
 'Plus'/2 = fun(X, Y) -> 3
 
@@ -136,6 +144,10 @@ module 'tests' ['module_info'/0,
 'map_eval3'/0 = fun() ->
 	let X = 5 in
 		~{5 => X, X => call 'erlang':'+'(1, X)}~
+
+'map_eval4'/0 = fun() ->
+	let <X, Y, Z> = <fun() -> 1, fun() -> 2, fun() -> 3> in
+		~{Z => 10, X => 11, Y => 12, X => 13}~
 
 'let_closure_apply_eval_without_overwrite'/0 = fun() ->
 	let X = 42 in


### PR DESCRIPTION
Create unique identifier for closure values. This pull request includes the followings:

- Additional field in the closure constructor
- Order and equality based on this field between closures
- Modified helper functions (append_funs_to_env, get_env)
- Additional cells in the semantic relation to use a global identifier which can be increased and assigned to closures
- Updated tests and proofs