### PR TITLE
Value list adjustment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ stack.yaml.lock
 .stack-work/
 .vscode/
 .history/
+*.lia.cache
+src/gen_test.v

--- a/Erl_codes/b.core
+++ b/Erl_codes/b.core
@@ -31,7 +31,27 @@ module 'b' ['module_info'/0,
 
 'fun1'/0 =
 	fun() ->
-		6
+%		 case 
+%		   {<2, 3>, 4}
+%		 of
+%		  {W, Q} when 'true' -> W
+%		  Q when 'true' -> 5
+%		 end
+%	let <X, Y> = let <W, Z> = < <3, 4>, 6> in W in {X, Y}
+%	{<3>, <4>, <5>}
+%	let <X, Y, Z> = <fun() -> 5, fun() -> 5, fun() -> 5> in {X, Y, Z}
+%	let X = fun() -> <3, 4, 5> in let <Y, Z, W> = apply X() in {Y, Z, W}
+%	let <X> =
+%		case 5 of
+%		  5 when 'true' -> <2>
+%		  X when 'true' -> 1
+%		end
+%	in
+%		{X, X}
+%[3, <>, 5]
+%do <3, 4, 5>
+%   4
+
 
 'fun2'/0 =
 	fun() ->
@@ -48,7 +68,7 @@ module 'b' ['module_info'/0,
 
 'fun6'/0 =
 	fun() -> let X = 5 in
-				let X = fun(X, X) -> X in apply X(4,fun() -> 5)
+				let X = fun(X, Y) -> X in apply X(4,fun() -> 5)
 'fun7'/0 =
 	fun() -> fun() -> 5
 
@@ -56,7 +76,7 @@ module 'b' ['module_info'/0,
 	fun(X) -> let Y = fun() -> 5 in let Y = fun(A) -> A in apply Y()
 	
 'fun8'/0 =
-	fun() -> let X = 5 in let <X, X, Y> = <3,4,X> in Y
+	fun() -> let X = 5 in let <X, Z, Y> = <3,4,X> in Y
 
 'fun9'/0 =
 	fun() -> let Y = fun() -> 5 in let Z = 5 in apply Y()

--- a/Erl_codes/tests.core
+++ b/Erl_codes/tests.core
@@ -41,7 +41,8 @@ module 'tests' ['module_info'/0,
 		'weird_apply'/0,
 		'sum'/0,
 		'letrec_no_replace'/0,
-		'seq_eval1'/0
+		'seq_eval1'/0,
+		'fun4'/0
 		]
     attributes [%% Line 1
 		'file' =
@@ -189,13 +190,13 @@ module 'tests' ['module_info'/0,
 'case_eval_fun'/0 = fun() ->
 	let Y = 'true' in
 		let X = fun() -> Y in
-			case X of
-				<5> when 'true' -> 5
-				<6> when 'true' -> 6
-				<Z> when 'true' -> apply Z()
+			case <X, Y> of
+				<5, 'true'> when 'true' -> 5
+				<6, 'true'> when 'true' -> 6
+				<Z, 'true'> when 'true' -> apply Z()
 			end
 
-'fun4'/0 = fun() -> ~{}~
+'fun4'/0 = fun() -> let <X, Y, Z> = <[], let Y = 5 in Y, call 'erlang':'+'(3, 4)> in {X, Y, Z}
 
 'letrec_eval'/0 = fun() ->
 	let X = 42 in

--- a/compilationorder.txt
+++ b/compilationorder.txt
@@ -1,0 +1,13 @@
+coqc Core_Erlang_Syntax.v
+coqc Core_Erlang_Equalities.v
+coqc Core_Erlang_Helpers.v
+coqc Core_Erlang_Environment.v
+coqc Core_Erlang_Side_Effects.v
+coqc Core_Erlang_Auxiliaries.v
+coqc Core_Erlang_Functional_Big_Step.v
+coqc Core_Erlang_Semantics.v
+coqc Core_Erlang_Tactics.v
+coqc Core_Erlang_Automated_Tests.v
+coqc Core_Erlang_Automated_Exception_Tests.v
+coqc Core_Erlang_Automated_Side_Effect_Tests.v
+coqc Core_Erlang_Automated_Side_Effect_Exception_Tests.v

--- a/compilationorder.txt
+++ b/compilationorder.txt
@@ -11,3 +11,5 @@ coqc Core_Erlang_Automated_Tests.v
 coqc Core_Erlang_Automated_Exception_Tests.v
 coqc Core_Erlang_Automated_Side_Effect_Tests.v
 coqc Core_Erlang_Automated_Side_Effect_Exception_Tests.v
+coqc Core_Erlang_Determinism_Helpers.v
+coqc Core_Erlang_Proofs.v

--- a/compilationorder.txt
+++ b/compilationorder.txt
@@ -13,3 +13,4 @@ coqc Core_Erlang_Automated_Side_Effect_Tests.v
 coqc Core_Erlang_Automated_Side_Effect_Exception_Tests.v
 coqc Core_Erlang_Determinism_Helpers.v
 coqc Core_Erlang_Proofs.v
+coqc Core_Erlang_Equivalence_Proofs.v

--- a/src/Core_Erlang_Automated_Exception_Tests.v
+++ b/src/Core_Erlang_Automated_Exception_Tests.v
@@ -15,7 +15,7 @@ Import ListNotations.
 *)
 Example eval_exception_call_fbs :
   (forall (env : Environment) (eff : SideEffectList) (id : nat), 
-  fbs_expr env id (ECall "+" [^ELit (Integer 5); ^ETuple []]) eff 1000 = Result id (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) eff).
+  fbs_expr 1000 env id (ECall "+" [^ELit (Integer 5); ^ETuple []]) eff = Result id (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) eff).
 Proof.
   intros. simpl. reflexivity.
 Qed.
@@ -32,7 +32,7 @@ Qed.
 
 
 Example exception_var_fbs :
-  fbs_expr [] 0 (EVar "X"%string) [] 1000 = Result 0 (inr novar) [].
+  fbs_expr 1000 [] 0 (EVar "X"%string) [] = Result 0 (inr novar) [].
 Proof.
   simpl. reflexivity.
 Qed.
@@ -47,10 +47,9 @@ Proof.
 Qed.
 
 Example exception_list_hd_fbs :
-  fbs_expr [] 0 
+  fbs_expr 1000 [] 0 
   (ECons (ECall "+" [^ELit (Integer 5); ^ETuple []]) (ELit (Atom "error"%string))) 
-  [] 1000
-  = Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
+  [] = Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
   simpl. reflexivity.
 Qed.
@@ -64,7 +63,7 @@ Proof.
 Qed.
 
 Example exception_list_tl_fbs : 
-  fbs_expr [] 0 (ECons (ELit (Atom "error"%string)) (ECons (ECall "+" [^ELit (Integer 5); ^ETuple []]) (ENil))) [] 1000
+  fbs_expr 1000 [] 0 (ECons (ELit (Atom "error"%string)) (ECons (ECall "+" [^ELit (Integer 5); ^ETuple []]) (ENil))) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -80,7 +79,7 @@ Proof.
 Qed.
 
 Example exception_tuple_fbs : 
-  fbs_expr [] 0 (ETuple [^ELit (Atom "error"%string) ; ^ELit (Atom "error"%string); ^ECall "+" [^ELit (Integer 5); ^ETuple []]]) [] 1000
+  fbs_expr 1000 [] 0 (ETuple [^ELit (Atom "error"%string) ; ^ELit (Atom "error"%string); ^ECall "+" [^ELit (Integer 5); ^ETuple []]]) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -96,11 +95,12 @@ Proof.
 Qed.
 
 Example try_eval_fbs : 
-  fbs_expr [] 0 (ETry (ETuple []) ["X"%string]
+  fbs_expr 1000 [] 0 
+               (ETry (ETuple []) ["X"%string]
                (ELit (Atom "ok"%string)) 
                ["Ex1"%string; "Ex2"%string; "Ex3"%string]
                (ELit (Atom "error"%string)))
-  [] 1000
+  []
 =
   Result 0 (inl [ok]) []
 .
@@ -122,11 +122,12 @@ Proof.
 Qed.
 
 Example try_eval_catch_fbs : 
-  fbs_expr [] 0 (ETry (ECall "+" [^ELit (Integer 5); ^ETuple []]) ["X"%string]
+  fbs_expr 1000 [] 0 
+               (ETry (ECall "+" [^ELit (Integer 5); ^ETuple []]) ["X"%string]
                (ELit (Atom "ok"%string))
                ["Ex1"%string; "Ex2"%string; "Ex3"%string]
                (ELit (Atom "error"%string)))
-  [] 1000
+  []
 =
   Result 0 (inl [VLit (Atom "error"%string)]) []
 .
@@ -148,11 +149,12 @@ Proof.
 Qed.
 
 Example try_eval_exception_fbs : 
-  fbs_expr [] 0 (ETry (ECall "+" [^ELit (Integer 5); ^ETuple []]) ["X"%string]
+  fbs_expr 1000 [] 0 
+               (ETry (ECall "+" [^ELit (Integer 5); ^ETuple []]) ["X"%string]
                (ELit (Atom "ok"%string))
                ["Ex1"%string; "Ex2"%string; "Ex3"%string]
                (ECall "+" [^ELit (Integer 5); ^ETuple []]))
-  [] 1000
+  []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) []
 .
@@ -174,11 +176,12 @@ Proof.
 Qed.
 
 Example try_eval_exception2_fbs : 
-  fbs_expr [] 0 (ETry (ETuple []) ["X"%string]
+  fbs_expr 1000 [] 0 
+               (ETry (ETuple []) ["X"%string]
                (ECall "+" [^ELit (Integer 5); ^ETuple []])
                ["Ex1"%string; "Ex2"%string; "Ex3"%string]
                (ELit (Atom "error"%string)))
-  [] 1000
+  []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) []
 .
@@ -200,8 +203,8 @@ Proof.
 Qed.
 
 Example eval_case_pat_ex_fbs :
-  fbs_expr [] 0 (ECase (ECall "+" [^ELit (Integer 5); ^ETuple []])
-                 [([PVar "X"%string], ^ELit (Atom "true"), ^ELit (Integer 1))]) [] 1000
+  fbs_expr 1000 [] 0 (ECase (ECall "+" [^ELit (Integer 5); ^ETuple []])
+                 [([PVar "X"%string], ^ELit (Atom "true"), ^ELit (Integer 1))]) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -218,10 +221,10 @@ Proof.
 Qed.
 
 Example eval_case_clause_ex_fbs :
-  fbs_expr [(inl "Y"%string, VLit (Integer 2))] 0
+  fbs_expr 1000 [(inl "Y"%string, VLit (Integer 2))] 0
      (ECase (EVar "Y"%string)
           [([PLit (Integer 1)], ^ELit (Atom "true"), ^ELit (Integer 1)); 
-           ([PVar "Z"%string], ^ELit (Atom "false"), ^ELit (Integer 2))]) [] 1000
+           ([PVar "Z"%string], ^ELit (Atom "false"), ^ELit (Integer 2))]) []
 =
   Result 0 (inr (if_clause)) [].
 Proof.
@@ -240,7 +243,7 @@ Proof.
 Qed.
 
 Example call_eval_body_ex_fbs : 
-  fbs_expr [] 0 (ECall "+"%string []) [] 1000
+  fbs_expr 1000 [] 0 (ECall "+"%string []) []
 =
   Result 0 (inr (undef (VLit (Atom "+")))) [].
 Proof.
@@ -256,7 +259,7 @@ Proof.
 Qed.
 
 Example call_eval_body_ex2_fbs :
-  fbs_expr [] 0 (ECall "+"%string [^ELit (Integer 5); ^ETuple []]) [] 1000
+  fbs_expr 1000 [] 0 (ECall "+"%string [^ELit (Integer 5); ^ETuple []]) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -272,7 +275,7 @@ Proof.
 Qed.
 
 Example call_eval_param_ex_fbs :
-  fbs_expr [] 0 (ECall "+"%string [^ELit (Integer 5); ^ECall "+" [^ELit (Integer 5); ^ETuple []]]) [] 1000
+  fbs_expr 1000 [] 0 (ECall "+"%string [^ELit (Integer 5); ^ECall "+" [^ELit (Integer 5); ^ETuple []]]) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -288,8 +291,8 @@ Proof.
 Qed.
 
 Example let_eval_exception_params_fbs :
-  fbs_expr [] 0 (ELet ["X"%string; "Y"%string] 
-               (EValues [ELit (Integer 5); ECall "+" [^ELit (Integer 5); ^ETuple []]]) (ETuple [])) [] 1000
+  fbs_expr 1000 [] 0 (ELet ["X"%string; "Y"%string] 
+               (EValues [ELit (Integer 5); ECall "+" [^ELit (Integer 5); ^ETuple []]]) (ETuple [])) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -306,8 +309,8 @@ Proof.
 Qed.
 
 Example let_eval_exception_body_fbs :
-  fbs_expr [] 0 (ELet ["X"%string; "Y"%string] (EValues [ELit (Integer 5); ELit (Integer 5)])
-               (ECall "+" [^ELit (Integer 5); ^ETuple []])) [] 1000
+  fbs_expr 1000 [] 0 (ELet ["X"%string; "Y"%string] (EValues [ELit (Integer 5); ELit (Integer 5)])
+               (ECall "+" [^ELit (Integer 5); ^ETuple []])) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -324,7 +327,7 @@ Proof.
 Qed.
 
 Example apply_eval_exception_closure_fbs :
-  fbs_expr [] 0 (EApp (ELit (Integer 4)) [^ELit (Integer 5); ^ELit (Integer 5)]) [] 1000
+  fbs_expr 1000 [] 0 (EApp (ELit (Integer 4)) [^ELit (Integer 5); ^ELit (Integer 5)]) []
 =
   Result 0 (inr (badfun (VLit (Integer 4)))) [].
 Proof.
@@ -340,7 +343,7 @@ Proof.
 Qed.
 
 Example apply_eval_exception_closure2_fbs :
-  fbs_expr [] 0 (EApp (ECall "+" [^ELit (Integer 5); ^ETuple []]) [^ELit (Integer 5); ^ELit (Integer 5)]) [] 1000
+  fbs_expr 1000 [] 0 (EApp (ECall "+" [^ELit (Integer 5); ^ETuple []]) [^ELit (Integer 5); ^ELit (Integer 5)]) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -356,8 +359,8 @@ Proof.
 Qed.
 
 Example apply_eval_exception_param_fbs :
-  fbs_expr [(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 4)))] 1
-    (EApp (EVar "X"%string) [^ECall "+" [^ELit (Integer 5); ^ETuple []]]) [] 1000
+  fbs_expr 1000 [(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 4)))] 1
+    (EApp (EVar "X"%string) [^ECall "+" [^ELit (Integer 5); ^ETuple []]]) []
 =
   Result 1 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -374,8 +377,8 @@ Proof.
 Qed.
 
 Example apply_eval_exception_param_count_fbs :
-  fbs_expr [(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 4)))] 1
-   (EApp (EVar "X"%string) [^ELit (Integer 2)]) [] 1000
+  fbs_expr 1000 [(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 4)))] 1
+   (EApp (EVar "X"%string) [^ELit (Integer 2)]) []
 =
   Result 1 (inr (badarity (VClos [] [] 0 [] (ELit (Integer 4))))) [].
 Proof.
@@ -392,8 +395,8 @@ Proof.
 Qed.
 
 Example apply_eval_exception_body_fbs :
-  fbs_expr [(inl "X"%string, VClos [] [] 0 [] (ECall "+" [^ELit (Integer 5); ^ETuple []]))] 1
-   (EApp (EVar "X"%string) []) [] 1000
+  fbs_expr 1000 [(inl "X"%string, VClos [] [] 0 [] (ECall "+" [^ELit (Integer 5); ^ETuple []]))] 1
+   (EApp (EVar "X"%string) []) []
 =
   Result 1 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -410,7 +413,7 @@ Proof.
 Qed.
 
 Example letrec_exception_fbs : 
-  fbs_expr [] 0 (ELetRec [(("fun1"%string, 0), ([], ^ELit (Atom "error"%string)))] (ECall "+" [^ELit (Integer 5); ^ETuple []])) [] 1000
+  fbs_expr 1000 [] 0 (ELetRec [(("fun1"%string, 0), ([], ^ELit (Atom "error"%string)))] (ECall "+" [^ELit (Integer 5); ^ETuple []])) []
 =
   Result 1 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -426,10 +429,10 @@ Proof.
 Qed.
 
 Example map_eval_ex_key_fbs :
-  fbs_expr [] 0 (EMap [(^ELit (Atom "error"%string), ^ ELit (Atom "error"%string)); 
+  fbs_expr 1000 [] 0 (EMap [(^ELit (Atom "error"%string), ^ ELit (Atom "error"%string)); 
                 (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
                 (^ECall "+" [^ELit (Integer 5); ^ETuple []], ^ELit (Atom "error"%string));
-                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string))]) [] 1000
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string))]) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -448,10 +451,11 @@ Proof.
 Qed.
 
 Example map_eval_ex_val_fbs :
-  fbs_expr [] 0 (EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
+  fbs_expr 1000 [] 0 
+                (EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
                 (^ELit (Atom "error"%string), ^ECall "+" [^ELit (Integer 5); ^ETuple []]);
                 (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
-                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string))]) [] 1000
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string))]) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -470,8 +474,8 @@ Proof.
 Qed.
 
 Example seq_eval_ex_1_fbs :
-  fbs_expr [] 0 (ESeq (ECall "+" [^ELit (Integer 5); ^ETuple []])
-                (ELit (Integer 42))) [] 1000
+  fbs_expr 1000 [] 0 (ESeq (ECall "+" [^ELit (Integer 5); ^ETuple []])
+                (ELit (Integer 42))) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.
@@ -489,8 +493,8 @@ Proof.
 Qed.
 
 Example seq_eval_ex_2_fbs :
-  fbs_expr [] 0 (ESeq (ELit (Integer 42))
-                (ECall "+" [^ELit (Integer 5); ^ETuple []])) [] 1000
+  fbs_expr 1000 [] 0 (ESeq (ELit (Integer 42))
+                (ECall "+" [^ELit (Integer 5); ^ETuple []])) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [] .
 Proof.
@@ -508,7 +512,7 @@ Proof.
 Qed.
 
 Example map_eval_ex_val2_fbs :
-  fbs_expr [] 0 (EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
+  fbs_expr 1000 [] 0 (EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
                 (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
                 (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
                 (^ELit (Atom "error"%string), ^EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
@@ -529,7 +533,7 @@ Example map_eval_ex_val2_fbs :
                 (^EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
                 (^ELit (Atom "error"%string), ^ECall "+" [^ELit (Integer 5); ^ETuple []]);
                 (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
-                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string))], ^ECall "+" [^ELit (Integer 5); ^ETuple []])])])])])])]) [] 1000
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string))], ^ECall "+" [^ELit (Integer 5); ^ETuple []])])])])])])]) []
 =
   Result 0 (inr (badarith (VCons (VLit (Integer 5)) (VTuple [])))) [].
 Proof.

--- a/src/Core_Erlang_Automated_Exception_Tests.v
+++ b/src/Core_Erlang_Automated_Exception_Tests.v
@@ -9,7 +9,7 @@ Import ListNotations.
 
 Example eval_exception_call :
   forall {env : Environment} {eff : SideEffectList} {id : nat}, 
-  |env, id, ECall "+" [ELit (Integer 5); ETuple []], eff|
+  |env, id, ECall "+" [^ELit (Integer 5); ^ETuple []], eff|
 -e> 
   |id, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), eff|.
 Proof.
@@ -27,7 +27,7 @@ Proof.
 Qed.
 
 Example exception_list_hd :
-  |[], 0, ECons (ECall "+" [ELit (Integer 5); ETuple []]) (ELit (Atom "error"%string)), []|
+  |[], 0, ECons (ECall "+" [^ELit (Integer 5); ^ETuple []]) (ELit (Atom "error"%string)), []|
 -e>
   | 0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -35,7 +35,7 @@ Proof.
 Qed.
 
 Example exception_list_tl : 
-  |[], 0, ECons (ELit (Atom "error"%string)) (ECons (ECall "+" [ELit (Integer 5); ETuple []]) (ENil)), []|
+  |[], 0, ECons (ELit (Atom "error"%string)) (ECons (ECall "+" [^ELit (Integer 5); ^ETuple []]) (ENil)), []|
 -e> 
   | 0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -43,7 +43,7 @@ Proof.
 Qed.
 
 Example exception_tuple : 
-  |[], 0, ETuple [ELit (Atom "error"%string) ; ELit (Atom "error"%string); ECall "+" [ELit (Integer 5); ETuple []]], []|
+  |[], 0, ETuple [^ELit (Atom "error"%string) ; ^ELit (Atom "error"%string); ^ECall "+" [^ELit (Integer 5); ^ETuple []]], []|
 -e>
   | 0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -51,34 +51,37 @@ Proof.
 Qed.
 
 Example try_eval : 
-  |[], 0, ETry [(ETuple [], "X"%string)]
+  |[], 0, ETry (ETuple []) ["X"%string]
                (ELit (Atom "ok"%string)) 
+               ["Ex1"%string; "Ex2"%string; "Ex3"%string]
                (ELit (Atom "error"%string)) 
-               "Ex1"%string "Ex2"%string "Ex3"%string, []|
+  , []|
 -e>
-  |0, inl ok, []|
+  |0, inl [ok], []|
 .
 Proof.
   solve.
 Qed.
 
 Example try_eval_catch : 
-  |[], 0, ETry [(ECall "+" [ELit (Integer 5); ETuple []], "X"%string)]
-               (ELit (Atom "ok"%string)) 
+  |[], 0, ETry (ECall "+" [^ELit (Integer 5); ^ETuple []]) ["X"%string]
+               (ELit (Atom "ok"%string))
+               ["Ex1"%string; "Ex2"%string; "Ex3"%string]
                (ELit (Atom "error"%string)) 
-               "Ex1"%string "Ex2"%string "Ex3"%string, []|
+   , []|
 -e> 
-  |0, inl (VLit (Atom "error"%string)), []|
+  |0, inl [VLit (Atom "error"%string)], []|
 .
 Proof.
   solve.
 Qed.
 
 Example try_eval_exception : 
-  |[], 0, ETry [(ECall "+" [ELit (Integer 5); ETuple []], "X"%string)]
-               (ELit (Atom "ok"%string)) 
-               (ECall "+" [ELit (Integer 5); ETuple []]) 
-                "Ex1"%string "Ex2"%string "Ex3"%string, []|
+  |[], 0, ETry (ECall "+" [^ELit (Integer 5); ^ETuple []]) ["X"%string]
+               (ELit (Atom "ok"%string))
+               ["Ex1"%string; "Ex2"%string; "Ex3"%string]
+               (ECall "+" [^ELit (Integer 5); ^ETuple []]) 
+  , []|
 -e>
   |0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|
 .
@@ -87,10 +90,11 @@ Proof.
 Qed.
 
 Example try_eval_exception2 : 
-  |[], 0, ETry [(ETuple [], "X"%string)]
-               (ECall "+" [ELit (Integer 5); ETuple []])
-               (ELit (Atom "error"%string)) 
-                "Ex1"%string "Ex2"%string "Ex3"%string, []|
+  |[], 0, ETry (ETuple []) ["X"%string]
+               (ECall "+" [^ELit (Integer 5); ^ETuple []])
+               ["Ex1"%string; "Ex2"%string; "Ex3"%string]
+               (ELit (Atom "error"%string))
+  , []|
 -e>
   | 0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|
 .
@@ -99,8 +103,8 @@ Proof.
 Qed.
 
 Example eval_case_pat_ex :
-  | [], 0, ECase [ECall "+" [ELit (Integer 5); ETuple []]]
-                 [([PVar "X"%string], ELit (Atom "true"), ELit (Integer 1))], []|
+  | [], 0, ECase (ECall "+" [^ELit (Integer 5); ^ETuple []])
+                 [([PVar "X"%string], ^ELit (Atom "true"), ^ELit (Integer 1))], []|
 -e>
   | 0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -109,9 +113,9 @@ Qed.
 
 Example eval_case_clause_ex :
   | [(inl "Y"%string, VLit (Integer 2))], 0,
-     ECase [EVar "Y"%string]
-          [([PLit (Integer 1)], ELit (Atom "true"), ELit (Integer 1)); 
-           ([PVar "Z"%string], ELit (Atom "false"), ELit (Integer 2))], []|
+     ECase (EVar "Y"%string)
+          [([PLit (Integer 1)], ^ELit (Atom "true"), ^ELit (Integer 1)); 
+           ([PVar "Z"%string], ^ELit (Atom "false"), ^ELit (Integer 2))], []|
 -e>
   | 0, inr (if_clause), []|.
 Proof.
@@ -127,7 +131,7 @@ Proof.
 Qed.
 
 Example call_eval_body_ex2 :
-  |[], 0, ECall "+"%string [ELit (Integer 5); ETuple []], []|
+  |[], 0, ECall "+"%string [^ELit (Integer 5); ^ETuple []], []|
 -e>
   | 0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -135,7 +139,7 @@ Proof.
 Qed.
 
 Example call_eval_param_ex :
-  |[], 0, ECall "+"%string [ELit (Integer 5); ECall "+" [ELit (Integer 5); ETuple []]], []|
+  |[], 0, ECall "+"%string [^ELit (Integer 5); ^ECall "+" [^ELit (Integer 5); ^ETuple []]], []|
 -e>
   |0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -143,8 +147,8 @@ Proof.
 Qed.
 
 Example let_eval_exception_params :
-  |[], 0, ELet [("X"%string, ELit (Integer 5)); 
-                 ("Y"%string, ECall "+" [ELit (Integer 5); ETuple []])] (ETuple []), []|
+  |[], 0, ELet ["X"%string; "Y"%string] 
+               (EValues [ELit (Integer 5); ECall "+" [^ELit (Integer 5); ^ETuple []]]) (ETuple []), []|
 -e>
   | 0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -152,9 +156,8 @@ Proof.
 Qed.
 
 Example let_eval_exception_body :
-  |[], 0, ELet [("X"%string, ELit (Integer 5)); 
-                ("Y"%string, ELit (Integer 5))] 
-               (ECall "+" [ELit (Integer 5); ETuple []]), []|
+  |[], 0, ELet ["X"%string; "Y"%string] (EValues [ELit (Integer 5); ELit (Integer 5)])
+               (ECall "+" [^ELit (Integer 5); ^ETuple []]), []|
 -e>
   |0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -162,7 +165,7 @@ Proof.
 Qed.
 
 Example apply_eval_exception_closure :
-  |[], 0, EApp (ELit (Integer 4)) [ELit (Integer 5); ELit (Integer 5)], []|
+  |[], 0, EApp (ELit (Integer 4)) [^ELit (Integer 5); ^ELit (Integer 5)], []|
 -e>
   | 0, inr (badfun (VLit (Integer 4))), []|.
 Proof.
@@ -170,7 +173,7 @@ Proof.
 Qed.
 
 Example apply_eval_exception_closure2 :
-  |[], 0, EApp (ECall "+" [ELit (Integer 5); ETuple []]) [ELit (Integer 5); ELit (Integer 5)], []|
+  |[], 0, EApp (ECall "+" [^ELit (Integer 5); ^ETuple []]) [^ELit (Integer 5); ^ELit (Integer 5)], []|
 -e>
   | 0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -179,7 +182,7 @@ Qed.
 
 Example apply_eval_exception_param :
   |[(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 4)))], 1,
-    EApp (EVar "X"%string) [ECall "+" [ELit (Integer 5); ETuple []]], []|
+    EApp (EVar "X"%string) [^ECall "+" [^ELit (Integer 5); ^ETuple []]], []|
 -e>
   |1, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -188,7 +191,7 @@ Qed.
 
 Example apply_eval_exception_param_count :
   |[(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 4)))], 1,
-   EApp (EVar "X"%string) [ELit (Integer 2)], []|
+   EApp (EVar "X"%string) [^ELit (Integer 2)], []|
 -e>
   |1, inr (badarity (VClos [] [] 0 [] (ELit (Integer 4)))), []|.
 Proof.
@@ -196,7 +199,7 @@ Proof.
 Qed.
 
 Example apply_eval_exception_body :
-  |[(inl "X"%string, VClos [] [] 0 [] (ECall "+" [ELit (Integer 5); ETuple []]))], 1,
+  |[(inl "X"%string, VClos [] [] 0 [] (ECall "+" [^ELit (Integer 5); ^ETuple []]))], 1,
    EApp (EVar "X"%string) [], []|
 -e> 
   | 1, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
@@ -205,7 +208,7 @@ Proof.
 Qed.
 
 Example letrec_exception : 
-  |[], 0, ELetRec [(("fun1"%string, 0), ([], ELit (Atom "error"%string)))] (ECall "+" [ELit (Integer 5); ETuple []]), []|
+  |[], 0, ELetRec [(("fun1"%string, 0), ([], ^ELit (Atom "error"%string)))] (ECall "+" [^ELit (Integer 5); ^ETuple []]), []|
 -e>
   |1, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -213,10 +216,10 @@ Proof.
 Qed.
 
 Example map_eval_ex_key :
-  |[], 0, EMap [(ELit (Atom "error"%string), ELit (Atom "error"%string)); 
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ECall "+" [ELit (Integer 5); ETuple []], ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), ELit (Atom "error"%string))], []|
+  |[], 0, EMap [(^ELit (Atom "error"%string), ^ ELit (Atom "error"%string)); 
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ECall "+" [^ELit (Integer 5); ^ETuple []], ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string))], []|
 -e>
   |0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -224,10 +227,10 @@ Proof.
 Qed.
 
 Example map_eval_ex_val :
-  |[], 0, EMap [(ELit (Atom "error"%string), ELit (Atom "error"%string)); 
-                (ELit (Atom "error"%string), ECall "+" [ELit (Integer 5); ETuple []]);
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), ELit (Atom "error"%string))], []|
+  |[], 0, EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
+                (^ELit (Atom "error"%string), ^ECall "+" [^ELit (Integer 5); ^ETuple []]);
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string))], []|
 -e>
   |0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
@@ -235,7 +238,7 @@ Proof.
 Qed.
 
 Example seq_eval_ex_1 :
-  | [], 0, ESeq (ECall "+" [ELit (Integer 5); ETuple []])
+  | [], 0, ESeq (ECall "+" [^ELit (Integer 5); ^ETuple []])
                 (ELit (Integer 42))
    , [] |
 -e>
@@ -246,7 +249,7 @@ Qed.
 
 Example seq_eval_ex_2 :
   | [], 0, ESeq (ELit (Integer 42))
-                (ECall "+" [ELit (Integer 5); ETuple []])
+                (ECall "+" [^ELit (Integer 5); ^ETuple []])
    , [] |
 -e>
   | 0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), [] |.
@@ -255,28 +258,28 @@ Proof.
 Qed.
 
 Example map_eval_ex_val2 :
-  |[], 0, EMap [(ELit (Atom "error"%string), ELit (Atom "error"%string)); 
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), EMap [(ELit (Atom "error"%string), ELit (Atom "error"%string)); 
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), EMap [(ELit (Atom "error"%string), ELit (Atom "error"%string)); 
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), EMap [(ELit (Atom "error"%string), ELit (Atom "error"%string)); 
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), EMap [(ELit (Atom "error"%string), ELit (Atom "error"%string)); 
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), EMap [(ELit (Atom "error"%string), ELit (Atom "error"%string)); 
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (EMap [(ELit (Atom "error"%string), ELit (Atom "error"%string)); 
-                (ELit (Atom "error"%string), ECall "+" [ELit (Integer 5); ETuple []]);
-                (ELit (Atom "error"%string), ELit (Atom "error"%string));
-                (ELit (Atom "error"%string), ELit (Atom "error"%string))], ECall "+" [ELit (Integer 5); ETuple []])])])])])])], []|
+  |[], 0, EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^EMap [(^ELit (Atom "error"%string), ^ELit (Atom "error"%string)); 
+                (^ELit (Atom "error"%string), ^ECall "+" [^ELit (Integer 5); ^ETuple []]);
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string))], ^ECall "+" [^ELit (Integer 5); ^ETuple []])])])])])])], []|
 -e>
   |0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.

--- a/src/Core_Erlang_Automated_Side_Effect_Exception_Tests.v
+++ b/src/Core_Erlang_Automated_Side_Effect_Exception_Tests.v
@@ -1,15 +1,33 @@
 Require Core_Erlang_Tactics.
+Require Core_Erlang_Functional_Big_Step.
 
 Module Side_Effect_Exception_Tests.
 
 Import Core_Erlang_Semantics.Semantics.
 Import Core_Erlang_Tactics.Tactics.
+Import Core_Erlang_Functional_Big_Step.Functional_Big_Step.
 
 Import ListNotations.
 
+
+(** 
+  Every first example: functional big-step semantics
+  Every second example: big-step semantics
+*)
 Definition side_exception_exp (a : Z) (s : string) : Expression := ELet
    ["X"%string] (ECall "fwrite" [^ELit (Atom s)])
       (EApp (ELit (Integer a)) []).
+
+Example side_exception_fbs (env : Environment) (eff : SideEffectList) (a : Z)
+                       (s : string) (id : nat) :
+  fbs_expr 1000 env id (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom s)])
+      (EApp (ELit (Integer a)) [])) eff
+=
+  Result id (inr (badfun (VLit (Integer a)))) (app eff [(Output, [VLit (Atom s)])]).
+Proof.
+  auto.
+Qed.
 
 Example side_exception (env : Environment) (eff : SideEffectList) (a : Z)
                        (s : string) (id : nat) :
@@ -22,6 +40,16 @@ Proof.
   solve.
 Qed.
 
+Example eval_list_tail_fbs :
+  fbs_expr 1000 [] 0 (ECons (ECall "fwrite" [^ELit (Atom "a")]) (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "b")])
+      (EApp (ELit (Integer 0)) []))) []
+=
+  Result 0 (inr (badfun (VLit (Integer 0)))) [(Output, [VLit (Atom "b")])].
+Proof.
+  auto.
+Qed.
+
 Example eval_list_tail :
   | [], 0, ECons (ECall "fwrite" [^ELit (Atom "a")]) (ELet
    ["X"%string] (ECall "fwrite" [^ELit (Atom "b")])
@@ -32,12 +60,31 @@ Proof.
   solve.
 Qed.
 
+Example eval_list_head_fbs :
+  fbs_expr 1000 [] 0 (ECons (EApp (ELit (Integer 0)) []) (ECall "fwrite" [^ELit (Atom "a")])) [] 
+=
+  Result 0 (inr (badfun (VLit (Integer 0)))) [(Output, [VLit (Atom "a")])].
+Proof.
+  auto.
+Qed.
+
 Example eval_list_head :
   | [], 0, ECons (EApp (ELit (Integer 0)) []) (ECall "fwrite" [^ELit (Atom "a")]), []| 
 -e>
   | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   solve.
+Qed.
+
+Example eval_tuple_s_e_fbs :
+  fbs_expr 1000 [] 0 (ETuple [^ECall "fwrite" [^ELit (Atom "a")]; ^ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "b")])
+      (EApp (ELit (Integer 0)) [])]) []
+=
+  Result 0 (inr (badfun (VLit (Integer 0))))
+          [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])].
+Proof.
+  auto.
 Qed.
 
 Example eval_tuple_s_e :
@@ -49,6 +96,19 @@ Example eval_tuple_s_e :
           [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
   solve.
+Qed.
+
+Example eval_try_s_e_fbs :
+  fbs_expr 1000 [] 0 (ETry (ECall "fwrite" [^ELit (Atom "a")]) ["X"%string] 
+  (ELet
+     ["X"%string] (ECall "fwrite" [^ELit (Atom "b")])
+       (EApp (ELit (Integer 0)) [])) 
+  ["Ex1"%string; "Ex2"%string; "Ex3"%string]
+  (ELit (Atom "error"%string))) []
+=
+  Result 0 (inr (badfun (VLit (Integer 0)))) [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])].
+Proof.
+  auto.
 Qed.
 
 Example eval_try_s_e :
@@ -66,6 +126,19 @@ Proof.
   solve.
 Qed.
 
+Example eval_catch_fbs :
+  fbs_expr 1000 [] 0 (ETry (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
+      (EApp (ELit (Integer 0)) [])) ["X"%string]
+   (ECall "fwrite" [^ELit (Atom "a")]) 
+   ["Ex1"%string; "Ex2"%string; "Ex3"%string]
+   (ECall "fwrite" [^ELit (Atom "c")])) []
+=
+  Result 0 (inl [ok]) [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])].
+Proof.
+  auto.
+Qed.
+
 Example eval_catch :
   | [], 0, ETry (ELet
    ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
@@ -80,6 +153,18 @@ Proof.
   solve.
 Qed.
 
+Example eval_case_pat_fbs :
+  fbs_expr 1000 [] 0 (ECase (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
+      (EApp (ELit (Integer 0)) []))
+                 [([PVar "X"%string], ^ELit (Atom "true"), ^ECall "fwrite" [^ELit (Atom "b")])])
+  []
+=
+  Result 0 (inr (badfun (VLit (Integer 0)))) [(Output, [VLit (Atom "a")])].
+Proof.
+  auto.
+Qed.
+
 Example eval_case_pat :
   | [],0,  ECase (ELet
    ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
@@ -91,6 +176,19 @@ Example eval_case_pat :
 Proof.
   solve.
 Qed.
+
+Example eval_case_clause_fbs :
+  fbs_expr 1000 [(inl "Y"%string, VLit (Integer 2))] 0
+     (ECase (ELet ["X"%string] (ECall "fwrite" [^ELit (Atom "a")]) (EVar "Y"%string))
+          [([PLit (Integer 1)], ^ELit (Atom "true"), ^ECall "fwrite" [^ELit (Atom "b")]); 
+           ([PVar "Z"%string], ^ELit (Atom "false"), ^ECall "fwrite" [^ELit (Atom "c")])])
+  []
+=
+  Result 0 (inr (if_clause)) [(Output, [VLit (Atom "a")])].
+Proof.
+  auto.
+Qed.
+
 
 Example eval_case_clause :
   | [(inl "Y"%string, VLit (Integer 2))], 0,
@@ -104,12 +202,30 @@ Proof.
   solve.
 Qed.
 
+Example eval_call_s_e_fbs :
+  fbs_expr 1000 [] 0 (ECall "fwrite" [^ECall "fwrite" [^ELit (Atom "a")]; ^EApp (ELit (Integer 0)) []]) []
+=
+  Result 0 (inr (badfun (VLit (Integer 0)))) [(Output, [VLit (Atom "a")])].
+Proof.
+  auto.
+Qed.
+
 Example eval_call_s_e :
   | [], 0, ECall "fwrite" [^ECall "fwrite" [^ELit (Atom "a")]; ^EApp (ELit (Integer 0)) []], []|
 -e>
   | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   solve.
+Qed.
+
+Example eval_apply_closure_ex_fbs :
+  fbs_expr 1000 [] 0 (EApp (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
+      (EApp (ELit (Integer 0)) [])) []) []
+=
+  Result 0 (inr (badfun (VLit (Integer 0)))) [(Output, [VLit (Atom "a")])].
+Proof.
+  auto.
 Qed.
 
 Example eval_apply_closure_ex :
@@ -120,6 +236,17 @@ Example eval_apply_closure_ex :
   | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   solve.
+Qed.
+
+Example eval_apply_param_fbs :
+  fbs_expr 1000 [] 0 (EApp (ECall "fwrite" [^ELit (Atom "a")]) [^ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "b")])
+      (EApp (ELit (Integer 0)) [])]) []
+=
+  Result 0 (inr (badfun (VLit (Integer 0))))
+       [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])].
+Proof.
+  auto.
 Qed.
 
 Example eval_apply_param :
@@ -133,6 +260,15 @@ Proof.
   solve.
 Qed.
 
+Example eval_apply_closure_fbs :
+  fbs_expr 1000 [] 0 (EApp (ECall "fwrite" [^ELit (Atom "a")]) [^ECall "fwrite" [^ELit (Atom "b")]]) []
+=
+  Result 0 (inr (badfun (VLit (Atom "ok"))))
+      [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])].
+Proof.
+  auto.
+Qed.
+
 Example eval_apply_closure :
   | [], 0, EApp (ECall "fwrite" [^ELit (Atom "a")]) [^ECall "fwrite" [^ELit (Atom "b")]], []|
 -e>
@@ -140,6 +276,16 @@ Example eval_apply_closure :
       [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
   solve.
+Qed.
+
+Example eval_apply_param_len_fbs :
+  fbs_expr 1000 [(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 5)))] 1
+    (EApp (EVar "X"%string) [^ECall "fwrite" [^ELit (Atom "a")]]) []
+=
+  Result 1 (inr (badarity (VClos [] [] 0 [] (ELit (Integer 5)))))
+       [(Output, [VLit (Atom "a")])].
+Proof.
+  auto.
 Qed.
 
 Example eval_apply_param_len :
@@ -152,6 +298,16 @@ Proof.
   solve.
 Qed.
 
+Example eval_let_fbs:
+  fbs_expr 1000 [] 0 (ELet ["X"%string] (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
+      (EApp (ELit (Integer 2)) [])) (EApp (ELit (Integer 0)) [])) []
+=
+  Result 0 (inr (badfun (VLit (Integer 2)))) [(Output, [VLit (Atom "a")])].
+Proof.
+  auto.
+Qed.
+
 Example eval_let:
   | [], 0, ELet ["X"%string] (ELet
    ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
@@ -160,6 +316,21 @@ Example eval_let:
   | 0, inr (badfun (VLit (Integer 2))), [(Output, [VLit (Atom "a")])]|.
 Proof.
   solve.
+Qed.
+
+Example eval_map_key_fbs:
+  fbs_expr 1000 [] 0 
+      (EMap [(^ECall "fwrite" [^ELit (Atom "a")], ^ECall "fwrite" [^ELit (Atom "b")]);
+                 (^ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "c")])
+      (EApp (ELit (Integer 0)) []), ^ECall "fwrite" [^ELit (Atom "d")])])
+  []
+=
+  Result 0 (inr (badfun (VLit (Integer 0))))
+       [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); 
+        (Output, [VLit (Atom "c")])].
+Proof.
+  auto.
 Qed.
 
 Example eval_map_key:
@@ -176,6 +347,21 @@ Proof.
   solve.
 Qed.
 
+Example eval_map_value_fbs:
+  fbs_expr 1000 [] 0 
+          (EMap [(^ECall "fwrite" [^ELit (Atom "a")], ^ECall "fwrite" [^ELit (Atom "b")]);
+                 (^ECall "fwrite" [^ELit (Atom "c")], ^ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "d")])
+      (EApp (ELit (Integer 0)) []))])
+  []
+=
+  Result 0 (inr (badfun (VLit (Integer 0))))
+        [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); 
+         (Output, [VLit (Atom "c")]); (Output, [VLit (Atom "d")])].
+Proof.
+  auto.
+Qed.
+
 Example eval_map_value:
   | [], 0, EMap [(^ECall "fwrite" [^ELit (Atom "a")], ^ECall "fwrite" [^ELit (Atom "b")]);
                  (^ECall "fwrite" [^ELit (Atom "c")], ^ELet
@@ -190,6 +376,18 @@ Proof.
   solve.
 Qed.
 
+Example seq_eval_ex_1_fbs :
+  fbs_expr 1000 [] 0 (ESeq (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
+      (EApp (ELit (Integer 0)) []))
+                (ECall "fwrite" [^ELit (Atom "b")]))
+   []
+=
+  Result 0 (inr (badfun (VLit (Integer 0)))) [(Output, [VLit (Atom "a")])].
+Proof.
+  auto.
+Qed.
+
 Example seq_eval_ex_1 :
   | [], 0, ESeq (ELet
    ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
@@ -200,6 +398,19 @@ Example seq_eval_ex_1 :
   | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])] |.
 Proof.
   solve.
+Qed.
+
+Example seq_eval_ex_2_fbs :
+  fbs_expr 1000 [] 0 (ESeq (ECall "fwrite" [^ELit (Atom "a")])
+                (ESeq (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "b")])
+      (EApp (ELit (Integer 0)) []))
+                      (ECall "fwrite" [^ELit (Atom "c")])))
+    [] 
+=
+  Result 0 (inr (badfun (VLit (Integer 0)))) [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])].
+Proof.
+  auto.
 Qed.
 
 Example seq_eval_ex_2 :

--- a/src/Core_Erlang_Automated_Side_Effect_Exception_Tests.v
+++ b/src/Core_Erlang_Automated_Side_Effect_Exception_Tests.v
@@ -8,23 +8,23 @@ Import Core_Erlang_Tactics.Tactics.
 Import ListNotations.
 
 Definition side_exception_exp (a : Z) (s : string) : Expression := ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom s)])]
+   ["X"%string] (ECall "fwrite" [^ELit (Atom s)])
       (EApp (ELit (Integer a)) []).
 
 Example side_exception (env : Environment) (eff : SideEffectList) (a : Z)
                        (s : string) (id : nat) :
   | env, id, ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom s)])]
+   ["X"%string] (ECall "fwrite" [^ELit (Atom s)])
       (EApp (ELit (Integer a)) []) , eff| 
 -e>
-  |id, inr (badfun (VLit (Integer a))), eff ++ [(Output, [VLit (Atom s)])]|.
+  |id, inr (badfun (VLit (Integer a))), app eff [(Output, [VLit (Atom s)])]|.
 Proof.
   solve.
 Qed.
 
 Example eval_list_tail :
-  | [], 0, ECons (ECall "fwrite" [ELit (Atom "a")]) (ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "b")])]
+  | [], 0, ECons (ECall "fwrite" [^ELit (Atom "a")]) (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "b")])
       (EApp (ELit (Integer 0)) [])), []|
 -e>
   | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "b")])]|.
@@ -33,7 +33,7 @@ Proof.
 Qed.
 
 Example eval_list_head :
-  | [], 0, ECons (EApp (ELit (Integer 0)) []) (ECall "fwrite" [ELit (Atom "a")]), []| 
+  | [], 0, ECons (EApp (ELit (Integer 0)) []) (ECall "fwrite" [^ELit (Atom "a")]), []| 
 -e>
   | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
@@ -41,8 +41,8 @@ Proof.
 Qed.
 
 Example eval_tuple_s_e :
-  | [], 0, ETuple [ECall "fwrite" [ELit (Atom "a")]; ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "b")])]
+  | [], 0, ETuple [^ECall "fwrite" [^ELit (Atom "a")]; ^ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "b")])
       (EApp (ELit (Integer 0)) [])], []|
 -e>
   | 0, inr (badfun (VLit (Integer 0))), 
@@ -52,10 +52,13 @@ Proof.
 Qed.
 
 Example eval_try_s_e :
-  | [], 0, ETry [(ECall "fwrite" [ELit (Atom "a")], "X"%string)] (ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "b")])]
-      (EApp (ELit (Integer 0)) [])) (ELit (Atom "error"%string))
-             "Ex1"%string "Ex2"%string "Ex3"%string, []|
+  | [], 0, ETry (ECall "fwrite" [^ELit (Atom "a")]) ["X"%string] 
+  (ELet
+     ["X"%string] (ECall "fwrite" [^ELit (Atom "b")])
+       (EApp (ELit (Integer 0)) [])) 
+  ["Ex1"%string; "Ex2"%string; "Ex3"%string]
+  (ELit (Atom "error"%string))
+  , []|
 -e>
   | 0, inr (badfun (VLit (Integer 0))), 
        [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
@@ -64,22 +67,24 @@ Proof.
 Qed.
 
 Example eval_catch :
-  | [], 0, ETry [(ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "a")])]
-      (EApp (ELit (Integer 0)) []), "X"%string)]
-             (ECall "fwrite" [ELit (Atom "a")]) (ECall "fwrite" [ELit (Atom "c")])
-             "Ex1"%string "Ex2"%string "Ex3"%string, []|
+  | [], 0, ETry (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
+      (EApp (ELit (Integer 0)) [])) ["X"%string]
+   (ECall "fwrite" [^ELit (Atom "a")]) 
+   ["Ex1"%string; "Ex2"%string; "Ex3"%string]
+   (ECall "fwrite" [^ELit (Atom "c")])
+  , []|
 -e>
-  | 0, inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
+  | 0, inl [ok], [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
 Proof.
   solve.
 Qed.
 
 Example eval_case_pat :
-  | [],0,  ECase [ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "a")])]
-      (EApp (ELit (Integer 0)) [])] 
-                 [([PVar "X"%string], ELit (Atom "true"), ECall "fwrite" [ELit (Atom "b")])]
+  | [],0,  ECase (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
+      (EApp (ELit (Integer 0)) []))
+                 [([PVar "X"%string], ^ELit (Atom "true"), ^ECall "fwrite" [^ELit (Atom "b")])]
   , []|
 -e>
   | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
@@ -89,9 +94,9 @@ Qed.
 
 Example eval_case_clause :
   | [(inl "Y"%string, VLit (Integer 2))], 0,
-     ECase [ELet [("X"%string, ECall "fwrite" [ELit (Atom "a")])] (EVar "Y"%string)] 
-          [([PLit (Integer 1)], ELit (Atom "true"), ECall "fwrite" [ELit (Atom "b")]); 
-           ([PVar "Z"%string], ELit (Atom "false"), ECall "fwrite" [ELit (Atom "c")])]
+     ECase (ELet ["X"%string] (ECall "fwrite" [^ELit (Atom "a")]) (EVar "Y"%string))
+          [([PLit (Integer 1)], ^ELit (Atom "true"), ^ECall "fwrite" [^ELit (Atom "b")]); 
+           ([PVar "Z"%string], ^ELit (Atom "false"), ^ECall "fwrite" [^ELit (Atom "c")])]
   , []|
 -e>
   | 0, inr (if_clause), [(Output, [VLit (Atom "a")])]|.
@@ -100,7 +105,7 @@ Proof.
 Qed.
 
 Example eval_call_s_e :
-  | [], 0, ECall "fwrite" [ECall "fwrite" [ELit (Atom "a")]; EApp (ELit (Integer 0)) []], []|
+  | [], 0, ECall "fwrite" [^ECall "fwrite" [^ELit (Atom "a")]; ^EApp (ELit (Integer 0)) []], []|
 -e>
   | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
 Proof.
@@ -109,7 +114,7 @@ Qed.
 
 Example eval_apply_closure_ex :
   | [], 0, EApp (ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "a")])]
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
       (EApp (ELit (Integer 0)) [])) [], []|
 -e>
   | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])]|.
@@ -118,8 +123,8 @@ Proof.
 Qed.
 
 Example eval_apply_param :
-  | [], 0, EApp (ECall "fwrite" [ELit (Atom "a")]) [ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "b")])]
+  | [], 0, EApp (ECall "fwrite" [^ELit (Atom "a")]) [^ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "b")])
       (EApp (ELit (Integer 0)) [])], []|
 -e>
   | 0, inr (badfun (VLit (Integer 0))), 
@@ -129,7 +134,7 @@ Proof.
 Qed.
 
 Example eval_apply_closure :
-  | [], 0, EApp (ECall "fwrite" [ELit (Atom "a")]) [ECall "fwrite" [ELit (Atom "b")]], []|
+  | [], 0, EApp (ECall "fwrite" [^ELit (Atom "a")]) [^ECall "fwrite" [^ELit (Atom "b")]], []|
 -e>
   | 0, inr (badfun (VLit (Atom "ok"))), 
       [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
@@ -139,7 +144,7 @@ Qed.
 
 Example eval_apply_param_len :
   | [(inl "X"%string, VClos [] [] 0 [] (ELit (Integer 5)))], 1,
-    EApp (EVar "X"%string) [ECall "fwrite" [ELit (Atom "a")]], []|
+    EApp (EVar "X"%string) [^ECall "fwrite" [^ELit (Atom "a")]], []|
 -e>
   | 1, inr (badarity (VClos [] [] 0 [] (ELit (Integer 5)))), 
        [(Output, [VLit (Atom "a")])]|.
@@ -148,9 +153,9 @@ Proof.
 Qed.
 
 Example eval_let:
-  | [], 0, ELet [("X"%string, ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "a")])]
-      (EApp (ELit (Integer 2)) []))] (EApp (ELit (Integer 0)) []), []|
+  | [], 0, ELet ["X"%string] (ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
+      (EApp (ELit (Integer 2)) [])) (EApp (ELit (Integer 0)) []), []|
 -e>
   | 0, inr (badfun (VLit (Integer 2))), [(Output, [VLit (Atom "a")])]|.
 Proof.
@@ -158,10 +163,10 @@ Proof.
 Qed.
 
 Example eval_map_key:
-  | [], 0, EMap [(ECall "fwrite" [ELit (Atom "a")], ECall "fwrite" [ELit (Atom "b")]);
-                 (ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "c")])]
-      (EApp (ELit (Integer 0)) []), ECall "fwrite" [ELit (Atom "d")])]
+  | [], 0, EMap [(^ECall "fwrite" [^ELit (Atom "a")], ^ECall "fwrite" [^ELit (Atom "b")]);
+                 (^ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "c")])
+      (EApp (ELit (Integer 0)) []), ^ECall "fwrite" [^ELit (Atom "d")])]
   , []|
 -e>
   | 0, inr (badfun (VLit (Integer 0))), 
@@ -172,9 +177,9 @@ Proof.
 Qed.
 
 Example eval_map_value:
-  | [], 0, EMap [(ECall "fwrite" [ELit (Atom "a")], ECall "fwrite" [ELit (Atom "b")]);
-                 (ECall "fwrite" [ELit (Atom "c")], ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "d")])]
+  | [], 0, EMap [(^ECall "fwrite" [^ELit (Atom "a")], ^ECall "fwrite" [^ELit (Atom "b")]);
+                 (^ECall "fwrite" [^ELit (Atom "c")], ^ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "d")])
       (EApp (ELit (Integer 0)) []))]
   , []|
 -e>
@@ -187,9 +192,9 @@ Qed.
 
 Example seq_eval_ex_1 :
   | [], 0, ESeq (ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "a")])]
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "a")])
       (EApp (ELit (Integer 0)) []))
-                (ECall "fwrite" [ELit (Atom "b")])
+                (ECall "fwrite" [^ELit (Atom "b")])
    , [] |
 -e>
   | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")])] |.
@@ -198,11 +203,11 @@ Proof.
 Qed.
 
 Example seq_eval_ex_2 :
-  | [], 0, ESeq (ECall "fwrite" [ELit (Atom "a")])
+  | [], 0, ESeq (ECall "fwrite" [^ELit (Atom "a")])
                 (ESeq (ELet
-   [("X"%string,ECall "fwrite" [ELit (Atom "b")])]
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "b")])
       (EApp (ELit (Integer 0)) []))
-                      (ECall "fwrite" [ELit (Atom "c")]))
+                      (ECall "fwrite" [^ELit (Atom "c")]))
    , [] |
 -e>
   | 0, inr (badfun (VLit (Integer 0))), [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])] |.

--- a/src/Core_Erlang_Automated_Side_Effect_Tests.v
+++ b/src/Core_Erlang_Automated_Side_Effect_Tests.v
@@ -7,104 +7,104 @@ Import Core_Erlang_Tactics.Tactics.
 
 Import ListNotations.
 
-
+Open Scope string_scope.
 
 Example tuple_eff :
-  |[], 0, ETuple [ECall "fwrite"%string [ELit (Atom "a"%string)];
-               ECall "fwrite"%string [ELit (Atom "b"%string)];
-               ECall "fread"%string [ELit (Atom ""%string) ; ELit (Atom "c"%string)]], []|
+  |[], 0, ETuple [^ECall "fwrite" [^ELit (Atom "a")];
+               ^ECall "fwrite" [^ELit (Atom "b")];
+               ^ECall "fread" [^ELit (Atom "") ; ^ELit (Atom "c")]], []|
 -e>
-  |0, inl (VTuple [ok;ok; VTuple [ok; VLit (Atom "c"%string)]]), 
-     [(Output, [VLit (Atom "a"%string)]); (Output, [VLit (Atom "b"%string)]);
-      (Input, [VLit (Atom ""%string); VLit (Atom "c"%string)])]|.
+  |0, inl [VTuple [ok;ok; VTuple [ok; VLit (Atom "c")]]], 
+     [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]);
+      (Input, [VLit (Atom ""); VLit (Atom "c")])]|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example list_eff :
-  |[], 0, ECons (ECall "fwrite"%string [ELit (Atom "a")])
-             (ECons (ECall "fwrite"%string [ELit (Atom "b")]) ENil), []|
+  |[], 0, ECons (ECall "fwrite" [^ELit (Atom "a")])
+             (ECons (ECall "fwrite" [^ELit (Atom "b")]) ENil), []|
 -e> 
-  | 0, inl (VCons ok (VCons ok VNil)), 
+  | 0, inl [VCons ok (VCons ok VNil)], 
      [(Output, [VLit (Atom "b")]); (Output, [VLit (Atom "a")])]|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example case_eff : 
-  |[], 0, ECase [ECall "fwrite"%string [ELit (Atom "a")]]
-      [([PVar "X"%string], ELit (Atom "false"), (ECall "fwrite"%string [ELit (Atom "b")])); 
-       ([PLit (Integer 5)], ELit (Atom "true"), ELit (Integer 2)); 
-       ([PVar "Y"%string], ELit (Atom "true"), (ECall "fwrite"%string [ELit (Atom "c")]))]
+  |[], 0, ECase (ECall "fwrite" [^ELit (Atom "a")])
+      [([PVar "X"], ^ELit (Atom "false"), ^(ECall "fwrite" [^ELit (Atom "b")])); 
+       ([PLit (Integer 5)], ^ELit (Atom "true"), ^ELit (Integer 2)); 
+       ([PVar "Y"], ^ELit (Atom "true"), ^(ECall "fwrite" [^ELit (Atom "c")]))]
   , []|
 -e>
-  |0, inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
+  |0, inl [ok], [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example call_eff :
-  |[], 0, ECall "fwrite"%string [ECall "fwrite"%string [ELit (Atom "a")]], []|
+  |[], 0, ECall "fwrite" [^ECall "fwrite" [^ELit (Atom "a")]], []|
 -e>
-  | 0, inl ok, [(Output, [VLit (Atom "a")]); (Output, [ok])]|.
+  | 0, inl [ok], [(Output, [VLit (Atom "a")]); (Output, [ok])]|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example apply_eff : 
-  |[(inl "Y"%string, VClos [] [] 0 ["Z"%string] (ECall "fwrite"%string [ELit (Atom "c")]))], 1, 
-    EApp (ELet [("X"%string, ECall "fwrite"%string [ELit (Atom "a")])] 
-             (EVar "Y"%string))
-           [ECall "fwrite" [ELit (Atom "b")] ], []|
+  |[(inl "Y", VClos [] [] 0 ["Z"] (ECall "fwrite" [^ELit (Atom "c")]))], 1, 
+    EApp (ELet ["X"] (ECall "fwrite" [^ELit (Atom "a")]) 
+             (EVar "Y"))
+           [^ECall "fwrite" [^ELit (Atom "b")] ], []|
 -e>
-  |1, inl ok, 
+  |1, inl [ok], 
    [(Output, [VLit (Atom "a")]);
     (Output, [VLit (Atom "b")]);
     (Output, [VLit (Atom "c")])]|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example let_eff : 
-  |[], 0, ELet [("X"%string, ECall "fwrite"%string [ELit (Atom "a")]); 
-                ("Y"%string, EFun [] (ECall "fwrite"%string [ELit (Atom "b")]))]
-          (EApp (EVar "Y"%string) []), []|
+  |[], 0, ELet ["X"; "Y"] 
+     (EValues [ECall "fwrite" [^ELit (Atom "a")]; EFun [] (ECall "fwrite" [^ELit (Atom "b")])])
+          (EApp (EVar "Y") []), []|
 -e>
-  |1, inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
+  |1, inl [ok], [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example letrec_eff : 
-  |[], 0, ELetRec [(("f1"%string, 0), ([], ECall "fwrite"%string [ELit (Atom "a")]))]
-           (EApp (EFunId ("f1"%string, 0)) []), []|
+  |[], 0, ELetRec [(("f1", 0), ([], ^ECall "fwrite" [^ELit (Atom "a")]))]
+           (EApp (EFunId ("f1", 0)) []), []|
 -e>
-  |1, inl ok, [(Output, [VLit (Atom "a")])]|.
+  |1, inl [ok], [(Output, [VLit (Atom "a")])]|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example map_eff : 
-  |[], 0, EMap [(ECall "fwrite"%string [ELit (Atom "a"%string)], ECall "fwrite"%string [ELit (Atom "b"%string)]);
-                (ECall "fwrite"%string [ELit (Atom "c"%string)], ELit (Integer 5))]
+  |[], 0, EMap [(^ECall "fwrite" [^ELit (Atom "a")], ^ECall "fwrite" [^ELit (Atom "b")]);
+                (^ECall "fwrite" [^ELit (Atom "c")], ^ELit (Integer 5))]
   , []| 
 -e> 
-  | 0, inl (VMap [(ok, VLit (Integer 5))]),
-      [(Output, [VLit (Atom "a"%string)]);
-       (Output, [VLit (Atom "b"%string)]);
-       (Output, [VLit (Atom "c"%string)])]|.
+  | 0, inl [VMap [(ok, VLit (Integer 5))]],
+      [(Output, [VLit (Atom "a")]);
+       (Output, [VLit (Atom "b")]);
+       (Output, [VLit (Atom "c")])]|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example seq_eff :
-  | [], 0, ESeq (ECall "fwrite"%string [ELit (Atom "a"%string)])
-                (ECall "fwrite"%string [ELit (Atom "b"%string)])
+  | [], 0, ESeq (ECall "fwrite" [^ELit (Atom "a")])
+                (ECall "fwrite" [^ELit (Atom "b")])
    , [] |
 -e>
-  | 0, inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])] |.
+  | 0, inl [ok], [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])] |.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 End Automated_Side_Effect_Tests.

--- a/src/Core_Erlang_Automated_Side_Effect_Tests.v
+++ b/src/Core_Erlang_Automated_Side_Effect_Tests.v
@@ -1,13 +1,31 @@
 Require Core_Erlang_Tactics.
+Require Core_Erlang_Functional_Big_Step.
 
 Module Automated_Side_Effect_Tests.
 
 Import Core_Erlang_Semantics.Semantics.
 Import Core_Erlang_Tactics.Tactics.
+Import Core_Erlang_Functional_Big_Step.Functional_Big_Step.
 
 Import ListNotations.
 
 Open Scope string_scope.
+
+(** 
+  Every first example: functional big-step semantics
+  Every second example: big-step semantics
+*)
+Example tuple_eff_fbs :
+  fbs_expr 1000 [] 0 (ETuple [^ECall "fwrite" [^ELit (Atom "a")];
+               ^ECall "fwrite" [^ELit (Atom "b")];
+               ^ECall "fread" [^ELit (Atom "") ; ^ELit (Atom "c")]]) []
+=
+  Result 0 (inl [VTuple [ok;ok; VTuple [ok; VLit (Atom "c")]]]) 
+     [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]);
+      (Input, [VLit (Atom ""); VLit (Atom "c")])].
+Proof.
+  auto.
+Qed.
 
 Example tuple_eff :
   |[], 0, ETuple [^ECall "fwrite" [^ELit (Atom "a")];
@@ -21,6 +39,16 @@ Proof.
   solve.
 Qed.
 
+Example list_eff_fbs :
+  fbs_expr 1000 [] 0 (ECons (ECall "fwrite" [^ELit (Atom "a")])
+             (ECons (ECall "fwrite" [^ELit (Atom "b")]) ENil)) []
+=
+  Result 0 (inl [VCons ok (VCons ok VNil)])
+     [(Output, [VLit (Atom "b")]); (Output, [VLit (Atom "a")])].
+Proof.
+  auto.
+Qed.
+
 Example list_eff :
   |[], 0, ECons (ECall "fwrite" [^ELit (Atom "a")])
              (ECons (ECall "fwrite" [^ELit (Atom "b")]) ENil), []|
@@ -29,6 +57,17 @@ Example list_eff :
      [(Output, [VLit (Atom "b")]); (Output, [VLit (Atom "a")])]|.
 Proof.
   solve.
+Qed.
+
+Example case_eff_fbs : 
+  fbs_expr 1000 [] 0 (ECase (ECall "fwrite" [^ELit (Atom "a")])
+      [([PVar "X"], ^ELit (Atom "false"), ^(ECall "fwrite" [^ELit (Atom "b")])); 
+       ([PLit (Integer 5)], ^ELit (Atom "true"), ^ELit (Integer 2)); 
+       ([PVar "Y"], ^ELit (Atom "true"), ^(ECall "fwrite" [^ELit (Atom "c")]))]) []
+=
+  Result 0 (inl [ok]) [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])].
+Proof.
+  auto.
 Qed.
 
 Example case_eff : 
@@ -43,12 +82,35 @@ Proof.
   solve.
 Qed.
 
+Example call_eff_fbs :
+  fbs_expr 1000 [] 0 (ECall "fwrite" [^ECall "fwrite" [^ELit (Atom "a")]]) []
+=
+  Result 0 (inl [ok]) [(Output, [VLit (Atom "a")]); (Output, [ok])].
+Proof.
+  auto.
+Qed.
+
+
 Example call_eff :
   |[], 0, ECall "fwrite" [^ECall "fwrite" [^ELit (Atom "a")]], []|
 -e>
   | 0, inl [ok], [(Output, [VLit (Atom "a")]); (Output, [ok])]|.
 Proof.
   solve.
+Qed.
+
+Example apply_eff_fbs : 
+  fbs_expr 1000 [(inl "Y", VClos [] [] 0 ["Z"] (ECall "fwrite" [^ELit (Atom "c")]))] 1
+    (EApp (ELet ["X"] (ECall "fwrite" [^ELit (Atom "a")]) 
+             (EVar "Y"))
+           [^ECall "fwrite" [^ELit (Atom "b")] ]) []
+=
+  Result 1 (inl [ok]) 
+   [(Output, [VLit (Atom "a")]);
+    (Output, [VLit (Atom "b")]);
+    (Output, [VLit (Atom "c")])].
+Proof.
+  auto.
 Qed.
 
 Example apply_eff : 
@@ -65,6 +127,16 @@ Proof.
   solve.
 Qed.
 
+Example let_eff_fbs : 
+  fbs_expr 1000 [] 0 (ELet ["X"; "Y"] 
+     (EValues [ECall "fwrite" [^ELit (Atom "a")]; EFun [] (ECall "fwrite" [^ELit (Atom "b")])])
+          (EApp (EVar "Y") [])) []
+=
+  Result 1 (inl [ok]) [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])].
+Proof.
+  auto.
+Qed.
+
 Example let_eff : 
   |[], 0, ELet ["X"; "Y"] 
      (EValues [ECall "fwrite" [^ELit (Atom "a")]; EFun [] (ECall "fwrite" [^ELit (Atom "b")])])
@@ -75,6 +147,15 @@ Proof.
   solve.
 Qed.
 
+Example letrec_eff_fbs : 
+  fbs_expr 1000 [] 0 (ELetRec [(("f1", 0), ([], ^ECall "fwrite" [^ELit (Atom "a")]))]
+           (EApp (EFunId ("f1", 0)) [])) []
+=
+  Result 1 (inl [ok]) [(Output, [VLit (Atom "a")])].
+Proof.
+  auto.
+Qed.
+
 Example letrec_eff : 
   |[], 0, ELetRec [(("f1", 0), ([], ^ECall "fwrite" [^ELit (Atom "a")]))]
            (EApp (EFunId ("f1", 0)) []), []|
@@ -82,6 +163,19 @@ Example letrec_eff :
   |1, inl [ok], [(Output, [VLit (Atom "a")])]|.
 Proof.
   solve.
+Qed.
+
+Example map_eff_fbs : 
+  fbs_expr 1000 [] 0 
+         (EMap [(^ECall "fwrite" [^ELit (Atom "a")], ^ECall "fwrite" [^ELit (Atom "b")]);
+                (^ECall "fwrite" [^ELit (Atom "c")], ^ELit (Integer 5))]) [] 
+=
+  Result 0 (inl [VMap [(ok, VLit (Integer 5))]])
+      [(Output, [VLit (Atom "a")]);
+       (Output, [VLit (Atom "b")]);
+       (Output, [VLit (Atom "c")])].
+Proof.
+  auto.
 Qed.
 
 Example map_eff : 
@@ -95,6 +189,16 @@ Example map_eff :
        (Output, [VLit (Atom "c")])]|.
 Proof.
   solve.
+Qed.
+
+Example seq_eff_fbs :
+  fbs_expr 1000 [] 0 (ESeq (ECall "fwrite" [^ELit (Atom "a")])
+                (ECall "fwrite" [^ELit (Atom "b")]))
+    []
+=
+  Result 0 (inl [ok]) [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])] .
+Proof.
+  auto.
 Qed.
 
 Example seq_eff :

--- a/src/Core_Erlang_Automated_Tests.v
+++ b/src/Core_Erlang_Automated_Tests.v
@@ -2,7 +2,7 @@ Require Core_Erlang_Tactics.
 
 (**
   IMPORTANT NOTICE:
-  To use the `solve` tactic, the abbreviations (e.g. `EEmptyTuple`)
+  To use the `solve` tactic, the abbreviations (e.g. `ETuple []`)
   should not be used (use `ETuple []` instead).
 *)
 
@@ -12,420 +12,437 @@ Import Core_Erlang_Tactics.Tactics.
 Import Core_Erlang_Semantics.Semantics.
 Import ListNotations.
 
-(** This is an edless recursion *)
+Open Scope string_scope.
+
+(** This is an endless recursion *)
 Example eval_letrec1 : 
-  |[], 0, ELetRec [(("x"%string, 1), (["X"%string], EApp (EFunId ("x"%string, 1)) [EVar "X"%string])) ]
-            (EApp (EFunId ("x"%string, 1)) [ETuple []]), []|
+  |[], 0, ELetRec [(("x", 1), (["X"], ^EApp (EFunId ("x", 1)) [^EVar "X"])) ]
+            (EApp (EFunId ("x", 1)) [^ETuple []]), []|
 -e> 
-  |1, inl ErrorValue, []|.
+  |1, inl [ErrorValue], []|.
 Proof.
-  try(timeout 5 solve).
+  try (timeout 10 solve).
 Abort.
 
-(* This is not accepted by the compiler in Core Erlang 
-  TODO: contains application exception: solve hasn't been working yet!
-*)
-(* Example eval_letrec2 : 
-  |[], 0, ELet [("F"%string, EFun ["X"%string] 
-         (EApp (EVar "F"%string) [EVar "X"%string]))] 
-            (EApp (EVar "F"%string) [ETuple []]), []| 
+(* (* This is not accepted by the compiler in Core Erlang *)
+Example eval_letrec2 : 
+  |[], 0, ELet [("F", EFun ["X"] 
+         (EApp (EVar "F") [EVar "X"]))] 
+            (EApp (EVar "F") [ETuple []]), []| 
 -e>
 |1, inr novar, []|.
 Proof.
-  try(timeout 10 solve).
+  eapply eval_let with (vals := [VClos [] [] 0 ["X"] (EApp (EVar "F") [EVar "X"])]) 
+                       (ids := [1])
+                       (eff := [[]]); auto.
+  * simpl. intros. inversion H.
+    - apply eval_fun.
+    - inversion H1.
+  * simpl. eapply eval_app with (vals := [VEmptyTuple]) (n := 0)
+                                  (var_list := ["X"]) (ids := [1])
+                                  (body := (EApp (EVar "F") [EVar "X"])) 
+                                  (ref := []) (ext := []) (eff := [[]]); try(reflexivity).
+    - apply eval_var. reflexivity.
+    - intros. inversion H.
+      + eapply eval_tuple with (eff := []) (ids := []); try(reflexivity).
+        ** intros. inversion H0.
+      + inversion H1.
+    - simpl. eapply eval_apply_ex_closure_ex.
+      + reflexivity.
+      + apply eval_var. reflexivity.
 Qed. *)
 
 (* Top level functions, and their closures must be added initially *)
-Example multiple_top_level_funs : |[(inr ("fun1"%string, 0), VClos [] [
-    (0, ("fun1"%string, 0), ([], (EApp (EFunId ("fun3"%string, 0)) [])));
-    (1, ("fun2"%string, 0), ([], (ELit (Integer 42))));
-    (2, ("fun3"%string, 0), ([], (EApp (EFunId ("fun2"%string, 0)) [])))
-  ] 0 [] (EApp (EFunId ("fun3"%string, 0)) [])) ; 
-                                      (inr ("fun2"%string, 0), VClos [] [
-    (0, ("fun1"%string, 0), ([], (EApp (EFunId ("fun3"%string, 0)) [])));
-    (1, ("fun2"%string, 0), ([], (ELit (Integer 42))));
-    (2, ("fun3"%string, 0), ([], (EApp (EFunId ("fun2"%string, 0)) [])))
+Example multiple_top_level_funs : |[(inr ("fun1", 0), VClos [] [
+    (0, ("fun1", 0), ([], (^EApp (EFunId ("fun3", 0)) [])));
+    (1, ("fun2", 0), ([], (^ELit (Integer 42))));
+    (2, ("fun3", 0), ([], (^EApp (EFunId ("fun2", 0)) [])))
+  ] 0 [] (EApp (EFunId ("fun3", 0)) [])) ; 
+                                      (inr ("fun2", 0), VClos [] [
+    (0, ("fun1", 0), ([], (^EApp (EFunId ("fun3", 0)) [])));
+    (1, ("fun2", 0), ([], (^ELit (Integer 42))));
+    (2, ("fun3", 0), ([], (^EApp (EFunId ("fun2", 0)) [])))
   ] 1 [] (ELit (Integer 42))) ;
-                                      (inr ("fun3"%string, 0), VClos [] [
-    (0, ("fun1"%string, 0), ([], (EApp (EFunId ("fun3"%string, 0)) [])));
-    (1, ("fun2"%string, 0), ([], (ELit (Integer 42))));
-    (2, ("fun3"%string, 0), ([], (EApp (EFunId ("fun2"%string, 0)) [])))
-  ] 2 [] (EApp (EFunId ("fun2"%string, 0)) []))], 3
-                                      , EApp (EFunId ("fun1"%string,0)) [], []| 
+                                      (inr ("fun3", 0), VClos [] [
+    (0, ("fun1", 0), ([], (^EApp (EFunId ("fun3", 0)) [])));
+    (1, ("fun2", 0), ([], (^ELit (Integer 42))));
+    (2, ("fun3", 0), ([], (^EApp (EFunId ("fun2", 0)) [])))
+  ] 2 [] (EApp (EFunId ("fun2", 0)) []))], 3
+                                      , EApp (EFunId ("fun1",0)) [], []| 
 -e> 
-  |3, inl (VLit (Integer 42)), []|.
+  |3, inl [VLit (Integer 42)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example multiple_top_level_funs2 :
-  | [], 0, ELetRec [(("fun1"%string,0), ([], EApp (EFunId ("fun3"%string, 0)) [])); 
-                    (("fun2"%string,0), ([], ELit (Integer 42))); 
-                    (("fun3"%string,0), ([], EApp (EFunId ("fun2"%string, 0)) []))]
-     (EApp (EFunId ("fun1"%string,0)) []), [] |
+  | [], 0, ELetRec [(("fun1",0), ([], ^EApp (EFunId ("fun3", 0)) [])); 
+                    (("fun2",0), ([], ^ELit (Integer 42))); 
+                    (("fun3",0), ([], ^EApp (EFunId ("fun2", 0)) []))]
+     (EApp (EFunId ("fun1",0)) []), [] |
 -e>
-  |3, inl (VLit (Integer 42)), []|.
+  |3, inl [VLit (Integer 42)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
-Example weird_apply : |[], 0, ELetRec [(("f"%string, 1), (["X"%string],
-   ECase [EVar "X"%string]
-          [([PLit (Integer 0)], ELit (Atom "true"%string), ELit (Integer 5));
-           ([PLit (Integer 1)], ELit (Atom "true"%string), EApp (EFunId ("f"%string, 1)) [ELit (Integer 0)]);
-           ([PVar "A"%string], ELit (Atom "true"%string), EApp (EFunId ("f"%string, 1)) [ELit (Integer 1)])]
+Example weird_apply : |[], 0, ELetRec [(("f", 1), (["X"],
+   ^ECase (EVar "X")
+          [([PLit (Integer 0)], ^ELit (Atom "true"), ^ELit (Integer 5));
+           ([PLit (Integer 1)], ^ELit (Atom "true"), ^EApp (EFunId ("f", 1)) [^ELit (Integer 0)]);
+           ([PVar "A"], ^ELit (Atom "true"), ^EApp (EFunId ("f", 1)) [^ELit (Integer 1)])]
    ))]
-   (ELet [("X"%string, EFun ["F"%string]
-       (ELetRec [(("f"%string, 1), (["X"%string], ELit (Integer 0)))] 
-          (EApp (EVar "F"%string) [ELit (Integer 2)])
+   (ELet ["X"] (^EFun ["F"]
+       (ELetRec [(("f", 1), (["X"], ^ELit (Integer 0)))] 
+          (EApp (EVar "F") [^ELit (Integer 2)])
        ))
-     ]
-    (EApp (EVar "X"%string) [EFunId ("f"%string, 1)])
+    (EApp (EVar "X") [^EFunId ("f", 1)])
    ), []|
 -e> 
-  |3, inl (VLit (Integer 5)), []|.
+  |3, inl [VLit (Integer 5)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example top_overwrite : 
-  |[(inr ("fun2"%string, 0), 
-       VClos [] [(0, ("fun2"%string, 0),([],  (ELit (Integer 42)) ))] 0 [] (ELit (Integer 42)))], 1,
-  ELetRec [(("fun2"%string, 0), ([], ELit (Integer 40)))] 
-     (EApp (EFunId ("fun2"%string, 0)) []), [] | 
+  |[(inr ("fun2", 0), 
+       VClos [] [(0, ("fun2", 0),([],  (^ELit (Integer 42)) ))] 0 [] (ELit (Integer 42)))], 1,
+  ELetRec [(("fun2", 0), ([], ^ELit (Integer 40)))] 
+     (EApp (EFunId ("fun2", 0)) []), [] | 
 -e>
-  |2, inl (VLit (Integer 40)), []|.
+  |2, inl [VLit (Integer 40)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example top_no_overwrite : 
-  |[(inr ("fun2"%string, 0), 
-     VClos [] [(0, ("fun2"%string, 0), ([], ELit (Integer 42)))] 0 [] (ELit (Integer 42)))], 1,
-   ELetRec [(("fun2"%string, 1), (["X"%string], (ELit (Integer 40))))] 
-     (EApp (EFunId ("fun2"%string, 0)) []), [] |
+  |[(inr ("fun2", 0), 
+     VClos [] [(0, ("fun2", 0), ([], ^ELit (Integer 42)))] 0 [] (ELit (Integer 42)))], 1,
+   ELetRec [(("fun2", 1), (["X"], (^ELit (Integer 40))))] 
+     (EApp (EFunId ("fun2", 0)) []), [] |
 -e> 
-  | 2, inl (VLit (Integer 42)), []|.
+  | 2, inl [VLit (Integer 42)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 (** This is not accepted by the compiler in Core Erlang *)
 Example eval_let_func : 
-  |[(inl "X"%string, VLit (Integer 42))], 0,
-   ELet [("X"%string, EFun [] (ENil)); ("X"%string, EFun [] (EMap []))] 
+  |[(inl "X", VLit (Integer 42))], 0,
+   ELet ["X"; "X"] (EValues [EFun [] ENil; EFun [] (EMap [])]) 
      (EMap []), []| 
 -e> 
-  |2, inl (VMap []), []|.
+  |2, inl [VEmptyMap], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example eval_let_apply : 
-  |[(inl "X"%string, VLit (Integer 42))], 0,
-   ELet [("Y"%string, EFun [] (EVar "X"%string))] 
-     (EApp (EVar "Y"%string) []), []| 
+  |[(inl "X", VLit (Integer 42))], 0,
+   ELet ["Y"] (EValues [EFun [] (EVar "X")])
+     (EApp (EVar "Y") []), []| 
 -e> 
-  |1, inl (VLit (Integer 42)), []|.
+  |1, inl [VLit (Integer 42)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example eval_muliple_let : 
-  |[], 0, ELet [("X"%string, ELit (Integer 1))] 
-            (ELet [("X"%string, ELit (Integer 2))] 
-               (EVar "X"%string)), []| 
+  |[], 0, ELet ["X"] (ELit (Integer 1)) 
+            (ELet ["X"] (ELit (Integer 2)) 
+               (EVar "X")), []| 
 -e> 
-  |0, inl (VLit (Integer 2)), []|.
+  |0, inl [VLit (Integer 2)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example let_eval_1 : 
-  |[], 0, ELet [("X"%string, ETuple [])] (EMap []), []|
+  |[], 0, ELet ["X"] (ETuple []) (EMap []), []|
 -e>
-  | 0, inl (VMap []), []|.
+  | 0, inl [VEmptyMap], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example let_eval_2 : 
-  |[(inl "X"%string, VMap [])], 0, ELet [("X"%string, ETuple [])] (EMap []), []| 
+  |[(inl "X", VEmptyMap)], 0, ELet ["X"] (ETuple []) (EMap []), []| 
 -e> 
-  | 0, inl (VMap []), []|.
+  | 0, inl [VEmptyMap], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 (** This shouldn't compile in Core Erlang *)
 Example eval_let_3 : 
-  |[(inl "X"%string, VMap [])], 0,
-   ELet [("X"%string, ETuple []); ("X"%string, ENil); ("Y"%string, EVar "X"%string)]
-     (EVar "Y"%string), []|
+  |[(inl "X", VEmptyMap)], 0,
+   ELet ["X"; "X"; "Y"] (EValues [ETuple []; ENil; EVar "X"])
+     (EVar "Y"), []|
 -e>
-  |0, inl (VMap []), []|.
+  |0, inl [VEmptyMap], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example let_eval_4 : 
-  |[], 0, ELet [("X"%string, ELit (Integer 5))] (EVar "X"%string), []| 
+  |[], 0, ELet ["X"] (ELit (Integer 5)) (EVar "X"), []| 
 -e> 
-  | 0, inl (VLit (Integer 5)), []|.
+  | 0, inl [VLit (Integer 5)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example tuple_eval : 
-  |[(inl "X"%string, VLit (Atom "foo"%string)); 
-    (inl "Y"%string, VEmptyTuple)], 0,
-   ETuple [ELit (Integer 5); EVar "X"%string; EVar "Y"%string], []| 
+  |[(inl "X", VLit (Atom "foo")); 
+    (inl "Y", VEmptyTuple)], 0,
+   ETuple [^ELit (Integer 5); ^EVar "X"; ^EVar "Y"], []| 
 -e>
-  |0, inl (VTuple [VLit (Integer 5); VLit (Atom "foo"%string); VEmptyTuple]), []|.
+  |0, inl [VTuple [VLit (Integer 5); VLit (Atom "foo"); VEmptyTuple]], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example apply_top_eval : 
-  |[(inr ("Plus"%string, 2), 
-       VClos [] [(0, ("Plus"%string, 2),
-                     (["X"%string ; "Y"%string], ELit (Integer 3)))] 
-                0 ["X"%string ; "Y"%string] 
+  |[(inr ("Plus", 2), 
+       VClos [] [(0, ("Plus", 2),
+                     (["X" ; "Y"], ^ELit (Integer 3)))] 
+                0 ["X" ; "Y"] 
                 (ELit (Integer 3)))], 1,
-   EApp (EFunId ("Plus"%string, 2)) [ELit (Integer 2); ELit (Integer 3)], []|
+   EApp (EFunId ("Plus", 2)) [^ELit (Integer 2); ^ELit (Integer 3)], []|
 -e>
-  |1, inl ((VLit (Integer 3))), []|.
+  |1, inl [VLit (Integer 3)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example apply_eval : 
-  |[(inl "Minus"%string,
-      VClos [] [] 0 ["X"%string; "Y"%string] (ELit (Integer 42))) ; 
-    (inl "X"%string, VMap [])], 1,
-   EApp (EVar "Minus"%string) [EVar "X"%string; EVar "X"%string], []|
+  |[(inl "Minus",
+      VClos [] [] 0 ["X"; "Y"] (ELit (Integer 42))) ; 
+    (inl "X", VEmptyMap)], 1,
+   EApp (EVar "Minus") [^EVar "X"; ^EVar "X"], []|
 -e>
-  |1, inl (VLit (Integer 42)), []|.
+  |1, inl [VLit (Integer 42)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 
 Example list_eval : 
-  |[(inl "X"%string, VLit (Integer 5))], 0,
-   ECons (EVar "X"%string) (ENil), []| 
+  |[(inl "X", VLit (Integer 5))], 0,
+   ECons (EVar "X") (ENil), []| 
 -e>
-  | 0, inl (VCons (VLit (Integer 5)) (VNil)), []|.
+  | 0, inl [VCons (VLit (Integer 5)) (VNil)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example list_eval2 : 
-  |[(inl "X"%string, VLit (Integer 5))], 0,
-   ECons (EVar "X"%string) 
-         (ECons (EVar "X"%string) 
+  |[(inl "X", VLit (Integer 5))], 0,
+   ECons (EVar "X") 
+         (ECons (EVar "X") 
                 (ENil)), []| 
 -e> 
-  |0, inl (VCons (VLit (Integer 5)) 
+  |0, inl [VCons (VLit (Integer 5)) 
                  (VCons (VLit (Integer 5)) 
-                        (VNil))), []|.
+                        (VNil))], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example let_eval_overwrite : 
-  |[], 0, ELet [("X"%string, EFun [] (ETuple []))] 
-           (ELet [("X"%string, ELit (Integer 5))] 
-             (EVar "X"%string)), []|
+  |[], 0, ELet ["X"] (EFun [] (ETuple [])) 
+           (ELet ["X"] (ELit (Integer 5)) 
+             (EVar "X")), []|
 -e>
-  | 1, inl (VLit (Integer 5)), []|.
+  | 1, inl [VLit (Integer 5)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example map_eval :
-  |[(inl "X"%string, VLit (Integer 42))], 0,
-    EMap [(ELit (Integer 5), EVar "X"%string)], []|
+  |[(inl "X", VLit (Integer 42))], 0,
+    EMap [(^ELit (Integer 5), ^EVar "X")], []|
 -e>
-  | 0, inl (VMap [(VLit (Integer 5), VLit (Integer 42))]), []|.
+  | 0, inl [VMap [(VLit (Integer 5), VLit (Integer 42))]], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example map_eval2 : 
-  |[(inl "X"%string, VLit (Integer 42))], 0,
-   EMap [(ELit (Integer 54), EVar "X"%string); (EVar "X"%string, EVar "X"%string)] 
+  |[(inl "X", VLit (Integer 42))], 0,
+   EMap [(^ELit (Integer 54), ^EVar "X"); (^EVar "X", ^EVar "X")] 
   , []|
 -e> 
-  |0, inl (VMap [(VLit (Integer 42), VLit (Integer 42)); 
-                 (VLit (Integer 54), VLit (Integer 42))])
+  |0, inl [VMap [(VLit (Integer 42), VLit (Integer 42)); 
+                 (VLit (Integer 54), VLit (Integer 42))]]
   , []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example map_eval3 : 
-  |[(inl "X"%string, VLit (Integer 5))], 0,
-   EMap [(ELit (Integer 5), EVar "X"%string); 
-         (EVar "X"%string, ECall "+" 
-                              [ELit (Integer 1); (EVar "X"%string)])] 
+  |[(inl "X", VLit (Integer 5))], 0,
+   EMap [(^ELit (Integer 5), ^EVar "X"); 
+         (^EVar "X", ^ECall "+" 
+                              [^ELit (Integer 1); (^EVar "X")])] 
   , []| 
 -e> 
-  | 0, inl (VMap [(VLit (Integer 5), VLit (Integer 6))]), []|.
+  | 0, inl [VMap [(VLit (Integer 5), VLit (Integer 6))]], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example map_eval4 : 
   |[], 0,
-   ELet [("X"%string, EFun [] (ELit (Integer 1))); 
-         ("Y"%string, EFun [] (ELit (Integer 2))); 
-         ("Z"%string, EFun [] (ELit (Integer 3)))]
-     (EMap [(EVar "Z"%string, ELit (Integer 10)); 
-            (EVar "X"%string, ELit (Integer 11));
-            (EVar "Y"%string, ELit (Integer 12)); 
-            (EVar "X"%string, ELit (Integer 13))])
+   ELet ["X"; "Y"; "Z"] 
+        (EValues [EFun [] (ELit (Integer 1)); 
+                  EFun [] (ELit (Integer 2)); 
+                  EFun [] (ELit (Integer 3))])
+     (EMap [(^EVar "Z", ^ELit (Integer 10)); 
+            (^EVar "X", ^ELit (Integer 11));
+            (^EVar "Y", ^ELit (Integer 12)); 
+            (^EVar "X", ^ELit (Integer 13))])
   , []| 
 -e> 
-  | 3, inl (VMap [(VClos [] [] 0 [] (ELit (Integer 1)), VLit (Integer 13));
+  | 3, inl [VMap [(VClos [] [] 0 [] (ELit (Integer 1)), VLit (Integer 13));
                   (VClos [] [] 1 [] (ELit (Integer 2)), VLit (Integer 12));
-                  (VClos [] [] 2 [] (ELit (Integer 3)), VLit (Integer 10))])
+                  (VClos [] [] 2 [] (ELit (Integer 3)), VLit (Integer 10))]]
   , []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 (** Function parameter always overwrites everything *)
 Example let_closure_apply_eval_without_overwrite :
   |[], 0,
-   ELet [("X"%string, ELit (Integer 42))] 
-     (ELet [("Y"%string, EFun ["X"%string] (EVar "X"%string))] 
-       (ELet [("X"%string, ELit (Integer 5))] 
-         (EApp (EVar "Y"%string) [ELit (Integer 7)]))), []|
+   ELet ["X"] (ELit (Integer 42))
+     (ELet ["Y"] (EFun ["X"] (EVar "X")) 
+       (ELet ["X"] (ELit (Integer 5))
+         (EApp (EVar "Y") [^ELit (Integer 7)]))), []|
 -e>
-  | 1, inl (VLit (Integer 7)), []|.
+  | 1, inl [VLit (Integer 7)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 
 (** Example to test that value overwriting does not affect the value in the closure *)
 Example let_closure_apply_eval_without_overwrite2 :
   |[], 0,
-   ELet [("X"%string, ELit (Integer 42))] 
-     (ELet [("Y"%string, EFun [] (EVar "X"%string))] 
-       (ELet [("X"%string, ELit (Integer 5))] 
-         (EApp (EVar "Y"%string) []))), []|
+   ELet ["X"] (ELit (Integer 42)) 
+     (ELet ["Y"] (EFun [] (EVar "X"))
+       (ELet ["X"] (ELit (Integer 5))
+         (EApp (EVar "Y") []))), []|
 -e> 
-  | 1, inl (VLit (Integer 42)), []|.
+  | 1, inl [VLit (Integer 42)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example call_eval : 
-  |[(inl "X"%string, VLit (Integer 5))], 0,
-   ECall "+"%string [EVar "X"%string ; ELit (Integer 2)], []|
+  |[(inl "X", VLit (Integer 5))], 0,
+   ECall "+" [^EVar "X" ; ^ELit (Integer 2)], []|
 -e> 
-  |0, inl (VLit (Integer 7)), []|.
+  |0, inl [VLit (Integer 7)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example mutliple_function_let : 
   |[], 0,
-   ELet [("Z"%string, ECall "+"%string [ELit (Integer 2) ; ELit (Integer 2)] )] 
-     (ELet [("Y"%string, EFun [] (EVar "Z"%string))] 
-        (ELet [("X"%string, EFun [] (EApp (EVar "Y"%string) []))] 
-          (EApp (EVar "X"%string) []))), []|
+   ELet ["Z"] (ECall "+" [^ELit (Integer 2) ; ^ELit (Integer 2)] ) 
+     (ELet ["Y"] (EFun [] (EVar "Z"))
+        (ELet ["X"] (EFun [] (EApp (EVar "Y") [])) 
+          (EApp (EVar "X") []))), []|
 -e>
-  | 2, inl (VLit (Integer 4)), []|.
+  | 2, inl [VLit (Integer 4)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example case_eval : 
-  |[(inl "X"%string, VEmptyTuple)], 0,
-   ECase [EVar "X"%string]
-         [([PLit (Integer 5)], ELit (Atom "true"%string), ELit (Integer 5)); 
-          ([PLit (Integer 6)], ELit (Atom "true"%string), ELit (Integer 6)); 
-          ([PVar "Z"%string], ELit (Atom "true"%string), EVar "Z"%string) ]
+  |[(inl "X", VEmptyTuple)], 0,
+   ECase (EVar "X")
+         [([PLit (Integer 5)], ^ELit (Atom "true"), ^ELit (Integer 5)); 
+          ([PLit (Integer 6)], ^ELit (Atom "true"), ^ELit (Integer 6)); 
+          ([PVar "Z"], ^ELit (Atom "true"), ^EVar "Z") ]
   , [] |
 -e> 
-  | 0, inl (VEmptyTuple), []|.
+  | 0, inl [VEmptyTuple], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example case_eval2 :
-  |[(inl "X"%string, VEmptyTuple)], 0,
-   ECase [EVar "X"%string]
-         [([PLit (Integer 5)], ELit (Atom "true"%string), ELit (Integer 5)); 
-          ([PLit (Integer 6)], ELit (Atom "true"%string), ELit (Integer 6));
-          ([PVar "Z"%string], ELit (Atom "false"%string), EVar "Z"%string);
-          ([PVar "Z"%string], ELit (Atom "true"%string), EMap [])]
+  |[(inl "X", VEmptyTuple)], 0,
+   ECase (EVar "X") 
+         [([PLit (Integer 5)], ^ELit (Atom "true"), ^ELit (Integer 5)); 
+          ([PLit (Integer 6)], ^ELit (Atom "true"), ^ELit (Integer 6));
+          ([PVar "Z"], ^ELit (Atom "false"), ^EVar "Z");
+          ([PVar "Z"], ^ELit (Atom "true"), ^EMap [])]
 
   , []|
 -e> 
-  | 0, inl (VMap []), []|.
+  | 0, inl [VEmptyMap], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example case_eval_fun : 
-  |[(inl "X"%string, VClos [(inl "Y"%string, ttrue)] [] 0 [] (EVar "Y"%string))], 1,
-   ECase [EVar "X"%string]
-         [([PLit (Integer 5)], ELit (Atom "true"%string), ELit (Integer 5)); 
-          ([PLit (Integer 6)], ELit (Atom "true"%string), ELit (Integer 6)); 
-          ([PVar "Z"%string], ELit (Atom "true"%string), EApp (EVar "Z"%string) [])] 
+  |[(inl "X", VClos [(inl "Y", ttrue)] [] 0 [] (EVar "Y")); (inl "Y", ttrue)], 1,
+   ECase (EValues [EVar "X"; EVar "Y"])
+         [([PLit (Integer 5); PLit (Atom "true")], ^ELit (Atom "true"), ^ELit (Integer 5)); 
+          ([PLit (Integer 6); PLit (Atom "true")], ^ELit (Atom "true"), ^ELit (Integer 6)); 
+          ([PVar "Z"; PLit (Atom "true")], ^ELit (Atom "true"), ^EApp (EVar "Z") [])] 
   , []| 
--e> | 1, inl (ttrue), []|.
+-e> | 1, inl [ttrue], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 
 Example letrec_eval : 
-  |[(inr ("fun4"%string, 0), VClos [] [(0, ("fun4"%string, 0), ([], EMap []))] 0 [] (EMap [])) ; 
-    (inl "X"%string, VLit (Integer 42))], 1,
-   ELetRec [(("fun2"%string, 0), ([], EVar "X"%string)); 
-            (("fun4"%string, 1), (["Z"%string],EVar "Z"%string))] 
-     (EApp (EFunId ("fun4"%string, 0)) []), []|
+  |[(inr ("fun4", 0), VClos [] [(0, ("fun4", 0), ([], ^EMap []))] 0 [] (EMap [])) ; 
+    (inl "X", VLit (Integer 42))], 1,
+   ELetRec [(("fun2", 0), ([], ^EVar "X")); 
+            (("fun4", 1), (["Z"], ^EVar "Z"))] 
+     (EApp (EFunId ("fun4", 0)) []), []|
 -e>
-  | 3, inl (VMap []), []|.
+  | 3, inl [VEmptyMap], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 
 Example unnamed_eval : 
-  |[(inl "X"%string, VLit (Integer 5))], 0,
-   EApp (EFun ["Y"%string] (EVar "Y"%string)) [EVar "X"%string], []|
+  |[(inl "X", VLit (Integer 5))], 0,
+   EApp (EFun ["Y"] (EVar "Y")) [^EVar "X"], []|
 -e> 
-  | 1, inl (VLit (Integer 5)), []|.
+  | 1, inl [VLit (Integer 5)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 
 Section B_Core.
 
-Definition B : ErlModule := ErlMod "b"%string [
-  TopLevelFun ("fun1"%string, 0) [] (ELit (Integer 6)) ;
-  TopLevelFun ("fun2"%string, 0) [] (ELet [("X"%string, (EFun [] (ELit (Integer 5))))] (
-                                         ELet [("X"%string, (EFun [] (ELit (Integer 6))))] 
-                                           (EApp (EVar "X"%string) [])) )
+Definition B : ErlModule := ErlMod "b" [
+  TopLevelFun ("fun1", 0) [] (ELit (Integer 6)) ;
+  TopLevelFun ("fun2", 0) [] (ELet ["X"] (EFun [] (ELit (Integer 5))) (
+                                         ELet ["X"] (EFun [] (ELit (Integer 6)))
+                                           (EApp (EVar "X") [])) )
 ].
 
 
 Example fun2 : 
   |[], 0,
-   ELet [("X"%string, (EFun [] (ELit (Integer 5))))] 
-     (ELet [("X"%string, (EFun [] (ELit (Integer 6))))] 
-       (EApp (EVar "X"%string) [])), []|
+   ELet ["X"] (EFun [] (ELit (Integer 5))) 
+     (ELet ["X"] (EFun [] (ELit (Integer 6))) 
+       (EApp (EVar "X") [])), []|
 -e>
-  | 2, inl (VLit (Integer 6)), []|.
+  | 2, inl [VLit (Integer 6)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 (* Compute initialize_proving B.
@@ -437,138 +454,148 @@ End B_Core.
 Section Documentation_Examples.
 
 Example ex1 : 
-  |[], 0, ELet [("X"%string, ELit (Integer 5))] (EVar "X"%string), []|
+  |[], 0, ELet ["X"] (ELit (Integer 5)) (EVar "X"), []|
 -e>
-  | 0, inl (VLit (Integer 5)), []|.
+  | 0, inl [VLit (Integer 5)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
-(* 
-  TODO: solve can't be used yet for exceptions
-Example ex2 : 
+(* Example ex2 : 
   |[], 0,
-   ELet [("X"%string, EFun [] (EApp (EVar "X"%string) []))] 
-     (EApp (EVar "X"%string) []), []|
+   ELet [("X", EFun [] (EApp (EVar "X") []))] 
+     (EApp (EVar "X") []), []|
 -e>
   | 1, inr novar, []|.
 Proof.
-  try(timeout 5 solve).
+  eapply eval_let with (vals := [VClos [] [] 0 [] (EApp ( EVar "X") [])])
+                       (eff := [[]]) (ids := [1]); auto.
+  * intros. inversion H.
+    - subst. apply eval_fun.
+    - inversion H1.
+  * simpl. eapply eval_app with (vals := []) (var_list := []) (ids := [])
+                                  (body := (EApp (EVar "X") [])) 
+                                  (ref := []) (ext := []) (n := 0) (eff := []); auto.
+    - apply eval_var. reflexivity.
+    - intros. inversion H.
+    - simpl. eapply eval_app_ex_closure_ex; auto.
+      + reflexivity.
+      + apply eval_var. reflexivity.
 Qed. *)
 
 Example ex3 :
-  |[], 0, ELetRec [(("X"%string, 0), ([], EApp (EFunId ("X"%string, 0)) []))] 
-            (EApp (EFunId ("X"%string, 0)) []), []|
+  |[], 0, ELetRec [(("X", 0), ([], ^EApp (EFunId ("X", 0)) []))] 
+            (EApp (EFunId ("X", 0)) []), []|
 -e>
-  |1, inl (VEmptyTuple), []|.
+  |1, inl [VEmptyTuple], []|.
 Proof.
-  try(timeout 5 solve).
+  try (timeout 10 solve).
 Abort.
 
 Example ex4 : 
-|[], 0, ELet [("X"%string, ELit (Integer 4))] 
-          (ELet [("X"%string, EFun [] (EVar "X"%string))] 
-             (ELet [("X"%string, EFun [] (EApp (EVar "X"%string) []))] 
-                (EApp (EVar "X"%string) []))), []|
+|[], 0, ELet ["X"] (ELit (Integer 4)) 
+          (ELet ["X"] (EFun [] (EVar "X")) 
+             (ELet ["X"] (EFun [] (EApp (EVar "X") []))
+                (EApp (EVar "X") []))), []|
 -e>
-  |2, inl (VLit (Integer 4)), []|.
+  |2, inl [VLit (Integer 4)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 End Documentation_Examples.
 
 Example returned_function :
   |[], 0,
-   ELet [("X"%string, EFun [] (EFun [] (ELit (Integer 5))))] 
-     (EApp (EApp (EVar "X"%string) []) []), []|
+   ELet ["X"] (EFun [] (EFun [] (ELit (Integer 5))))
+     (EApp (EApp (EVar "X") []) []), []|
 -e>
-  | 2, inl (VLit (Integer 5)), []|.
+  | 2, inl [VLit (Integer 5)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example returned_recursive_function : 
   |[], 0,
-   ELetRec [(("fun1"%string, 0), ([], (EFun [] (ELit (Integer 5)))))] 
-     (EApp (EApp (EFunId ("fun1"%string, 0)) []) []), []|
+   ELetRec [(("fun1", 0), ([], (^EFun [] (ELit (Integer 5)))))] 
+     (EApp (EApp (EFunId ("fun1", 0)) []) []), []|
 -e>
-  | 2, inl (VLit (Integer 5)), []|.
+  | 2, inl [VLit (Integer 5)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example returned_function2 :
-  |[(inl "X"%string, VLit (Integer 7))], 0,
-   ELet [("X"%string, EFun [] (EFun [] (EVar "X"%string)))] 
-     (EApp (EApp (EVar "X"%string) []) []), []|
+  |[(inl "X", VLit (Integer 7))], 0,
+   ELet ["X"] (EFun [] (EFun [] (EVar "X")))
+     (EApp (EApp (EVar "X") []) []), []|
 -e>
-  | 2, inl (VLit (Integer 7)), []|.
+  | 2, inl [VLit (Integer 7)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example returned_recursive_function2 :
-  |[(inl "X"%string, VLit (Integer 7))], 0,
-   ELetRec [(("fun1"%string, 0), ([], EFun [] (EVar "X"%string)))] 
-     (EApp (EApp (EFunId ("fun1"%string, 0)) []) []), []|
+  |[(inl "X", VLit (Integer 7))], 0,
+   ELetRec [(("fun1", 0), ([], ^EFun [] (EVar "X")))] 
+     (EApp (EApp (EFunId ("fun1", 0)) []) []), []|
 -e>
-  | 2, inl (VLit (Integer 7)), []|.
+  | 2, inl [VLit (Integer 7)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example returned_function3 : 
   |[], 0,
-   ELet [("F"%string, 
-     EFun ["X"%string] 
-        (ELet [("Y"%string, ECall "+"%string [EVar "X"%string; ELit (Integer 3)] )] 
-              (EFun ["Z"%string] 
-                    (ECall "+"%string 
-                          [ECall "+"%string [EVar "X"%string; EVar "Y"%string]
-                     ; EVar "Z"%string]))))]
-  (EApp (EApp (EVar "F"%string) [ELit (Integer 1)]) [ELit (Integer 1)]), []|
+   ELet ["F"] 
+     (EFun ["X"] 
+        (ELet ["Y"] (ECall "+" [^EVar "X"; ^ELit (Integer 3)] ) 
+              (EFun ["Z"] 
+                    (ECall "+" 
+                          [^ECall "+" [^EVar "X"; ^EVar "Y"]
+                     ; ^EVar "Z"]))))
+  (EApp (EApp (EVar "F") [^ELit (Integer 1)]) [^ELit (Integer 1)]), []|
 -e>
-  |2, inl (VLit (Integer 6)), []|.
+  |2, inl [VLit (Integer 6)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example sum :
   | [], 0,
-    ELetRec [(("f"%string, 1), (["X"%string], 
+    ELetRec [(("f", 1), (["X"], 
       
-      ECase [EVar "X"%string] [([PLit (Integer 0)], ELit (Atom "true"%string), ELit (Integer 0)); 
-                               ([PVar "Y"%string], ELit (Atom "true"%string), 
-                               ECall "+"%string [
-                                     EVar "Y"%string; 
-                                     EApp (EFunId ("f"%string, 1)) [ECall "+"%string [EVar "Y"%string; ELit (Integer (Z.pred 0))] ]
+      ^ECase (EVar "X") [([PLit (Integer 0)], ^ELit (Atom "true"), ^ELit (Integer 0)); 
+                               ([PVar "Y"], ^ELit (Atom "true"), 
+                               ^ECall "+" [
+                                     ^EVar "Y"; 
+                                     ^EApp (EFunId ("f", 1)) [ ^ECall "+" [^EVar "Y"; ^ELit (Integer (Z.pred 0))] ]
                               ])]
-      ))] (EApp (EFunId ("f"%string, 1)) [ELit (Integer 2)]), []| -e> |1, inl (VLit (Integer 3)), []|.
+      ))] (EApp (EFunId ("f", 1)) [^ELit (Integer 2)]), []| -e> |1, inl [VLit (Integer 3)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example letrec_no_replace :
   |[], 0,
-   ELet [("X"%string, ELit (Integer 42))] 
-     (ELetRec [(("f"%string, 0), ([], EVar "X"%string))]
-       (ELet [("X"%string, ELit (Integer 5))]
-         (EApp (EFunId ("f"%string, 0)) []))), []|
+   ELet ["X"] (ELit (Integer 42)) 
+     (ELetRec [(("f", 0), ([], ^EVar "X"))]
+       (ELet ["X"] (ELit (Integer 5))
+         (EApp (EFunId ("f", 0)) []))), []|
 -e>
-  | 1, inl (VLit (Integer 42)), []|.
+  | 1, inl [VLit (Integer 42)], []|.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 Example seq_eval1 :
-  | [], 0, ESeq (ELet [("X"%string, ELit (Integer 42))] (EVar "X"%string))
-                (ELet [("Y"%string, ELit (Integer 20))] (EVar "Y"%string))
+  | [], 0, ESeq (ELet ["X"] (ELit (Integer 42)) (EVar "X"))
+                (ELet ["Y"] (ELit (Integer 20)) (EVar "Y"))
    , [] |
 -e>
-  | 0, inl (VLit (Integer 20)), [] |.
+  | 0, inl [VLit (Integer 20)], [] |.
 Proof.
-  try(timeout 5 solve).
+  solve.
 Qed.
 
 End Automated_Tests.

--- a/src/Core_Erlang_Auxiliaries.v
+++ b/src/Core_Erlang_Auxiliaries.v
@@ -1,0 +1,413 @@
+Require Core_Erlang_Side_Effects.
+
+Module Auxiliaries.
+
+Export Core_Erlang_Side_Effects.Side_Effects.
+
+Import ListNotations.
+
+(** For biuilt-in arithmetic calls *)
+Definition eval_arith (fname : string) (params : list Value) :  ValueSequence + Exception :=
+match fname, params with
+(** addition *)
+| "+"%string, [VLit (Integer a); VLit (Integer b)] => inl [VLit (Integer (a + b))]
+| "+"%string, [a; b]                               => inr (badarith (VCons a b))
+(** subtraction *)
+| "-"%string, [VLit (Integer a); VLit (Integer b)] => inl [VLit (Integer (a - b))]
+| "-"%string, [a; b]                               => inr (badarith (VCons a b))
+(** unary minus *)
+| "-"%string, [VLit (Integer a)]                   => inl [VLit (Integer (0 - a))]
+| "-"%string, [a]                                  => inr (badarith a)
+(** multiplication *)
+| "*"%string, [VLit (Integer a); VLit (Integer b)] => inl [VLit (Integer (a * b))]
+| "*"%string, [a; b]                               => inr (badarith (VCons a b))
+(** division *)
+| "/"%string, [VLit (Integer a); VLit (Integer b)] => inl [VLit (Integer (a / b))]
+| "/"%string, [a; b]                               => inr (badarith (VCons a b))
+(** rem *)
+| "rem"%string, [VLit (Integer a); VLit (Integer b)] => inl [VLit (Integer (Z.rem a b))]
+| "rem"%string, [a; b]                               => inr (badarith (VCons a b))
+(** div *)
+| "div"%string, [VLit (Integer a); VLit (Integer b)] => inl [VLit (Integer (Z.div a b))]
+| "div"%string, [a; b]                               => inr (badarith (VCons a b))
+(** anything else *)
+| _         , _                                    => inr (undef (VLit (Atom fname)))
+end.
+
+(** For IO maniputaion: *)
+Definition eval_io (fname : string) (params : list Value) (eff : SideEffectList) 
+   : ((ValueSequence + Exception) * SideEffectList) :=
+match fname, length params, params with
+(** writing *)
+| "fwrite"%string, 1, _ => (inl [ok]                                  , eff ++ [(Output, params)])
+(** reading *)
+| "fread"%string , 2, e => (inl [VTuple [ok; nth 1 params ErrorValue]], eff ++ [(Input, params)])
+(** anything else *)
+| _              , _, _ => (inr (undef (VLit (Atom fname)))           , eff)
+end.
+
+Definition eval_logical (fname : string) (params : list Value) : ValueSequence + Exception :=
+match fname, params with
+(** logical and *)
+| "and"%string, [a; b] => 
+   match a, b with
+   | VLit (Atom "true") , VLit (Atom "true")    => inl [ttrue]
+   | VLit (Atom "false"), VLit (Atom "true")    => inl [ffalse]
+   | VLit (Atom "true") , VLit (Atom "false")   => inl [ffalse]
+   | VLit (Atom "false"), VLit (Atom "false")   => inl [ffalse]
+   | _                         , _              => inr (badarg (VCons a b))
+   end
+(** logical or *)
+| "or"%string, [a; b] =>
+   match a, b with
+   | VLit (Atom "true") , VLit (Atom "true")    => inl [ttrue]
+   | VLit (Atom "false"), VLit (Atom "true")    => inl [ttrue]
+   | VLit (Atom "true") , VLit (Atom "false")   => inl [ttrue]
+   | VLit (Atom "false"), VLit (Atom "false")   => inl [ffalse]
+   | _                         , _              => inr (badarg (VCons a b))
+   end
+(** logical not *)
+| "not"%string, [a] =>
+   match a with
+   | VLit (Atom "true")  => inl [ffalse]
+   | VLit (Atom "false") => inl [ttrue]
+   | _                   => inr (badarg a)
+   end
+(** anything else *)
+| _ , _ => inr (undef (VLit (Atom fname)))
+end.
+
+Definition eval_equality (fname : string) (params : list Value) : ValueSequence + Exception :=
+match fname, params with
+| "=="%string,  [v1; v2] (* TODO: with floats, this one should be adjusted *)
+| "=:="%string, [v1; v2] => if Value_eqb v1 v2 then inl [ttrue] else inl [ffalse]
+| "/="%string,  [v1; v2] (* TODO: with floats, this one should be adjusted *)
+| "=/="%string, [v1; v2] => if Value_eqb v1 v2 then inl [ffalse] else inl [ttrue]
+(** anything else *)
+| _ , _ => inr (undef (VLit (Atom fname)))
+end.
+
+Fixpoint is_shallow_proper_list (v : Value) : bool :=
+match v with
+| VNil => true
+| VCons x y => is_shallow_proper_list y
+| _ => false
+end.
+
+Fixpoint eval_append (v1 v2 : Value) : ValueSequence + Exception :=
+match v1, v2 with
+| VNil, VNil => inl [VNil]
+| VNil, VCons x y => inl [VCons x y]
+| VCons x y, VNil => inl [VCons x y]
+| VCons x y, VCons x' y' =>
+  match y with
+  | VCons z w => match eval_append y (VCons x' y') with
+                 | inr ex => inr ex
+                 | inl [res] => inl [VCons x res]
+                 | _ => inr (badarg (VCons v1 v2))
+                 end
+  | VNil      => inl [VCons x (VCons x' y')]
+  | z         => inr (badarg (VCons v1 v2))
+  end
+| _, _ => inr (badarg (VCons v1 v2))
+end.
+
+Fixpoint subtract_elem (v1 v2 : Value) : Value :=
+match v1 with
+| VNil => VNil
+| VCons x y =>
+  match y with
+  | VNil => if Value_eqb x v2 then VNil else VCons x y
+  | VCons z w => if Value_eqb x v2 then y else VCons x (subtract_elem y v2)
+  | z => if Value_eqb x v2 then VCons z VNil else if Value_eqb z v2 then VCons x VNil else VCons x y
+  end
+| _ => ErrorValue
+end.
+
+Fixpoint eval_subtract (v1 v2 : Value) : ValueSequence + Exception :=
+if andb (is_shallow_proper_list v1) (is_shallow_proper_list v2) then
+  match v1, v2 with
+  | VNil, VNil => inl [VNil]
+  | VNil, VCons x y => inl [VNil]
+  | VCons x y, VNil => inl [VCons x y]
+  | VCons x y, VCons x' y' => 
+     match y' with
+     | VNil => inl [subtract_elem (VCons x y) x']
+     | VCons z w => eval_subtract (subtract_elem (VCons x y) x') y'
+     | z => inl [subtract_elem (subtract_elem (VCons x y) x') z]
+     end
+  | _        , _         => inr (badarg (VCons v1 v2))
+  end
+else
+  inr (badarg (VCons v1 v2)).
+
+Definition eval_transform_list (fname : string) (params : list Value) : ValueSequence + Exception :=
+match fname, params with
+| "++"%string, [v1; v2] => eval_append v1 v2
+| "--"%string, [v1; v2] => eval_subtract v1 v2
+| _ , _ => inr (undef (VLit (Atom fname)))
+end.
+
+Definition transform_tuple (v : Value) : ValueSequence + Exception :=
+match v with
+| VTuple l => inl [((fix unfold_list l :=
+                   match l with
+                   | [] => VNil
+                   | x::xs => VCons x (unfold_list xs)
+                   end) l)]
+| _        => inr (badarg v)
+end.
+
+Fixpoint transform_list (v : Value) : list Value + Exception :=
+match v with
+| VNil      => inl []
+| VCons x y => match y with
+               | VNil => inl [x]
+               | VCons z w => match (transform_list y) with
+                              | inr ex => inr ex
+                              | inl res => inl (x::res)
+                              end
+               | z => inr (badarg v)
+               end
+| _         => inr (badarg v)
+end.
+
+Definition eval_list_tuple (fname : string) (params : list Value) : ValueSequence + Exception :=
+match fname, params with
+| "tuple_to_list"%string, [v] => transform_tuple v
+| "list_to_tuple"%string, [v] => match (transform_list v) with
+                                 | inr ex => inr ex
+                                 | inl l => inl [VTuple l]
+                                 end
+| _                     , _   => inr (undef (VLit (Atom fname)))
+end.
+
+Definition eval_cmp (fname : string) (params : list Value) : ValueSequence + Exception :=
+match fname, params with
+| "<"%string,  [v1; v2] => if Value_ltb v1 v2 then inl [ttrue] else inl [ffalse]
+| "=<"%string, [v1; v2] => if orb (Value_ltb v1 v2) (Value_eqb v1 v2) 
+                           then inl [ttrue] else inl [ffalse]
+| ">"%string,  [v1; v2] => if Value_ltb v2 v1 then inl [ttrue] else inl [ffalse]
+| ">="%string, [v1; v2] => if orb (Value_ltb v2 v1) (Value_eqb v1 v2) 
+                           then inl [ttrue] else inl [ffalse]
+(** anything else *)
+| _ , _ => inr (undef (VLit (Atom fname)))
+end.
+
+Definition eval_length (params : list Value) : ValueSequence + Exception :=
+match params with
+| [v] => let res :=
+          (fix len val := match val with
+                         | VNil => inl Z.zero
+                         | VCons x y => let res := len y in
+                                          match res with
+                                          | inl n => inl (Z.add 1 n)
+                                          | inr _ => res
+                                          end
+                         | _ => inr (badarg v)
+                         end) v in
+        match res with
+        | inl n => inl [VLit (Integer n)]
+        | inr ex => inr ex
+        end
+| _ => inr (undef (VLit (Atom "length")))
+end.
+
+Definition eval_tuple_size (params : list Value) : ValueSequence + Exception :=
+match params with
+| [VTuple l] => inl [VLit (Integer (Z.of_nat (length l)))]
+| [v] => inr (badarg v)
+| _ => inr (undef (VLit (Atom "tuple_size")))
+end.
+
+Definition eval_hd_tl (fname : string) (params : list Value) : ValueSequence + Exception :=
+match fname, params with
+| "hd"%string, [VCons x y] => inl [x]
+| "hd"%string, [v] => inr (badarg v)
+| "tl"%string, [VCons x y] => inl [y]
+| "tl"%string, [v] => inr (badarg v)
+| _, _ => inr (undef (VLit (Atom fname)))
+end.
+
+Fixpoint replace_nth_error {A : Type} (l : list A) (i : nat) (e : A) : option (list A) :=
+match i, l with
+| 0, x::xs => Some (e::xs)
+| _, [] => None
+| S n, x::xs => match (replace_nth_error xs n e) with
+               | None => None
+               | Some l' => Some (x::l')
+               end
+end.
+
+Definition eval_elem_tuple (fname : string) (params : list Value) : ValueSequence + Exception :=
+match fname, params with
+| "element"%string, [VLit (Integer i); VTuple l] =>
+    match i with
+    | Z.pos p => match nth_error l (pred (Pos.to_nat p)) with
+                 | None   => inr (badarg (VCons (VLit (Integer i)) (VTuple l)))
+                 | Some v => inl [v]
+                 end
+    | _       => inr (badarg (VCons (VLit (Integer i)) (VTuple l)))
+    end
+| "element"%string, [v1; v2] => inr (badarg (VCons v1 v2))
+| "setelement"%string, [VLit (Integer i); VTuple l; val] =>
+    match i with
+    | Z.pos p => match replace_nth_error l (pred (Pos.to_nat p)) val with
+                 | None    => inr (badarg (VCons (VLit (Integer i)) (VCons (VTuple l) val)))
+                 | Some l' => inl [VTuple l']
+                 end
+    | _       => inr (badarg (VCons (VLit (Integer i)) (VTuple l)))
+    end
+| "setelement"%string, [v1; v2; v3] => inr (badarg (VCons v1 (VCons v2 v3)))
+| _, _ => inr (undef (VLit (Atom fname)))
+end.
+
+(* TODO: Always can be extended, this function simulates inter-module calls *)
+Definition eval (fname : string) (params : list Value) (eff : SideEffectList) 
+   : ((ValueSequence + Exception) * SideEffectList) :=
+match fname with
+| "+"%string      | "-"%string
+| "*"%string      | "/"%string
+| "rem"%string    | "div"%string   => (eval_arith fname params, eff)
+| "fwrite"%string | "fread"%string => eval_io fname params eff
+| "and"%string    | "or"%string
+| "not"%string                     => (eval_logical fname params, eff)
+| "=="%string     | "=:="%string
+| "/="%string     | "=/="%string   => (eval_equality fname params, eff)
+| "++"%string     | "--"%string    => (eval_transform_list fname params, eff)
+| "tuple_to_list"%string
+| "list_to_tuple"%string           => (eval_list_tuple fname params, eff)
+| "<"%string      | ">"%string 
+| "=<"%string     | ">="%string    => (eval_cmp fname params, eff)
+| "length"%string                  => (eval_length params, eff)
+| "tuple_size"%string              => (eval_tuple_size params, eff)
+| "hd"%string     | "tl"%string    => (eval_hd_tl fname params, eff)
+| "element"%string
+| "setelement"%string              => (eval_elem_tuple fname params, eff)
+(** anything else *)
+| _                                => (inr (undef (VLit (Atom fname))), eff)
+end.
+
+End Auxiliaries.
+
+Section Tests.
+
+Import Auxiliaries.
+Import ListNotations.
+
+(** Tests *)
+
+Compute (eval "+" [VLit (Integer 1); VLit (Integer 2)]) [] = (inl [VLit (Integer 3)], []).
+Compute (eval "-" [VLit (Integer 1); VLit (Integer 2)]) [] = (inl [VLit (Integer (-1))], []).
+Compute (eval "+" [VLit (Atom "foo"); VLit (Integer 2)]) [] 
+    = (inr (badarith (VCons (VLit (Atom "foo")) (VLit (Integer 2)))), []).
+Compute (eval "+" [VLit (Integer 1); VLit (Atom "foo")]) [] 
+    = (inr (badarith (VCons (VLit (Integer 2)) (VLit (Atom "foo")))), []).
+Compute (eval "-" [VLit (Atom "foo"); VLit (Integer 2)]) [] 
+    = (inr (badarith (VCons (VLit (Atom "foo")) (VLit (Integer 2)))), []).
+Compute (eval "-" [VLit (Integer 1); VLit (Atom "foo")]) [] 
+    = (inr (badarith (VCons (VLit (Integer 2)) (VLit (Atom "foo")))), []).
+Compute (eval "-" [VLit (Atom "foo")]) [] 
+    = (inr (badarith (VLit (Atom "foo"))), []).
+Compute (eval "+" [VLit (Atom "foo")]) [] 
+    = (inr (undef (VLit (Atom "+"))), []).
+
+Compute (eval "not" [ttrue]) [] = (inl [ffalse], []).
+Compute (eval "not" [ffalse]) [] = (inl [ttrue], []).
+Compute (eval "not" [VLit (Integer 5)]) [] = (inr (badarg (VLit (Integer 5))), []).
+Compute (eval "not" [VLit (Integer 5); VEmptyTuple]) [] = (inr (undef (VLit (Atom "not"))), []).
+
+Compute (eval "and" [ttrue; ttrue]) [] = (inl [ttrue], []).
+Compute (eval "and" [ttrue; ffalse]) [] = (inl [ffalse], []).
+Compute (eval "and" [ffalse; ttrue]) [] = (inl [ffalse], []).
+Compute (eval "and" [ffalse; ffalse]) [] = (inl [ffalse], []).
+Compute (eval "and" [ttrue; VEmptyTuple]) [] = (inr (badarg (VCons (VLit (Atom "true")) (VTuple []))), []).
+Compute (eval "and" [ttrue]) [] = (inr (undef (VLit (Atom "and"))), []).
+
+Compute (eval "or" [ttrue; ttrue]) [] = (inl [ttrue], []).
+Compute (eval "or" [ttrue; ffalse]) [] = (inl [ttrue], []).
+Compute (eval "or" [ffalse; ttrue]) [] = (inl [ttrue], []).
+Compute (eval "or" [ffalse; ffalse]) [] = (inl [ffalse], []).
+Compute (eval "or" [ttrue; VEmptyTuple]) [] = (inr (badarg (VCons (VLit (Atom "true")) (VTuple []))), []).
+Compute (eval "or" [ttrue]) [] = (inr (undef (VLit (Atom "or"))), []).
+
+Compute (eval "fwrite" [ttrue]) [] = (inl [ok], [(Output, [ttrue])]).
+Compute (eval "fwrite" [VMap [(ttrue, ttrue)]]) [] = (inl [ok], [(Output, [VMap [(ttrue, ttrue)]])]).
+Compute (eval "fwrite" []) [] = (inr (undef (VLit (Atom "fwrite"))), []).
+
+Compute (eval "fread" [VLit (Atom "foo.txt"); ttrue]) [] = 
+   (inl [VTuple [ok; ttrue]], [(Input, [VLit (Atom "foo.txt"); ttrue])]).
+Compute (eval "fread" [VLit (Atom "foo.txt"); VMap [(ttrue, ttrue)]]) [] = 
+   (inl [VTuple [ok; VMap [(ttrue, ttrue)]]], [(Input, [VLit (Atom "foo.txt"); VMap [(ttrue, ttrue)]])]).
+Compute (eval "fread" []) [] = (inr (undef (VLit (Atom "fread"))), []).
+
+Compute (eval "==" [ttrue; ttrue]) [] = (inl [ttrue], []).
+Compute (eval "==" [ttrue; ffalse]) [] = (inl [ffalse], []).
+Compute (eval "==" [VClos [] [] 1 [] EEmptyMap; ttrue]) [] = (inl [ffalse], []).
+Compute (eval "==" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 2 [] EEmptyMap]) [] = (inl [ffalse], []).
+Compute (eval "==" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl [ttrue], []).
+
+Compute (eval "/=" [ttrue; ttrue]) [] = (inl [ffalse], []).
+Compute (eval "/=" [ttrue; ffalse]) [] = (inl [ttrue], []).
+Compute (eval "/=" [VClos [] [] 1 [] EEmptyMap; ttrue]) [] = (inl [ttrue], []).
+Compute (eval "/=" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 2 [] EEmptyMap]) [] = (inl [ttrue], []).
+Compute (eval "/=" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl [ffalse], []).
+Compute (eval "/=" [ttrue]) [] = (inr (undef (VLit (Atom "/="))), []).
+
+Definition l1 : Value := VCons ttrue VNil.
+Definition l2 : Value := VCons ttrue ttrue.
+Definition l3 : Value := VCons (VCons ttrue ttrue) ttrue.
+Definition l4 : Value := VCons ttrue (VCons ttrue (VCons ttrue VNil)).
+Definition l5 : Value := VCons ttrue (VCons ttrue ttrue).
+
+Compute (eval "++" [ttrue; ttrue]) [] = (inr (badarg _), []).
+Compute (eval "++" [l1; l1]) [].
+Compute (eval "++" [l1; l2]) [].
+Compute (eval "++" [l1; l3]) [].
+Compute (eval "++" [l3; l3]) [].
+
+Compute (eval "--" [ttrue; ttrue]) [] = (inr (badarg _), []).
+Compute (eval "--" [l1; l1]) [].
+Compute (eval "--" [l1; l2]) [].
+Compute (eval "--" [l1; l3]) [].
+Compute (eval "--" [l3; l3]) [].
+Compute (eval "--" [l3; l1]) [].
+Compute (eval "--" [l4; l4]) [].
+
+Compute (eval "tuple_to_list" [VTuple [ttrue; ttrue; ttrue; l1]] []).
+Compute (eval "tuple_to_list" [VTuple [ttrue; ttrue; l5; l1]] []).
+Compute (eval "tuple_to_list" [VTuple [ttrue; l3; ttrue; l1]] []).
+Compute (eval "tuple_to_list" [VTuple [ttrue; ttrue; l2; l1]] []).
+Compute (eval "tuple_to_list" [ttrue] []).
+
+Compute (eval "list_to_tuple" [l1] []).
+Compute (eval "list_to_tuple" [l2] []).
+Compute (eval "list_to_tuple" [l3] []).
+Compute (eval "list_to_tuple" [l4] []).
+Compute (eval "list_to_tuple" [l5] []).
+
+Compute (eval "<" [ttrue; ttrue]) [] = (inl [ffalse], []).
+Compute (eval "<" [ttrue; ffalse]) [] = (inl [ffalse], []).
+Compute (eval "<" [VClos [] [] 1 [] EEmptyMap; VEmptyMap]) [] = (inl [ttrue], []).
+Compute (eval "<" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 2 [] EEmptyMap]) [] = (inl [ttrue], []).
+Compute (eval "<" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl [ffalse], []).
+
+Compute (eval "=<" [ttrue; ttrue]) [] = (inl [ttrue], []).
+Compute (eval "=<" [ttrue; ffalse]) [] = (inl [ffalse], []).
+Compute (eval "=<" [VClos [] [] 1 [] EEmptyMap; VEmptyMap]) [] = (inl [ttrue], []).
+Compute (eval "=<" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 2 [] EEmptyMap]) [] = (inl [ttrue], []).
+Compute (eval "=<" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl [ttrue], []).
+
+Compute (eval ">" [ttrue; ttrue]) [] = (inl [ffalse], []).
+Compute (eval ">" [ffalse; ttrue]) [] = (inl [ffalse], []).
+Compute (eval ">" [VEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl [ttrue], []).
+Compute (eval ">" [VClos [] [] 2 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl [ttrue], []).
+Compute (eval ">" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl [ffalse], []).
+
+Compute (eval ">=" [ttrue; ttrue]) [] = (inl [ttrue], []).
+Compute (eval ">=" [ffalse; ttrue]) [] = (inl [ffalse], []).
+Compute (eval ">=" [VEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl [ttrue], []).
+Compute (eval ">=" [VClos [] [] 2 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl [ttrue], []).
+Compute (eval ">=" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl [ttrue], []).
+
+End Tests.

--- a/src/Core_Erlang_Determinism_Helpers.v
+++ b/src/Core_Erlang_Determinism_Helpers.v
@@ -1,45 +1,16 @@
 Require Core_Erlang_Tactics.
 
-From Coq Require Export Arith.PeanoNat.
+From Coq Require Arith.PeanoNat.
 
 (** Helper lemmas for determinism *)
 Module Determinism_Helpers.
 
 Export Core_Erlang_Semantics.Semantics.
+Export Arith.PeanoNat.
+
 Import Core_Erlang_Tactics.Tactics.
 
 Import ListNotations.
-
-(* Lemma concatn_app {eff1 x1 : SideEffectList} {x6 : list SideEffectList} {i : nat} : 
-  concatn eff1 (x1 :: x6) (S i) = concatn (eff1 ++ x1) x6 i.
-Proof.
-  induction i.
-  * simpl_concatn. reflexivity.
-  * simpl_concatn. simpl_concatn_H IHi. reflexivity.
-Qed.
- *)
-(** Attibute restriction to a smaller list *)
-Lemma restrict_helper {env : Environment} {eff1 : SideEffectList} {exps : list Expression} 
-    (a : Expression) (x1 : SideEffectList) (x6 : list SideEffectList) (x0 : Value) 
-    (x3 : list Value) (id' : nat) (ids : list nat) (id : nat):
-(forall i : nat,
-    i < Datatypes.length (a :: exps) ->
-    | env, nth_def (id'::ids) id 0 i, nth i (a :: exps) ErrorExp, nth_def (x1 :: x6) eff1 [] i | -e>
-    | nth_def (id'::ids) id 0 (S i), inl (nth i (x0 :: x3) ErrorValue), nth_def (x1 :: x6) eff1 [] (S i) |)
-->
-forall i : nat,
-    i < Datatypes.length exps ->
-    | env, nth_def ids id' 0 i, nth i exps ErrorExp, nth_def x6 x1 [] i | -e>
-    | nth_def ids id' 0 (S i), inl (nth i x3 ErrorValue), nth_def x6 x1 [] (S i) |
-.
-Proof.
-  intros.
-  assert (S i < Datatypes.length (a :: exps)) as A1.
-  { simpl. apply lt_n_S. assumption. } pose (E := H (S i) A1). 
-  (* pose (P1 := @concatn_app eff1 x1 x6 i).
-  pose (P2 := @concatn_app eff1 x1 x6 (S i)).
-  rewrite P1, P2 in E. *) simpl in E. simpl. unfold nth_def. exact E.
-Qed.
 
 Ltac empty_list_in_hypo :=
 match goal with
@@ -66,28 +37,22 @@ end
 .
 
 (** Value lists are equal ased on the determinism hypotheses *)
-Lemma list_equality {env : Environment} {exps : list Expression} {eff1 : SideEffectList} : 
+Lemma explist_equality {env : Environment} {exps : list Expression} {eff1 : SideEffectList} : 
 forall vals vals0 : list Value, forall eff eff4 : list SideEffectList,
 forall id ids ids0,
-  (forall i : nat,
-     i < Datatypes.length exps ->
-     | env, nth_def ids id 0 i, nth i exps ErrorExp, nth_def eff eff1 [] i | 
-     -e> 
-     | nth_def ids id 0 (S i), inl (nth i vals ErrorValue), nth_def eff eff1 [] (S i) |)
-->
 (forall i : nat,
      i < Datatypes.length exps ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
      | env, nth_def ids id 0 i, nth i exps ErrorExp, nth_def eff eff1 [] i |
      -e>
      | id'', v2, eff'' | ->
-     inl (nth i vals ErrorValue) = v2 /\ nth_def eff eff1 [] (S i) = eff'' /\ nth_def ids id 0 (S i) = id'')
+     inl [nth i vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S i) = eff'' /\ nth_def ids id 0 (S i) = id'')
 ->
 (forall i : nat,
      i < Datatypes.length exps ->
      | env, nth_def ids0 id 0 i, nth i exps ErrorExp, nth_def eff4 eff1 [] i |
      -e> 
-     | nth_def ids0 id 0 (S i), inl (nth i vals0 ErrorValue), nth_def eff4 eff1 [] (S i) |)
+     | nth_def ids0 id 0 (S i), inl [nth i vals0 ErrorValue], nth_def eff4 eff1 [] (S i) |)
 ->
 Datatypes.length exps = Datatypes.length vals0
 ->
@@ -104,60 +69,126 @@ length exps = length ids0
 eff = eff4 /\ vals = vals0 /\ ids = ids0.
 Proof.
   generalize dependent eff1. induction exps.
-  * intros. simpl in H3, H2, H4, H5, H6, H7.
-    repeat (empty_list_in_hypo).
+  * intros. simpl in H3, H2, H4, H5, H6, H1.
+    repeat empty_list_in_hypo.
     subst. auto.
-  * intros. inversion H3. inversion H2. inversion H4. inversion H5. inversion H6. inversion H7.
+  * intros. inversion H3. inversion H2. inversion H4. inversion H5. inversion H6. inversion H1.
   
   (* first elements are the same *)
     single_unfold_list. single_unfold_list.
     single_unfold_list. single_unfold_list.
     single_unfold_list. single_unfold_list.
-    pose (P1 := H1 0 list_length).
-    pose (P2 := H0 0 list_length (inl x7) (nth_def (x9 :: x10) eff1 [] 1) x).
-    pose (P3 := P2 P1). inversion P3. inversion H25. inversion H27. simpl in H28. simpl in H30.
+    pose (P1 := H0 0 list_length).
+    pose (P2 := H 0 list_length _ _ _ P1).
+    inversion P2. inversion H24. destruct H26.
+    simpl in H26, H27.
     subst.
   (* remaining lists are the same *)
-
-  (* These three asserts ensure, that if something states for every element in 
-    a (b::l) list, then it states for every element in l too*)
-    assert (
-      (forall i : nat,
-    i < Datatypes.length exps ->
-    | env, nth_def x2 x 0 i, nth i exps ErrorExp, nth_def x4 x9 [] i | -e> 
-    | nth_def x2 x 0 (S i), inl (nth i x6 ErrorValue),
-    nth_def x4 x9 [] (S i) |)
-    ).
-    {
-      intros. pose (P4 := restrict_helper a _ _ _ _ _ _ _ H i H28). assumption.
-    }
     assert (
       (forall i : nat,
       i < Datatypes.length exps ->
-      forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-      | env, nth_def x2 x 0 i, nth i exps ErrorExp, nth_def x4 x9 [] i | -e> | id'', v2, eff'' | ->
-      inl (nth i x6 ErrorValue) = v2 /\ nth_def x4 x9 [] (S i) = eff'' /\ nth_def x2 x 0 (S i) = id'')
+      forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
+      | env, nth_def x4 x1 0 i, nth i exps ErrorExp, nth_def x6 x7 [] i | -e> | id'', v2, eff'' | ->
+      inl [nth i x10 ErrorValue] = v2 /\ nth_def x6 x7 [] (S i) = eff'' /\ nth_def x4 x1 0 (S i) = id'')
     ).
     {
-      intros. assert (S i < Datatypes.length (a::exps)). { simpl. omega. } 
-      pose (P4 := H0 (S i) H31 v2 eff'' id''). simpl nth in P4. exact (P4 H30).
+      intros. assert (S i < Datatypes.length (a::exps)). { simpl. lia. } 
+      pose (P4 := H (S i) H28 v2 eff'' id''). simpl nth in P4. exact (P4 H27).
     }
     assert (
      (forall i : nat,
     i < Datatypes.length exps ->
-    | env, nth_def x0 x 0 i, nth i exps ErrorExp, nth_def x10 x9 [] i | -e>
-    | nth_def x0 x 0 (S i), inl (nth i x8 ErrorValue),
-    nth_def x10 x9 [] (S i) |)
+    | env, nth_def x2 x1 0 i, nth i exps ErrorExp, nth_def x8 x7 [] i | -e>
+    | nth_def x2 x1 0 (S i), inl [nth i x0 ErrorValue],
+    nth_def x8 x7 [] (S i) |)
     ).
     {
-      intros. assert (S i < Datatypes.length (a :: exps)). { simpl. omega. } 
-      pose (P4 := H1 (S i) H31). simpl nth in P4. assumption.
+      intros. assert (S i < Datatypes.length (a :: exps)). { simpl. lia. } 
+      pose (P4 := H0 (S i) H28). simpl nth in P4. assumption.
     }
     (* simpl list lengths *)
-    inversion H10. inversion H11. inversion H12. inversion H13. inversion H14.
-    pose (IH := IHexps x9 x6 x8 x4 x10 x x2 x0 H28 H29 H30 H32 H26 H33 H34 H35 H36). 
-    inversion IH. inversion H37. subst. auto.
+    inversion H10. inversion H11. inversion H12. inversion H13. inversion H9.
+    inversion H8.
+    pose (IH := IHexps _ _ _ _ _ _ _ _ H26 H27 H32 H33 H34 H29 H30 H31). 
+    destruct IH. destruct H35. subst. auto.
 Qed.
+
+Lemma singleexplist_equality {env : Environment} {exps : list SingleExpression} {eff1 : SideEffectList} : 
+forall vals vals0 : list Value, forall eff eff4 : list SideEffectList,
+forall id ids ids0,
+(forall i : nat,
+     i < Datatypes.length exps ->
+     forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_def ids id 0 i, nth i exps ErrorExp, nth_def eff eff1 [] i |
+     -s>
+     | id'', v2, eff'' | ->
+     inl [nth i vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S i) = eff'' /\ nth_def ids id 0 (S i) = id'')
+->
+(forall i : nat,
+     i < Datatypes.length exps ->
+     | env, nth_def ids0 id 0 i, nth i exps ErrorExp, nth_def eff4 eff1 [] i |
+     -s> 
+     | nth_def ids0 id 0 (S i), inl [nth i vals0 ErrorValue], nth_def eff4 eff1 [] (S i) |)
+->
+Datatypes.length exps = Datatypes.length vals0
+->
+Datatypes.length exps = Datatypes.length eff4
+->
+Datatypes.length exps = Datatypes.length vals
+->
+Datatypes.length exps = Datatypes.length eff
+->
+length exps = length ids
+->
+length exps = length ids0
+->
+eff = eff4 /\ vals = vals0 /\ ids = ids0.
+Proof.
+  generalize dependent eff1. induction exps.
+  * intros. simpl in H3, H2, H4, H5, H6, H1.
+    repeat empty_list_in_hypo.
+    subst. auto.
+  * intros. inversion H3. inversion H2. inversion H4. inversion H5. inversion H6. inversion H1.
+  
+  (* first elements are the same *)
+    single_unfold_list. single_unfold_list.
+    single_unfold_list. single_unfold_list.
+    single_unfold_list. single_unfold_list.
+    pose (P1 := H0 0 list_length).
+    pose (P2 := H 0 list_length _ _ _ P1).
+    inversion P2. inversion H24. destruct H26.
+    simpl in H26, H27.
+    subst.
+  (* remaining lists are the same *)
+    assert (
+      (forall i : nat,
+      i < Datatypes.length exps ->
+      forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
+      | env, nth_def x4 x1 0 i, nth i exps ErrorExp, nth_def x6 x7 [] i | -s> | id'', v2, eff'' | ->
+      inl [nth i x10 ErrorValue] = v2 /\ nth_def x6 x7 [] (S i) = eff'' /\ nth_def x4 x1 0 (S i) = id'')
+    ).
+    {
+      intros. assert (S i < Datatypes.length (a::exps)). { simpl. lia. } 
+      pose (P4 := H (S i) H28 v2 eff'' id''). simpl nth in P4. exact (P4 H27).
+    }
+    assert (
+     (forall i : nat,
+    i < Datatypes.length exps ->
+    | env, nth_def x2 x1 0 i, nth i exps ErrorExp, nth_def x8 x7 [] i | -s>
+    | nth_def x2 x1 0 (S i), inl [nth i x0 ErrorValue],
+    nth_def x8 x7 [] (S i) |)
+    ).
+    {
+      intros. assert (S i < Datatypes.length (a :: exps)). { simpl. lia. } 
+      pose (P4 := H0 (S i) H28). simpl nth in P4. assumption.
+    }
+    (* simpl list lengths *)
+    inversion H10. inversion H11. inversion H12. inversion H13. inversion H9.
+    inversion H8.
+    pose (IH := IHexps _ _ _ _ _ _ _ _ H26 H27 H32 H33 H34 H29 H30 H31). 
+    destruct IH. destruct H35. subst. auto.
+Qed.
+
 
 (** Based on determinism hypotheses, the same clause was chosen in case evaluation *)
 Lemma index_case_equality {env : Environment} {clauses : list (list Pattern * Expression * Expression)} {vals : list Value} (i i0 : nat) 
@@ -167,74 +198,74 @@ Lemma index_case_equality {env : Environment} {clauses : list (list Pattern * Ex
      j < i ->
      forall (gg ee : Expression) (bb : list (Var * Value)),
      match_clause vals clauses j = Some (gg, ee, bb) ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
      | add_bindings bb env, id', gg, eff1 | -e> | id'', v2, eff'' | ->
-     inl ffalse = v2 /\ eff1 = eff'' /\ id' = id'')
+     inl [ffalse] = v2 /\ eff1 = eff'' /\ id' = id'')
   ->
   (forall j : nat,
       j < i0 ->
       forall (gg ee : Expression) (bb : list (Var * Value)),
       match_clause vals clauses j = Some (gg, ee, bb) ->
-      | add_bindings bb env, id', gg, eff1 | -e> | id', inl ffalse, eff1 |)
+      | add_bindings bb env, id', gg, eff1 | -e> | id', inl [ffalse], eff1 |)
   ->
   match_clause vals clauses i = Some (guard, exp, bindings)
   ->
   match_clause vals clauses i0 = Some (guard0, exp0, bindings0)
   ->
-  | add_bindings bindings0 env, id', guard0, eff1 | -e> | id', inl ttrue, eff1 |
+  | add_bindings bindings0 env, id', guard0, eff1 | -e> | id', inl [ttrue], eff1 |
   ->
-  | add_bindings bindings env, id', guard, eff1 | -e> | id', inl ttrue, eff1 |
+  | add_bindings bindings env, id', guard, eff1 | -e> | id', inl [ttrue], eff1 |
   ->
-  (forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+  (forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
          | add_bindings bindings env, id', guard, eff1 | -e> | id'', v2, eff'' | ->
-         inl ttrue = v2 /\ eff1 = eff'' /\ id' = id'')
+         inl [ttrue] = v2 /\ eff1 = eff'' /\ id' = id'')
 ->
   i = i0.
 Proof.
   intros. pose (D := Nat.lt_decidable i i0). destruct D.
-  * pose (P1 := H0 i H6 guard exp bindings H1). pose (P2 := H5 (inl ffalse) _ _ P1). 
+  * pose (P1 := H0 i H6 guard exp bindings H1). pose (P2 := H5 (inl [ffalse]) _ _ P1). 
     inversion P2. inversion H7.
-  * apply not_lt in H6. apply (nat_ge_or) in H6. inversion H6.
+  * apply Compare_dec.not_lt in H6. apply (nat_ge_or) in H6. inversion H6.
     - assumption.
-    - pose (P3 := H i0 H7 guard0 exp0 bindings0 H2 (inl ttrue) _ _ H3). inversion P3. inversion H8.
+    - pose (P3 := H i0 H7 guard0 exp0 bindings0 H2 (inl [ttrue]) _ _ H3). inversion P3. inversion H8.
 Qed.
 
 (** Based on determinism, until the i-th element, the side effects are equal *)
-Lemma firstn_eq {env : Environment} {eff : list SideEffectList} : 
-forall (eff5 : list SideEffectList) (exps : list Expression) (vals vals0 : list Value) 
-   (eff1 : SideEffectList) (ids ids0 : list nat) (id id'' : nat) ex eff3,
+Lemma explist_prefix_eq {env : Environment} {eff : list SideEffectList} : 
+forall (eff' : list SideEffectList) (exps : list Expression) (vals vals' : list Value) 
+   (eff1 : SideEffectList) (ids ids' : list nat) (id id'' : nat) ex eff3,
 length exps = length vals ->
 Datatypes.length exps = Datatypes.length eff
 ->
-Datatypes.length eff5 = Datatypes.length vals0
+Datatypes.length eff' = Datatypes.length vals'
 ->
-Datatypes.length vals0 < Datatypes.length exps 
+Datatypes.length vals' < Datatypes.length exps 
 ->
 length exps = length ids
 ->
-length ids0 = length vals0
+length ids' = length vals'
 ->
 (forall i : nat,
      i < Datatypes.length exps ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
      | env, nth_def ids id 0 i, nth i exps ErrorExp, nth_def eff eff1 [] i | -e> | id'', v2, eff'' | ->
-     inl (nth i vals ErrorValue) = v2 /\ nth_def eff eff1 [] (S i) = eff'' /\ nth_def ids id 0 (S i) = id'')
+     inl [nth i vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S i) = eff'' /\ nth_def ids id 0 (S i) = id'')
 ->
 (forall j : nat,
-     j < Datatypes.length vals0 ->
-     | env, nth_def ids0 id 0 j, nth j exps ErrorExp, nth_def eff5 eff1 [] j | -e>
-     | nth_def ids0 id 0 (S j), inl (nth j vals0 ErrorValue),
-     nth_def eff5 eff1 [] (S j) |)
+     j < Datatypes.length vals' ->
+     | env, nth_def ids' id 0 j, nth j exps ErrorExp, nth_def eff' eff1 [] j | -e>
+     | nth_def ids' id 0 (S j), inl [nth j vals' ErrorValue],
+     nth_def eff' eff1 [] (S j) |)
 ->
-| env, last ids0 id, nth (Datatypes.length vals0) exps ErrorExp,
-      last eff5 eff1 | -e> | id'', inr ex,
+| env, last ids' id, nth (Datatypes.length vals') exps ErrorExp,
+      last eff' eff1 | -e> | id'', inr ex,
       eff3 |
 ->
 False.
 Proof.
   induction eff.
   * intros. inversion H0. rewrite H9 in H2. inversion H2.
-  * intros. destruct eff5.
+  * intros. destruct eff'.
     - inversion H1. simpl in H1. apply eq_sym, length_zero_iff_nil in H1. subst.
       simpl in H4.
       apply length_zero_iff_nil in H4. subst. simpl in H0. rewrite H0 in H5.
@@ -242,13 +273,13 @@ Proof.
     - inversion H1. simpl.
     (* first elements *)
       inversion H0.
-      assert (0 < length exps). { omega. }
-      assert (0 < length vals0). { omega. }
-      assert (0 < length ids0). { omega. }
+      assert (0 < length exps). { lia. }
+      assert (0 < length vals'). { lia. }
+      assert (0 < length ids'). { lia. }
       simpl in H0, H1.
       (* single_unfold_list H1. *)
       assert (Datatypes.length exps = S (Datatypes.length eff)) as Helper. { auto. }
-      assert (Datatypes.length ids0 = Datatypes.length vals0) as Helper2. { auto. }
+      assert (Datatypes.length ids' = Datatypes.length vals') as Helper2. { auto. }
       assert (Datatypes.length exps = Datatypes.length ids) as Helper3. { auto. }
       pose (EE1 := element_exist _ _ (eq_sym H10)).
       pose (EE2 := element_exist _ _ H1).
@@ -261,83 +292,124 @@ Proof.
       inversion EE4 as [id0']. inversion EE5 as [id0'']. 
       inversion H13. inversion H14. inversion H15. inversion H16. inversion H17. subst.
       pose (P0 := H6 0 H11).
-      pose (P1 := H5 0 H8 (inl v) (s)).
+      pose (P1 := H5 0 H8 (inl [v]) (s)).
       pose (P2 := P1 _ P0). destruct P2. destruct H18, H19. simpl in H18, H19. subst.
     (* other elements *)
       inversion H1.
-      eapply IHeff with (exps := x) (vals := x1) (vals0 := x0) (eff1 := s)
-                      (ids := x2) (ids0 := x3) (id := id0'') (eff5 := eff5); auto.
+      eapply IHeff with (exps := x) (vals := x1) (vals' := x0) (eff1 := s)
+                      (ids := x2) (ids' := x3) (id := id0'') (eff' := eff'); auto.
         + intuition.
-        + intros. assert (S i < Datatypes.length (e :: x)). { simpl. omega. }
+        + intros. assert (S i < Datatypes.length (e :: x)). { simpl. lia. }
           pose (A := H5 (S i) H21 v2 eff''). simpl in A, H20.
           pose (B := A _ H20). assumption.
-        + intros. assert (S j < Datatypes.length (v :: x0)). { omega. } 
+        + intros. assert (S j < Datatypes.length (v :: x0)). { lia. } 
           pose (A := H6 (S j) H20). exact A.
         + rewrite <- last_element_equal, <- last_element_equal in H7. exact H7.
 Qed.
 
-(** Side effect equality until the ith element using concatn *)
-Lemma eff_until_i {env : Environment} {eff : list SideEffectList} : 
-forall (eff5 : list SideEffectList) {exps : list Expression} (vals vals0 : list Value) 
-   (eff1 : SideEffectList) (ids ids0 : list nat) (id id'' : nat) ex  eff3,
+
+Lemma singleexplist_prefix_eq {env : Environment} {eff : list SideEffectList} : 
+forall (eff' : list SideEffectList) (exps : list SingleExpression) (vals vals' : list Value) 
+   (eff1 : SideEffectList) (ids ids' : list nat) (id id'' : nat) ex eff3,
 length exps = length vals ->
 Datatypes.length exps = Datatypes.length eff
 ->
-Datatypes.length eff5 = Datatypes.length vals0
+Datatypes.length eff' = Datatypes.length vals'
 ->
-Datatypes.length vals0 < Datatypes.length exps 
+Datatypes.length vals' < Datatypes.length exps 
 ->
 length exps = length ids
 ->
-length ids0 = length vals0
+length ids' = length vals'
 ->
 (forall i : nat,
      i < Datatypes.length exps ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 i, nth i exps ErrorExp, nth_def eff eff1 [] i | -e> | id'', v2, eff'' | ->
-     inl (nth i vals ErrorValue) = v2 /\ nth_def eff eff1 [] (S i) = eff'' /\ nth_def ids id 0 (S i) = id'')
+     forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_def ids id 0 i, nth i exps ErrorExp, nth_def eff eff1 [] i | -s> | id'', v2, eff'' | ->
+     inl [nth i vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S i) = eff'' /\ nth_def ids id 0 (S i) = id'')
 ->
 (forall j : nat,
-     j < Datatypes.length vals0 ->
-     | env, nth_def ids0 id 0 j, nth j exps ErrorExp, nth_def eff5 eff1 [] j | -e>
-     | nth_def ids0 id 0 (S j), inl (nth j vals0 ErrorValue),
-     nth_def eff5 eff1 [] (S j) |)
+     j < Datatypes.length vals' ->
+     | env, nth_def ids' id 0 j, nth j exps ErrorExp, nth_def eff' eff1 [] j | -s>
+     | nth_def ids' id 0 (S j), inl [nth j vals' ErrorValue],
+     nth_def eff' eff1 [] (S j) |)
 ->
-| env, last ids0 id, nth (Datatypes.length vals0) exps ErrorExp,
-      last eff5 eff1 | -e> | id'', inr ex, eff3 |
+| env, last ids' id, nth (Datatypes.length vals') exps ErrorExp,
+      last eff' eff1 | -s> | id'', inr ex,
+      eff3 |
 ->
-  False.
+False.
 Proof.
-  intros. pose (P := firstn_eq eff5 exps vals vals0 _ _ _ _ _ _ _
-                                H H0 H1 H2 H3 H4 H5 H6 H7). inversion P.
+  induction eff.
+  * intros. inversion H0. rewrite H9 in H2. inversion H2.
+  * intros. destruct eff'.
+    - inversion H1. simpl in H1. apply eq_sym, length_zero_iff_nil in H1. subst.
+      simpl in H4.
+      apply length_zero_iff_nil in H4. subst. simpl in H0. rewrite H0 in H5.
+      pose (P := H5 0 (Nat.lt_0_succ _) _ _ _ H7). destruct P. inversion H1.
+    - inversion H1. simpl.
+    (* first elements *)
+      inversion H0.
+      assert (0 < length exps). { lia. }
+      assert (0 < length vals'). { lia. }
+      assert (0 < length ids'). { lia. }
+      simpl in H0, H1.
+      (* single_unfold_list H1. *)
+      assert (Datatypes.length exps = S (Datatypes.length eff)) as Helper. { auto. }
+      assert (Datatypes.length ids' = Datatypes.length vals') as Helper2. { auto. }
+      assert (Datatypes.length exps = Datatypes.length ids) as Helper3. { auto. }
+      pose (EE1 := element_exist _ _ (eq_sym H10)).
+      pose (EE2 := element_exist _ _ H1).
+      rewrite H in H0.
+      pose (EE3 := element_exist _ _ (eq_sym H0)).
+      rewrite <- H1 in H4. rewrite H10 in H3.
+      pose (EE4 := element_exist _ _ H3).
+      pose (EE5 := element_exist _ _ (eq_sym H4)).
+      inversion EE1 as [e]. inversion EE2 as [v]. inversion EE3 as [v'].
+      inversion EE4 as [id0']. inversion EE5 as [id0'']. 
+      inversion H13. inversion H14. inversion H15. inversion H16. inversion H17. subst.
+      pose (P0 := H6 0 H11).
+      pose (P1 := H5 0 H8 (inl [v]) (s)).
+      pose (P2 := P1 _ P0). destruct P2. destruct H18, H19. simpl in H18, H19. subst.
+    (* other elements *)
+      inversion H1.
+      eapply IHeff with (exps := x) (vals := x1) (vals' := x0) (eff1 := s)
+                      (ids := x2) (ids' := x3) (id := id0'') (eff' := eff'); auto.
+        + intuition.
+        + intros. assert (S i < Datatypes.length (e :: x)). { simpl. lia. }
+          pose (A := H5 (S i) H21 v2 eff''). simpl in A, H20.
+          pose (B := A _ H20). assumption.
+        + intros. assert (S j < Datatypes.length (v :: x0)). { lia. } 
+          pose (A := H6 (S j) H20). exact A.
+        + rewrite <- last_element_equal, <- last_element_equal in H7. exact H7.
 Qed.
 
 (** First i elements are equal, but with changed hypotheses *)
-Lemma firstn_eq_rev {env : Environment} {eff : list SideEffectList} : 
-   forall (eff5 : list SideEffectList) (exps : list Expression) (vals vals0 : list Value) 
-          (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat) (eff2 : SideEffectList) 
+Lemma explist_prefix_eq_rev {env : Environment} {eff : list SideEffectList} : 
+   forall (eff' : list SideEffectList) (exps : list Expression) (vals vals' : list Value) 
+          (eff1 : SideEffectList) (ids ids' : list nat) (id : nat) (eff2 : SideEffectList) 
           (id' : nat) (ex : Exception),
 (forall j : nat,
      j < Datatypes.length vals ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
      | env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j | -e> | id'', v2, eff'' | ->
-     inl (nth j vals ErrorValue) = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
+     inl [nth j vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
 ->
 (forall i : nat,
      i < Datatypes.length exps ->
-     | env, nth_def ids0 id 0 i, nth i exps ErrorExp, nth_def eff5 eff1 [] i | -e>
-     | nth_def ids0 id 0 (S i), inl (nth i vals0 ErrorValue),
-     nth_def eff5 eff1 [] (S i) |) ->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_def ids' id 0 i, nth i exps ErrorExp, nth_def eff' eff1 [] i | -e>
+     | nth_def ids' id 0 (S i), inl [nth i vals' ErrorValue],
+     nth_def eff' eff1 [] (S i) |) ->
+(forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
         | env, last ids id, nth (Datatypes.length vals) exps ErrorExp,
         last eff eff1 | -e> | id'', v2, eff'' | ->
         inr ex = v2 /\ eff2 = eff'' /\ id' = id'')
 ->
 Datatypes.length vals < Datatypes.length exps ->
 Datatypes.length eff = Datatypes.length vals ->
-Datatypes.length exps = Datatypes.length vals0 ->
-Datatypes.length exps = Datatypes.length eff5 ->
-length exps = length ids0 ->
+Datatypes.length exps = Datatypes.length vals' ->
+Datatypes.length exps = Datatypes.length eff' ->
+length exps = length ids' ->
 length ids = length vals
 ->
 False.
@@ -347,20 +419,20 @@ Proof.
     apply length_zero_iff_nil in H7. subst.
     pose (P := H0 0 H2).
     pose (P2 := H1 _ _ _ P). inversion P2. congruence.
-  * intros. destruct eff5.
+  * intros. destruct eff'.
     - inversion H5. rewrite H5 in H2. inversion H2.
     - inversion H3. inversion H5.
     (* first elements *)
-      assert (0 < length exps). { omega. } assert (0 < length vals). { omega. }
-      assert (S (Datatypes.length eff5) = Datatypes.length exps). { auto. }
-      assert (Datatypes.length exps = Datatypes.length vals0) as LENGTH. { auto. }
+      assert (0 < length exps). { lia. } assert (0 < length vals). { lia. }
+      assert (S (Datatypes.length eff') = Datatypes.length exps). { auto. }
+      assert (Datatypes.length exps = Datatypes.length vals') as LENGTH. { auto. }
       assert (S (Datatypes.length eff) = Datatypes.length vals) as Helper1. { auto. }
-      assert (Datatypes.length exps = Datatypes.length ids0) as Helper2. { auto. }
+      assert (Datatypes.length exps = Datatypes.length ids') as Helper2. { auto. }
       (* single_unfold_list H9. *)
-      pose (EE1 := element_exist (length eff5) exps (eq_sym H5)).
+      pose (EE1 := element_exist (length eff') exps (eq_sym H5)).
       pose (EE2 := element_exist (length eff) vals H9).
       rewrite H5 in H4, H6. rewrite <- H9 in H7.
-      pose (EE3 := element_exist (length eff5) vals0 H4).
+      pose (EE3 := element_exist (length eff') vals' H4).
       pose (EE4 := element_exist _ _ (eq_sym H7)).
       pose (EE5 := element_exist _ _ H6).
       
@@ -368,55 +440,94 @@ Proof.
       inversion EE4 as [id0']. inversion EE5 as [id0'']. 
       inversion H13. inversion H14. inversion H15. inversion H16. inversion H17. subst.
       pose (P0 := H0 0 H8).
-      pose (P1 := H 0 H11 (inl v') s).
+      pose (P1 := H 0 H11 (inl [v']) s).
       pose (P2 := P1 _ P0). destruct P2. destruct H19. inversion H18. simpl in H19, H20. subst.
     (* other elements *)
       inversion H3.
-      apply IHeff with (exps := x) (vals := x0) (eff1 := s) (vals0 := x1)
-                  (ids := x2) (ids0 := x3) (id := id0'') (ex := ex) (eff5 := eff5)
+      apply IHeff with (exps := x) (vals := x0) (eff1 := s) (vals' := x1)
+                  (ids := x2) (ids' := x3) (id := id0'') (ex := ex) (eff' := eff')
                   (eff2 := eff2) (id' := id'); auto.
-        + intros. assert (S j < Datatypes.length (v' :: x0)). { simpl. omega. } 
+        + intros. assert (S j < Datatypes.length (v' :: x0)). { simpl. lia. } 
           pose (A := H (S j) H22 v2 eff'').
           pose (B := A _ H21). assumption.
-        + intros. assert (S i < Datatypes.length (e :: x)). { simpl. omega. } 
+        + intros. assert (S i < Datatypes.length (e :: x)). { simpl. lia. } 
           pose (A := H0 (S i) H21). exact A.
         + intros. rewrite <- last_element_equal, <- last_element_equal in H1. apply H1. assumption.
         + intuition.
-        + inversion H7. omega.
+        + inversion H7. lia.
 Qed.
 
-(** First i (length vals) element are equal with concatn *)
-Lemma eff_until_i_rev {env : Environment} {eff : list SideEffectList} : 
-   forall (eff5 : list SideEffectList) (exps : list Expression) (vals vals0 : list Value) 
-          (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat) (eff2 : SideEffectList) 
+
+Lemma singleexplist_prefix_eq_rev {env : Environment} {eff : list SideEffectList} : 
+   forall (eff' : list SideEffectList) (exps : list SingleExpression) (vals vals' : list Value) 
+          (eff1 : SideEffectList) (ids ids' : list nat) (id : nat) (eff2 : SideEffectList) 
           (id' : nat) (ex : Exception),
 (forall j : nat,
      j < Datatypes.length vals ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j | -e> | id'', v2, eff'' | ->
-     inl (nth j vals ErrorValue) = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
+     forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j | -s> | id'', v2, eff'' | ->
+     inl [nth j vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
 ->
 (forall i : nat,
      i < Datatypes.length exps ->
-     | env, nth_def ids0 id 0 i, nth i exps ErrorExp, nth_def eff5 eff1 [] i | -e>
-     | nth_def ids0 id 0 (S i), inl (nth i vals0 ErrorValue),
-     nth_def eff5 eff1 [] (S i) |) ->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_def ids' id 0 i, nth i exps ErrorExp, nth_def eff' eff1 [] i | -s>
+     | nth_def ids' id 0 (S i), inl [nth i vals' ErrorValue],
+     nth_def eff' eff1 [] (S i) |) ->
+(forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
         | env, last ids id, nth (Datatypes.length vals) exps ErrorExp,
-        last eff eff1 | -e> | id'', v2, eff'' | ->
+        last eff eff1 | -s> | id'', v2, eff'' | ->
         inr ex = v2 /\ eff2 = eff'' /\ id' = id'')
 ->
 Datatypes.length vals < Datatypes.length exps ->
 Datatypes.length eff = Datatypes.length vals ->
-Datatypes.length exps = Datatypes.length vals0 ->
-Datatypes.length exps = Datatypes.length eff5 ->
-length exps = length ids0 ->
+Datatypes.length exps = Datatypes.length vals' ->
+Datatypes.length exps = Datatypes.length eff' ->
+length exps = length ids' ->
 length ids = length vals
 ->
 False.
 Proof.
-  intros. apply (firstn_eq_rev eff5 exps vals vals0 eff1 _ _ _ _ _ _
-                                   H H0 H1 H2 H3 H4 H5 H6 H7).
+  induction eff.
+  * intros. apply eq_sym, length_zero_iff_nil in H3. subst.
+    apply length_zero_iff_nil in H7. subst.
+    pose (P := H0 0 H2).
+    pose (P2 := H1 _ _ _ P). inversion P2. congruence.
+  * intros. destruct eff'.
+    - inversion H5. rewrite H5 in H2. inversion H2.
+    - inversion H3. inversion H5.
+    (* first elements *)
+      assert (0 < length exps). { lia. } assert (0 < length vals). { lia. }
+      assert (S (Datatypes.length eff') = Datatypes.length exps). { auto. }
+      assert (Datatypes.length exps = Datatypes.length vals') as LENGTH. { auto. }
+      assert (S (Datatypes.length eff) = Datatypes.length vals) as Helper1. { auto. }
+      assert (Datatypes.length exps = Datatypes.length ids') as Helper2. { auto. }
+      (* single_unfold_list H9. *)
+      pose (EE1 := element_exist (length eff') exps (eq_sym H5)).
+      pose (EE2 := element_exist (length eff) vals H9).
+      rewrite H5 in H4, H6. rewrite <- H9 in H7.
+      pose (EE3 := element_exist (length eff') vals' H4).
+      pose (EE4 := element_exist _ _ (eq_sym H7)).
+      pose (EE5 := element_exist _ _ H6).
+      
+      inversion EE1 as [e]. inversion EE2 as [v]. inversion EE3 as [v'].
+      inversion EE4 as [id0']. inversion EE5 as [id0'']. 
+      inversion H13. inversion H14. inversion H15. inversion H16. inversion H17. subst.
+      pose (P0 := H0 0 H8).
+      pose (P1 := H 0 H11 (inl [v']) s).
+      pose (P2 := P1 _ P0). destruct P2. destruct H19. inversion H18. simpl in H19, H20. subst.
+    (* other elements *)
+      inversion H3.
+      apply IHeff with (exps := x) (vals := x0) (eff1 := s) (vals' := x1)
+                  (ids := x2) (ids' := x3) (id := id0'') (ex := ex) (eff' := eff')
+                  (eff2 := eff2) (id' := id'); auto.
+        + intros. assert (S j < Datatypes.length (v' :: x0)). { simpl. lia. } 
+          pose (A := H (S j) H22 v2 eff'').
+          pose (B := A _ H21). assumption.
+        + intros. assert (S i < Datatypes.length (e :: x)). { simpl. lia. } 
+          pose (A := H0 (S i) H21). exact A.
+        + intros. rewrite <- last_element_equal, <- last_element_equal in H1. apply H1. assumption.
+        + intuition.
+        + inversion H7. lia.
 Qed.
 
 (** First i element are equal with concatn *)
@@ -424,17 +535,17 @@ Lemma con_n_equality {env : Environment} {eff : list SideEffectList} :
   forall (exps : list Expression) (vals vals0 : list Value) eff1 eff6 i i0 ids ids0 id eff3 id' ex,
 (forall j : nat,
     j < i ->
-    forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+    forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
     | env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j | -e> | id'', v2, eff'' | ->
-    inl (nth j vals ErrorValue) = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
+    inl [nth j vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
 ->
 (forall j : nat,
      j < i0 ->
      | env, nth_def ids0 id 0 j, nth j exps ErrorExp, nth_def eff6 eff1 [] j | -e>
-     | nth_def ids0 id 0 (S j), inl (nth j vals0 ErrorValue),
+     | nth_def ids0 id 0 (S j), inl [nth j vals0 ErrorValue],
      nth_def eff6 eff1 [] (S j) |)
 ->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+(forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
      | env, last ids id, nth i exps ErrorExp, last eff eff1 | -e> | id'', v2, eff'' | ->
      inr ex = v2 /\ eff3 = eff'' /\ id' = id'')
 ->
@@ -471,10 +582,10 @@ Proof.
       inversion H5. inversion H15. subst.
       assert (s = a /\ id0' = id0''). {
         subst.
-        assert (0 < Datatypes.length (x :: x0)). {  simpl. omega. }
+        assert (0 < Datatypes.length (x :: x0)). {  simpl. lia. }
         pose (P := H0 0 H16).
-        assert (0 < S (Datatypes.length eff)). {  simpl. omega. }
-        pose (P2 := H 0 H17 (inl (nth 0 (x :: x0) ErrorValue)) (nth_def (s :: eff6) eff1 [] 1) _ P). 
+        assert (0 < S (Datatypes.length eff)). {  simpl. lia. }
+        pose (P2 := H 0 H17 (inl [nth 0 (x :: x0) ErrorValue]) (nth_def (s :: eff6) eff1 [] 1) _ P). 
         inversion P2.
         destruct H19. auto.
       }
@@ -482,9 +593,9 @@ Proof.
       
       eapply IHeff with (exps := x3) (vals := vs) (vals0 := x0) (eff1 := a)
                         (i0 := length x0) (ids := x4) (ids0 := x5); auto.
-      + intros. assert (S j < S (Datatypes.length eff)). { simpl. omega. }
+      + intros. assert (S j < S (Datatypes.length eff)). { simpl. lia. }
         pose (P := H (S j) H18 v2 eff'' id''). pose (P H17). assumption.
-      + intros. assert (S j < Datatypes.length (x :: x0)). { simpl. omega. }
+      + intros. assert (S j < Datatypes.length (x :: x0)). { simpl. lia. }
         pose (P := H0 (S j) H17). exact P.
       + intros. apply H1.
         rewrite (last_element_equal _ _ id), (last_element_equal _ _ eff1) in H16.
@@ -501,14 +612,14 @@ Lemma list_equal_until_i {env : Environment} {eff : list SideEffectList} :
       (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat),
 (forall j : nat,
     j < Datatypes.length vals ->
-    forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+    forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
     | env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j | -e> | id'', v2, eff'' | ->
-    inl (nth j vals ErrorValue) = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
+    inl [nth j vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
 ->
 (forall j : nat,
      j < Datatypes.length vals0 ->
      | env, nth_def ids0 id 0 j, nth j exps ErrorExp, nth_def eff6 eff1 [] j | -e> 
-     | nth_def ids0 id 0 (S j), inl (nth j vals0 ErrorValue),
+     | nth_def ids0 id 0 (S j), inl [nth j vals0 ErrorValue],
      nth_def eff6 eff1 [] (S j) |)
 ->
 Datatypes.length vals = Datatypes.length vals0
@@ -541,18 +652,18 @@ Proof.
     pose (EE6 := element_exist _ _ (eq_sym H6)).
     inversion EE5 as [id']. inversion EE6 as [id''].
     inversion H12. inversion H13. subst.
-    assert (0 < Datatypes.length (v' :: x1)). { simpl. omega. }
+    assert (0 < Datatypes.length (v' :: x1)). { simpl. lia. }
     pose (P := H0 0 H14).
-    assert (0 < Datatypes.length (v :: x0)). { simpl. omega. }
-    pose (P1 := H 0 H15 (inl (nth 0 (v' :: x1) ErrorValue)) (nth_def (fe :: x2) eff1 [] 1) _ P).
+    assert (0 < Datatypes.length (v :: x0)). { simpl. lia. }
+    pose (P1 := H 0 H15 (inl [nth 0 (v' :: x1) ErrorValue]) (nth_def (fe :: x2) eff1 [] 1) _ P).
     inversion P1. destruct H17. simpl in H18. inversion H16. simpl in H17. subst.
     
     assert (eff = x2 /\ x0 = x1 /\ x4 = x5).
     {
       apply IHeff with (exps := x3) (vals := x0) (vals0 := x1) (eff1 := fe) (id := id''); auto.
-      + intros. assert (S j < S (Datatypes.length x0)). { simpl. omega. } pose (P2 := H (S j) H19 v2 eff''). 
+      + intros. assert (S j < S (Datatypes.length x0)). { simpl. lia. } pose (P2 := H (S j) H19 v2 eff''). 
         simpl in P2. pose (P2 _ H18). assumption.
-      + intros. assert (S j < Datatypes.length (v' :: x1)). { simpl. omega. }
+      + intros. assert (S j < Datatypes.length (v' :: x1)). { simpl. lia. }
         pose (P3 := H0 (S j) H18). simpl in P3. assumption.
       + inversion H2. inversion H3. inversion H1. auto.
       + inversion H2. inversion H3. inversion H1. auto.
@@ -567,14 +678,14 @@ forall (exps : list Expression) (vals vals0 : list Value) (eff1 : SideEffectList
    (eff6 : list SideEffectList) (i i0 : nat) (id : nat) (ids ids0 : list nat) id' ex0 eff4,
 (forall j : nat,
     j < i ->
-    forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+    forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
     | env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j | -e> | id'', v2, eff'' | ->
-    inl (nth j vals ErrorValue) = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
+    inl [nth j vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
 ->
 (forall j : nat,
      j < i0 ->
      | env, nth_def ids0 id 0 j, nth j exps ErrorExp, nth_def eff6 eff1 [] j | -e> 
-     | nth_def ids0 id 0 (S j), inl (nth j vals0 ErrorValue),
+     | nth_def ids0 id 0 (S j), inl [nth j vals0 ErrorValue],
      nth_def eff6 eff1 [] (S j) |)
 ->
 Datatypes.length eff = i ->
@@ -610,25 +721,25 @@ induction eff.
       inversion EE4 as [id0']. inversion EE5 as [id0'']. inversion H4. inversion H14. subst.
       assert (s = a /\ id0' = id0''). {
         subst.
-        assert (0 < Datatypes.length (x :: x0)). {  simpl. omega. }
+        assert (0 < Datatypes.length (x :: x0)). {  simpl. lia. }
         pose (P := H0 0 H15).
-        assert (0 < S (Datatypes.length eff)). {  simpl. omega. }
-        pose (P1 := H 0 H16 (inl (nth 0 (x :: x0) ErrorValue)) (nth_def (s :: eff6) eff1 [] 1) _ P).
+        assert (0 < S (Datatypes.length eff)). {  simpl. lia. }
+        pose (P1 := H 0 H16 (inl [nth 0 (x :: x0) ErrorValue]) (nth_def (s :: eff6) eff1 [] 1) _ P).
         destruct P1. destruct H18. simpl in H19, H18. auto.
       }
       destruct H15. subst.
       eapply IHeff with (exps := x3) (vals := vs) (vals0 := x0) (eff1 := a) 
                        (i0 := length eff6) (i := length eff) (ids := x4) (ids0 := x5); auto.
-      + intros. assert (S j < S (Datatypes.length eff)). { simpl. omega. }
+      + intros. assert (S j < S (Datatypes.length eff)). { simpl. lia. }
         pose (P := H (S j) H17 v2 eff''). simpl in P.
         pose (P1 := P _ H16). assumption.
-      + intros. inversion H6. assert (S j < Datatypes.length (x :: x0)). { simpl. omega. }
+      + intros. inversion H6. assert (S j < Datatypes.length (x :: x0)). { simpl. lia. }
         pose (P := H0 (S j) H16). assumption.
       + intuition.
       + inversion H6. auto.
-      + rewrite <- H6 in H5. simpl in H5. omega.
+      + rewrite <- H6 in H5. simpl in H5. lia.
       + rewrite <- H6 in Helper. auto.
-      + simpl in *. rewrite <- H6 in H9. omega.
+      + simpl in *. rewrite <- H6 in H9. lia.
       + rewrite <- last_element_equal, <- last_element_equal in H10. simpl in H10. 
         inversion H6. rewrite H16. exact H10.
 Qed.
@@ -640,21 +751,21 @@ Lemma exception_equality {env : Environment} {exps : list Expression} (vals vals
    (id id' id'' : nat) :
 (forall j : nat,
      j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+     forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
      | env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j | -e> | id'', v2, eff'' | ->
-     inl (nth j vals ErrorValue) = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
+     inl [nth j vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
 ->
 | env, last ids0 id, nth i0 exps ErrorExp, last eff6 eff1 | -e>
 | id'', inr ex0, eff4 |
 ->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
+(forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
         | env, last ids id, nth i exps ErrorExp, last eff eff1 | -e>
         | id'', v2, eff'' | -> inr ex = v2 /\ eff3 = eff'' /\ id' = id'')
 ->
 (forall j : nat,
       j < i0 ->
       | env, nth_def ids0 id 0 j, nth j exps ErrorExp, nth_def eff6 eff1 [] j | -e>
-      | nth_def ids0 id 0 (S j), inl (nth j vals0 ErrorValue),
+      | nth_def ids0 id 0 (S j), inl [nth j vals0 ErrorValue],
       nth_def eff6 eff1 [] (S j) |)
 ->
 Datatypes.length vals = i ->
@@ -668,8 +779,8 @@ Datatypes.length vals = i ->
 ->
 i = i0 /\ eff = eff6 /\ vals = vals0 /\ ids = ids0.
 Proof.
-  intros. destruct (le_gt_dec i i0).
-  * case_eq (le_lt_or_eq i i0 l).
+  intros. destruct (Compare_dec.le_gt_dec i i0).
+  * case_eq (Lt.le_lt_or_eq i i0 l).
     - intros.
       pose (P1 := con_n_equality exps vals vals0 eff1 eff6 i i0 ids ids0 id _ _ _
                  H H2 H1 H5 H4 H3 H6 H7 H8 H9 H10 l0). inversion P1.
@@ -679,770 +790,263 @@ Proof.
                H H2 H5 H4 H3 H6 H7 H8 H9 H10 g H0). inversion P.
 Qed.
 
-(** Map lists are equal *)
-Lemma map_lists_equality {env : Environment} {kl : list Expression} : 
-forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (eff1 : SideEffectList) 
-     (eff eff7 : list SideEffectList) (ids ids0 : list nat) (id : nat),
+Lemma con_n_equality_single {env : Environment} {eff : list SideEffectList} : 
+  forall (exps : list SingleExpression) (vals vals0 : list Value) eff1 eff6 i i0 ids ids0 id eff3 id' ex,
 (forall j : nat,
-     j < length vl ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 (2*j), nth j kl ErrorExp, nth_def eff eff1 [] (2 * j) | -e> 
-     | id'', v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ nth_def eff eff1 [] (S (2 * j)) = eff'' 
-     /\ nth_def ids id 0 (S (2*j)) = id'')
+    j < i ->
+    forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
+    | env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j | -s> | id'', v2, eff'' | ->
+    inl [nth j vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
 ->
 (forall j : nat,
-     j < length vl ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 (S (2*j)), nth j vl ErrorExp, nth_def eff eff1 [] (S (2 * j)) | -e> 
-     | id'', v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ nth_def eff eff1 [] (S (S (2 * j))) = eff'' /\ 
-     nth_def ids id 0 (S (S (2*j))) = id'')
+     j < i0 ->
+     | env, nth_def ids0 id 0 j, nth j exps ErrorExp, nth_def eff6 eff1 [] j | -s>
+     | nth_def ids0 id 0 (S j), inl [nth j vals0 ErrorValue],
+     nth_def eff6 eff1 [] (S j) |)
 ->
-Datatypes.length kl = Datatypes.length vl ->
-length kl = Datatypes.length vvals ->
-length kl = Datatypes.length kvals ->
-((length kl) * 2)%nat = Datatypes.length eff ->
-((length kl) * 2)%nat = length ids ->
-(forall j : nat,
-      j < length vl ->
-      | env, nth_def ids0 id 0 (2*j), nth j kl ErrorExp, nth_def eff7 eff1 [] (2 * j) | -e> 
-      | nth_def ids0 id 0 (S (2*j)), inl (nth j kvals0 ErrorValue),
-      nth_def eff7 eff1 [] (S (2 * j)) |)
+(forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, last ids id, nth i exps ErrorExp, last eff eff1 | -s> | id'', v2, eff'' | ->
+     inr ex = v2 /\ eff3 = eff'' /\ id' = id'')
 ->
-(forall j : nat,
-      j < length vl ->
-      | env, nth_def ids0 id 0 (S (2*j)), nth j vl ErrorExp, nth_def eff7 eff1 [] (S (2 * j)) | -e>
-      | nth_def ids0 id 0 (S(S(2*j))), inl (nth j vvals0 ErrorValue), nth_def eff7 eff1 [] (S (S (2 * j))) |)
+Datatypes.length eff = i ->
+i < Datatypes.length exps ->
+Datatypes.length vals = i ->
+Datatypes.length vals0 = i0 ->
+i0 < Datatypes.length exps ->
+Datatypes.length eff6 = i0 ->
+length ids = i ->
+length ids0 = i0 ->
+i < i0
 ->
-length kl = Datatypes.length vvals0 ->
-length kl = Datatypes.length kvals0 ->
-((length kl) * 2)%nat = Datatypes.length eff7 ->
-((length kl) * 2)%nat = length ids0
-->
-kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7 /\ ids = ids0.
+False.
 Proof.
-  induction kl.
-  * intros. inversion H1. inversion H2. inversion H3. inversion H4.
-    repeat empty_list_in_hypo.
-    inversion H10. inversion H8. inversion H9. inversion H11. inversion H5.
-    repeat empty_list_in_hypo.
-    subst. auto.
-  * intros. inversion H1. inversion H2. inversion H3. inversion H4.
-    simpl in H9, H14, H7, H8, H10, H5, H11.
-    single_unfold_list. single_unfold_list. single_unfold_list. 
-    single_unfold_list. single_unfold_list. single_unfold_list.
-    single_unfold_list. single_unfold_list. single_unfold_list.
-    single_unfold_list. single_unfold_list. single_unfold_list. single_unfold_list.
-    (** FIRST ELEMENTS ARE EQUAL *)
-    pose (F1 := H6 0 (Nat.lt_0_succ (length x7))). simpl in F1.
-    pose (F2 := H 0 (Nat.lt_0_succ _) _ _ _ F1). inversion F2. inversion H41.
-    destruct H43. simpl in H43, H44. subst.
-    pose (F3 := H7 0 (Nat.lt_0_succ (length x7))).
-    pose (F4 := H0 0 (Nat.lt_0_succ _) _ _ _ F3). inversion F4. inversion H43.
-    destruct H44. simpl in H44, H45. subst. simpl.
-    (** OTHER ELEMETS *)
-    assert (x3 = x15 /\ x5 = x17 /\ x2 = x14 /\ x21 = x11).
-    {
-      eapply IHkl with (vl := x7); auto.
-      * intros. assert (S j < length (x6 :: x7)). { simpl. omega. }
-        pose (P3 := H (S j) H46 v2 eff''). simpl mult in H45, P3. rewrite Nat.add_0_r in H45, P3.
-        rewrite Nat.add_succ_r in P3. simpl in P3.
-        pose (P4 := P3 _ H45). simpl. rewrite Nat.add_0_r. assumption.
-      * intros. assert (S j < length (x6 :: x7)). { simpl. omega. }
-        pose (P3 := H0 (S j) H46 v2 eff''). simpl mult in H45, P3. rewrite Nat.add_0_r in H45, P3.
-        rewrite Nat.add_succ_r in P3. simpl in P3.
-        pose (P4 := P3 _ H45). simpl. rewrite Nat.add_0_r. assumption.
-      * intros. assert (S j < length (x6 :: x7)). { simpl. omega. }
-        pose (P3 := H6 (S j) H45).
-        simpl. simpl mult in P3. rewrite Nat.add_0_r in P3.
-        rewrite Nat.add_succ_r in P3. simpl in P3. rewrite Nat.add_0_r. assumption.
-      * intros. assert (S j < length (x6 :: x7)). { simpl. omega. }
-        pose (P3 := H7 (S j) H45). 
-        simpl. simpl mult in P3. rewrite Nat.add_0_r in P3.
-        rewrite Nat.add_succ_r in P3. simpl in P3. rewrite Nat.add_0_r. assumption.
-        
-    }
-    destruct H44. destruct H45. destruct H46. subst. auto.
-Qed.
-
-(** Map lists are equal until ith element *)
-Lemma map_lists_equal_until_i {env : Environment} {kl : list Expression} : forall {vl : list Expression}
-   (kvals vvals kvals0 vvals0 : list Value) (i0 : nat) (eff1 : SideEffectList)
-   (eff eff7 : list SideEffectList) (ex0 : Exception) (eff5 eff6 : SideEffectList) (val0 : Value)
-   (ids ids0 : list nat) (id id' id'' : nat),
-(forall j : nat,
-     j < length vl ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 (2*j), nth j kl ErrorExp, nth_def eff eff1 [] (2 * j) | -e>
-     | id'', v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ nth_def eff eff1 [] (S (2 * j)) = eff'' /\
-     nth_def ids id 0 (S (2*j)) = id'')
-->
-(forall j : nat,
-     j < length vl ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 (S (2*j)), nth j vl ErrorExp, nth_def eff eff1 [] (S (2 * j)) | -e>
-     | id'', v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ nth_def eff eff1 [] (S (S (2 * j))) = eff'' /\
-     nth_def ids id 0 (S (S (2*j))) = id'')
-->
-Datatypes.length kl = Datatypes.length vl ->
-length kl = Datatypes.length vvals ->
-length kl = Datatypes.length kvals ->
-((length kl) * 2)%nat = Datatypes.length eff ->
-((length kl) * 2)%nat = Datatypes.length ids ->
-(forall j : nat,
-      j < i0 ->
-      | env, nth_def ids0 id 0 (2*j), nth j kl ErrorExp, nth_def eff7 eff1 [] (2 * j) | -e>
-      | nth_def ids0 id 0 (S (2*j)), inl (nth j kvals0 ErrorValue),
-      nth_def eff7 eff1 [] (S (2 * j)) |)
-->
-(forall j : nat,
-      j < i0 ->
-      | env, nth_def ids0 id 0 (S (2*j)), nth j vl ErrorExp, nth_def eff7 eff1 [] (S (2 * j)) | -e>
-      | nth_def ids0 id 0 (S (S (2*j))), inl (nth j vvals0 ErrorValue), nth_def eff7 eff1 [] (S (S (2 * j))) |)
-->
-Datatypes.length vvals0 = i0 ->
-Datatypes.length kvals0 = i0 ->
-i0 <= Datatypes.length kl ->
-Datatypes.length eff7 = (i0 * 2)%nat ->
-length ids0 = (i0 * 2)%nat ->
-(| env, last ids0 id, nth i0 kl ErrorExp, last eff7 eff1 | -e>
-| id', inr ex0, eff5 |
-\/
-(| env, last ids0 id, nth i0 kl ErrorExp, last eff7 eff1 | -e> | id', inl val0,
-      eff5 | /\
-| env, id', nth i0 vl ErrorExp, eff5 | -e> | 
-      id'', inr ex0, eff6 |)
-)
-->
-length vl = i0 /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7 /\ ids = ids0.
-Proof.
-  induction kl.
-  * intros. inversion H2. apply eq_sym, length_zero_iff_nil in H15. subst. inversion H1.
-    apply eq_sym, length_zero_iff_nil in H14. subst. inversion H10. apply length_zero_iff_nil in H14.
-    subst. inversion H3. apply eq_sym,  length_zero_iff_nil in H14. subst. inversion H11.
-    apply length_zero_iff_nil in H14. subst. inversion H12. apply length_zero_iff_nil in H14. subst.
-    inversion H4. apply eq_sym, length_zero_iff_nil in H14. subst. apply length_zero_iff_nil in H9.
-    subst. apply eq_sym, length_zero_iff_nil in H5. auto.
-  * intros. inversion H1.
-    pose (EE1 := element_exist (length kl) vl H15). 
-    inversion EE1 as [ve]. inversion H14 as [ves].
-    subst.
-    case_eq (length vvals0).
-    - intros. apply length_zero_iff_nil in H8. subst.
-      apply length_zero_iff_nil in H9. apply length_zero_iff_nil in H12.
-      apply length_zero_iff_nil in H11. subst.
-      rewrite <- H1 in H, H0.
-      inversion H13.
-      + pose (P1 := H 0 (Nat.lt_0_succ _) (inr ex0) ( eff5) id').
-        simpl in P1, H8.
-        pose (P2 := P1 H8). inversion P2. inversion H9.
-      + destruct H8. pose (P1 := H 0 (Nat.lt_0_succ _) (inl val0) (eff5) id').
-        pose (P2 := P1 H8). destruct P2. inversion H11. subst.
-        pose (P3 := H0 0 (Nat.lt_0_succ _) (inr ex0) (eff6) id'').
-        destruct H12.
-        rewrite <- H12 in H9 at 1. rewrite H16 in P3.
-        pose (P4 := P3 H9). inversion P4. inversion H17.
-
-    - intros. rewrite H8 in *. simpl in H2, H3. simpl in H4, H10.
-      pose (EE2 := element_exist _ kvals0 (eq_sym H9)).
-      pose (EE3 := element_exist _ vvals0 (eq_sym H8)).
-      pose (EE4 := element_exist _ kvals H3).
-      pose (EE5 := element_exist _ vvals H2).
-      pose (EE6 := element_exist _ eff H4).
-      pose (EE7 := element_exist _ eff7 (eq_sym H11)).
-      pose (EE8 := element_exist _ _ H5).
-      pose (EE9 := element_exist _ _ (eq_sym H12)).
-      inversion EE2 as [kv']. inversion EE3 as [vv']. inversion EE4 as [kv]. inversion EE5 as [vv].
-      inversion EE6 as [e1]. inversion EE7 as [e1']. inversion EE8 as [id1]. inversion EE9 as [id1'].
-      inversion H16. inversion H17. inversion H18. inversion H19.
-      inversion H20. inversion H21. inversion H22. inversion H23. subst.
+  induction eff.
+  * intros. simpl in H1. subst. simpl in H10. pose (P := H0 0 H10).
+    simpl in H8, P. apply length_zero_iff_nil in H8. subst.
+    pose (P2 := H1 _ _ _ P). inversion P2. congruence.
+  * intros. inversion H2. simpl in H2. rewrite <- H2 in H4.
+    pose (EE1 := element_exist (length eff) vals (eq_sym H4)). 
+    inversion EE1 as [v]. inversion H12 as [vs]. destruct eff6.
+    - simpl in H7. subst. rewrite <- H7 in H10. inversion H10.
+    - subst. simpl. (* simpl_concatn_H IHeff. rewrite concatn_app, concatn_app. simpl_concatn. *)
+      simpl in H7. (* single_unfold_list H6. *) 
+      pose (EE2 := element_exist (length eff6) vals0 H7). inversion EE2. 
+      inversion H2.
+      pose (NE := nat_lt_zero _ _  H3). inversion NE.
+      pose (EE3 := element_exist x1 exps (eq_sym H13)). inversion EE3. inversion H14.
+      subst. 
+      pose (EE4 := element_exist _ _ (eq_sym H8)).
+      pose (EE5 := element_exist _ _ (eq_sym H9)).
+      inversion EE4 as [id0']. inversion EE5 as [id0''].
+      inversion H5. inversion H15. subst.
+      assert (s = a /\ id0' = id0''). {
+        subst.
+        assert (0 < Datatypes.length (x :: x0)). {  simpl. lia. }
+        pose (P := H0 0 H16).
+        assert (0 < S (Datatypes.length eff)). {  simpl. lia. }
+        pose (P2 := H 0 H17 (inl [nth 0 (x :: x0) ErrorValue]) (nth_def (s :: eff6) eff1 [] 1) _ P). 
+        inversion P2.
+        destruct H19. auto.
+      }
+      destruct H16. subst.
       
-      inversion H4. inversion H11. inversion H5. inversion H12.
-      pose (EE10 := element_exist _ x3 (H25)).
-      pose (EE11 := element_exist _ x4 (eq_sym H26)).
-      pose (EE12 := element_exist _ x5 (H27)).
-      pose (EE13 := element_exist _ x6 (eq_sym H28)).
-      inversion EE10 as [e2]. inversion EE11 as [e2']. inversion EE12 as [id2]. inversion EE13 as [id2']. 
-      inversion H24. inversion H29. inversion H30. inversion H31. subst.
-      (** FIRST ELEMENTS ARE EQUAL *)
-      pose (F1 := H6 0 (Nat.lt_0_succ n)).
-      pose (F2 := H 0 (Nat.lt_0_succ _) _ _ _ F1). inversion F2. inversion H32. destruct H33.
-      simpl in H34, H33. subst.
-      pose (F3 := H7 0 (Nat.lt_0_succ n)).
-      pose (F4 := H0 0 (Nat.lt_0_succ _) _ _ _ F3). inversion F4. inversion H33. destruct H34.
-      simpl in H35, H34. subst. simpl.
-      (** OTHER ELEMETS *)
-      assert (length ves = n /\ x1 = x /\ x2 = x0 /\ x7 = x8 /\ x9 = x10).
-      {
-        eapply IHkl with (* (eff1 := eff1 ++ e1' ++ e2') *) (ex0 := ex0) (eff5 := eff5) (vl := ves)
-                         (eff6 := eff6) (val0 := val0); auto.
-        * intros. assert (S j < length (ve :: ves)). { simpl. omega. }
-          pose (P3 := H (S j) H36 v2 eff''). simpl mult in H35, P3. rewrite Nat.add_0_r in H35, P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          pose (P4 := P3 _ H35). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. assert (S j < length (ve :: ves)). { simpl. omega. }
-          pose (P3 := H0 (S j) H36 v2 eff''). 
-          simpl mult in H35, P3. rewrite Nat.add_0_r in H35, P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          pose (P4 := P3 _ H35). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. assert (S j < S n). { omega. }
-          pose (P3 := H6 (S j) H35). simpl in P3.
-          simpl mult in P3. rewrite Nat.add_0_r in P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          simpl. rewrite Nat.add_0_r. assumption.
-        * intros. assert (S j < S n). { omega. }
-          pose (P3 := H7 (S j) H35). simpl in P3.
-          simpl mult in *. rewrite Nat.add_0_r in *.
-          rewrite Nat.add_succ_r in *. simpl in *.
-          assumption.
-        * simpl in H9. omega.
-        * rewrite <- last_element_equal, <- last_element_equal,
-                  <- last_element_equal, <- last_element_equal in H13. simpl in H13.
-          simpl. exact H13.
-      }
-      destruct H34. destruct H35. destruct H36. destruct H37. subst. auto.
+      eapply IHeff with (exps := x3) (vals := vs) (vals0 := x0) (eff1 := a)
+                        (i0 := length x0) (ids := x4) (ids0 := x5); auto.
+      + intros. assert (S j < S (Datatypes.length eff)). { simpl. lia. }
+        pose (P := H (S j) H18 v2 eff'' id''). pose (P H17). assumption.
+      + intros. assert (S j < Datatypes.length (x :: x0)). { simpl. lia. }
+        pose (P := H0 (S j) H17). exact P.
+      + intros. apply H1.
+        rewrite (last_element_equal _ _ id), (last_element_equal _ _ eff1) in H16.
+        exact H16.
+      + intuition.
+      + intuition.
+      + intuition.
+      + intuition.
 Qed.
 
-(** Map lists are equal until ith key *)
-Lemma map_lists_equal_until_i_key {env : Environment} {kl : list Expression} :
-  forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (i i0 : nat) 
-     (eff1 : SideEffectList) (eff eff7 : list SideEffectList) (ex0 : Exception) 
-     (eff5 eff2 eff6 : SideEffectList) (val0 : Value) (ex : Exception) (id id1 id1' id2' : nat)
-     (ids ids0 : list nat) ,
+(** Value lists are equal until ith value *)
+Lemma list_equal_until_i_single {env : Environment} {eff : list SideEffectList} :
+  forall (exps : list SingleExpression) (vals vals0 : list Value) (eff6 : list SideEffectList)
+      (eff1 : SideEffectList) (ids ids0 : list nat) (id : nat),
 (forall j : nat,
-     j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 (2 * j), nth j kl ErrorExp, nth_def eff eff1 [] (2 * j) | -e> | id'', v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ nth_def eff eff1 [] (S (2 * j)) = eff'' /\
-     nth_def ids id 0 (S (2 * j)) = id'')
+    j < Datatypes.length vals ->
+    forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
+    | env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j | -s> | id'', v2, eff'' | ->
+    inl [nth j vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
 ->
 (forall j : nat,
+     j < Datatypes.length vals0 ->
+     | env, nth_def ids0 id 0 j, nth j exps ErrorExp, nth_def eff6 eff1 [] j | -s> 
+     | nth_def ids0 id 0 (S j), inl [nth j vals0 ErrorValue],
+     nth_def eff6 eff1 [] (S j) |)
+->
+Datatypes.length vals = Datatypes.length vals0
+->
+Datatypes.length eff = Datatypes.length vals
+->
+Datatypes.length eff6 = Datatypes.length vals0
+->
+Datatypes.length vals0 < Datatypes.length exps
+->
+length ids = length vals
+->
+length ids0 = length vals0
+->
+eff = eff6 /\ vals = vals0 /\ ids = ids0.
+Proof.
+  induction eff.
+  * intros. inversion H2. apply eq_sym, length_zero_iff_nil in H8. subst. simpl in H1. 
+    apply eq_sym, length_zero_iff_nil in H1. subst. simpl in H3. apply length_zero_iff_nil in H3. 
+    apply length_zero_iff_nil in H5. apply length_zero_iff_nil in H6. subst. auto.
+  * intros. simpl in H2. rewrite <- H2 in H1. rewrite <- H1 in H3. pose (NE := nat_lt_zero _ _ H4). inversion NE.
+    (* single_unfold_list H2. *)
+    pose (EE1 := element_exist (length eff) vals H2).
+    pose (EE2 := element_exist (length eff) vals0 H1).
+    pose (EE3 := element_exist (length eff) eff6 (eq_sym H3)).
+    pose (EE4 := element_exist x exps (eq_sym H7)).
+    inversion EE1 as [v]. inversion EE2 as [v']. inversion EE3 as [fe]. inversion EE4 as [e'].
+    inversion H8. inversion H9. inversion H10. inversion H11. subst.
+    pose (EE5 := element_exist _ _ (eq_sym H5)).
+    pose (EE6 := element_exist _ _ (eq_sym H6)).
+    inversion EE5 as [id']. inversion EE6 as [id''].
+    inversion H12. inversion H13. subst.
+    assert (0 < Datatypes.length (v' :: x1)). { simpl. lia. }
+    pose (P := H0 0 H14).
+    assert (0 < Datatypes.length (v :: x0)). { simpl. lia. }
+    pose (P1 := H 0 H15 (inl [nth 0 (v' :: x1) ErrorValue]) (nth_def (fe :: x2) eff1 [] 1) _ P).
+    inversion P1. destruct H17. simpl in H18. inversion H16. simpl in H17. subst.
+    
+    assert (eff = x2 /\ x0 = x1 /\ x4 = x5).
+    {
+      apply IHeff with (exps := x3) (vals := x0) (vals0 := x1) (eff1 := fe) (id := id''); auto.
+      + intros. assert (S j < S (Datatypes.length x0)). { simpl. lia. } pose (P2 := H (S j) H19 v2 eff''). 
+        simpl in P2. pose (P2 _ H18). assumption.
+      + intros. assert (S j < Datatypes.length (v' :: x1)). { simpl. lia. }
+        pose (P3 := H0 (S j) H18). simpl in P3. assumption.
+      + inversion H2. inversion H3. inversion H1. auto.
+      + inversion H2. inversion H3. inversion H1. auto.
+      + intuition.
+    }
+    inversion H17. inversion H19. subst. auto.
+Qed.
+
+(** Slightly different hypotheses for i first element concatn equality *)
+Lemma con_n_equality_rev_single {env : Environment} {eff : list SideEffectList} : 
+forall (exps : list SingleExpression) (vals vals0 : list Value) (eff1 : SideEffectList) 
+   (eff6 : list SideEffectList) (i i0 : nat) (id : nat) (ids ids0 : list nat) id' ex0 eff4,
+(forall j : nat,
+    j < i ->
+    forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
+    | env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j | -s> | id'', v2, eff'' | ->
+    inl [nth j vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
+->
+(forall j : nat,
+     j < i0 ->
+     | env, nth_def ids0 id 0 j, nth j exps ErrorExp, nth_def eff6 eff1 [] j | -s> 
+     | nth_def ids0 id 0 (S j), inl [nth j vals0 ErrorValue],
+     nth_def eff6 eff1 [] (S j) |)
+->
+Datatypes.length eff = i ->
+i < Datatypes.length exps ->
+Datatypes.length vals = i ->
+Datatypes.length vals0 = i0 ->
+i0 < Datatypes.length exps ->
+Datatypes.length eff6 = i0 ->
+length ids = i ->
+length ids0 = i0 ->
+i > i0 ->
+(| env, last ids0 id, nth i0 exps ErrorExp, last eff6 eff1 | -s> | id', 
+     inr ex0,eff4 |)
+->
+False.
+Proof.
+induction eff.
+  * intros. simpl in H1. subst. inversion H9.
+  * intros. simpl in H1. rewrite <- H1 in H3.
+    pose (EE1 := element_exist (length eff) vals (eq_sym H3)).
+    inversion EE1 as [v]. inversion H11 as [vs]. destruct eff6.
+    - subst. apply eq_sym, length_zero_iff_nil in H6. subst. apply length_zero_iff_nil in H8.
+      subst.
+      simpl in H10. pose (P := H 0 (Nat.lt_0_succ _) _ _ _ H10). inversion P. congruence.
+    - subst.
+      assert (Datatypes.length ids0 = Datatypes.length vals0) as Helper. { auto. }
+      pose (EE2 := element_exist (length eff6) vals0 H6). inversion EE2. inversion H1.
+      pose (NE := nat_lt_zero _ _ H2). inversion NE.
+      pose (EE3 := element_exist x1 exps (eq_sym H12)). inversion EE3.
+      inversion H13. subst.
+      pose (EE4 := element_exist _ _ (eq_sym H7)).
+      pose (EE5 := element_exist _ _ (eq_sym H8)).
+      inversion EE4 as [id0']. inversion EE5 as [id0'']. inversion H4. inversion H14. subst.
+      assert (s = a /\ id0' = id0''). {
+        subst.
+        assert (0 < Datatypes.length (x :: x0)). {  simpl. lia. }
+        pose (P := H0 0 H15).
+        assert (0 < S (Datatypes.length eff)). {  simpl. lia. }
+        pose (P1 := H 0 H16 (inl [nth 0 (x :: x0) ErrorValue]) (nth_def (s :: eff6) eff1 [] 1) _ P).
+        destruct P1. destruct H18. simpl in H19, H18. auto.
+      }
+      destruct H15. subst.
+      eapply IHeff with (exps := x3) (vals := vs) (vals0 := x0) (eff1 := a) 
+                       (i0 := length eff6) (i := length eff) (ids := x4) (ids0 := x5); auto.
+      + intros. assert (S j < S (Datatypes.length eff)). { simpl. lia. }
+        pose (P := H (S j) H17 v2 eff''). simpl in P.
+        pose (P1 := P _ H16). assumption.
+      + intros. inversion H6. assert (S j < Datatypes.length (x :: x0)). { simpl. lia. }
+        pose (P := H0 (S j) H16). assumption.
+      + intuition.
+      + inversion H6. auto.
+      + rewrite <- H6 in H5. simpl in H5. lia.
+      + rewrite <- H6 in Helper. auto.
+      + simpl in *. rewrite <- H6 in H9. lia.
+      + rewrite <- last_element_equal, <- last_element_equal in H10. simpl in H10. 
+        inversion H6. rewrite H16. exact H10.
+Qed.
+
+(** Based on determinsim, using lists with exceptions, these are equal *)
+Lemma exception_equality_single {env : Environment} {exps : list SingleExpression} (vals vals0 : list Value) 
+   (ex : Exception) (eff1 : SideEffectList) (eff eff6 : list SideEffectList) (i i0 : nat) 
+   (eff3 : SideEffectList) (ex0 : Exception) (eff4 : SideEffectList) (ids ids0 : list nat)
+   (id id' id'' : nat) :
+(forall j : nat,
      j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 (S (2 * j)), nth j vl ErrorExp, nth_def eff eff1 [] (S (2 * j)) | -e>
-     | id'', v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ nth_def eff eff1 [] (S (S (2 * j))) = eff'' /\
-     nth_def ids id 0 (S (S (2 * j))) = id'')
+     forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
+     | env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j | -s> | id'', v2, eff'' | ->
+     inl [nth j vals ErrorValue] = v2 /\ nth_def eff eff1 [] (S j) = eff'' /\ nth_def ids id 0 (S j) = id'')
 ->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-         | env, last ids id, nth i kl ErrorExp, last eff eff1 | -e> | id'', v2, eff'' | ->
-         inr ex = v2 /\ eff2 = eff'' /\ id1 = id'')
+| env, last ids0 id, nth i0 exps ErrorExp, last eff6 eff1 | -s>
+| id'', inr ex0, eff4 |
 ->
-Datatypes.length kl = Datatypes.length vl ->
-Datatypes.length vvals = i ->
-Datatypes.length kvals = i ->
-i <= Datatypes.length kl ->
-Datatypes.length eff = (i * 2)%nat ->
-length ids = (i*2)%nat ->
+(forall (v2 : ValueSequence + Exception) (eff'' : SideEffectList) (id'' : nat),
+        | env, last ids id, nth i exps ErrorExp, last eff eff1 | -s>
+        | id'', v2, eff'' | -> inr ex = v2 /\ eff3 = eff'' /\ id' = id'')
+->
 (forall j : nat,
       j < i0 ->
-      | env, nth_def ids0 id 0 (2 * j), nth j kl ErrorExp, nth_def eff7 eff1 [] (2 * j) | -e>
-      | nth_def ids0 id 0 (S (2 * j)), inl (nth j kvals0 ErrorValue),
-      nth_def eff7 eff1 [] (S (2 * j)) |)
+      | env, nth_def ids0 id 0 j, nth j exps ErrorExp, nth_def eff6 eff1 [] j | -s>
+      | nth_def ids0 id 0 (S j), inl [nth j vals0 ErrorValue],
+      nth_def eff6 eff1 [] (S j) |)
 ->
-(forall j : nat,
-  j < i0 ->
-  | env, nth_def ids0 id 0 (S (2 * j)), nth j vl ErrorExp, nth_def eff7 eff1 [] (S (2 * j)) | -e>
-  | nth_def ids0 id 0 (S (S (2 * j))), inl (nth j vvals0 ErrorValue), nth_def eff7 eff1 [] (S (S (2 * j))) |)
+Datatypes.length vals = i ->
+ i < Datatypes.length exps ->
+ Datatypes.length eff = i ->
+ Datatypes.length vals0 = i0 ->
+ i0 < Datatypes.length exps ->
+ Datatypes.length eff6 = i0 ->
+ length ids = i ->
+ length ids0 = i0
 ->
-Datatypes.length vvals0 = i0 ->
-Datatypes.length kvals0 = i0 ->
-i0 <= Datatypes.length kl ->
-Datatypes.length eff7 = (i0 * 2)%nat ->
-length ids0 = (i0*2)%nat ->
-(| env, last ids0 id, nth i0 kl ErrorExp, last eff7 eff1 | -e>
-| id1', inr ex0, eff5 |
-\/
-(| env, last ids0 id, nth i0 kl ErrorExp, last eff7 eff1 | -e>
-| id1', inl val0,
-       eff5 | /\
-| env, id1', nth i0 vl ErrorExp, eff5 | -e> | 
-      id2', inr ex0, eff6 |)
-)
-->
-i = i0 /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7 /\ ids = ids0.
+i = i0 /\ eff = eff6 /\ vals = vals0 /\ ids = ids0.
 Proof.
-  induction kl.
-  * intros. inversion H2. apply eq_sym, length_zero_iff_nil in H17. subst.
-    inversion H12. apply length_zero_iff_nil in H10. subst.
-    inversion H5. apply length_zero_iff_nil in H10. subst.
-    inversion H6. apply length_zero_iff_nil in H10. subst.
-    inversion H7. apply length_zero_iff_nil in H10. subst.
-    inversion H11. apply length_zero_iff_nil in H10. subst.
-    inversion H4. apply length_zero_iff_nil in H10. subst. 
-    inversion H13. apply length_zero_iff_nil in H10. subst.
-    inversion H14. apply length_zero_iff_nil in H10. subst. 
-    auto.
-  * intros. inversion H2.
-    pose (EE1 := element_exist (length kl) vl H17).
-    inversion EE1 as [ve]. inversion H16 as [ves]. subst.
-    case_eq (length vvals); case_eq (length vvals0).
+  intros. destruct (Compare_dec.le_gt_dec i i0).
+  * case_eq (Lt.le_lt_or_eq i i0 l).
     - intros.
-      apply length_zero_iff_nil in H3.
-      apply length_zero_iff_nil in H10. subst.
-      apply length_zero_iff_nil in H4.
-      apply length_zero_iff_nil in H6.
-      apply length_zero_iff_nil in H7.
-      apply length_zero_iff_nil in H11.
-      apply length_zero_iff_nil in H13.
-      apply length_zero_iff_nil in H14.
-      subst. auto.
-    - intros. rewrite H3, H10 in *.
-      apply length_zero_iff_nil in H6.
-      pose (EE2 := element_exist _ eff7 (eq_sym H13)).
-      inversion EE2. inversion H18.
-      subst. inversion H13. 
-      pose (EE3 := element_exist _ x0 (eq_sym H19)).
-      inversion EE3. inversion H6.
-      apply length_zero_iff_nil in H7. subst.
-      pose (P1 := H8 0 (Nat.lt_0_succ n)). pose (P2 := H9 0 (Nat.lt_0_succ n)). simpl in P1, P2.
-      pose (P3 := H1 _ _ _ P1). inversion P3.
-      inversion H7.
-    - intros. rewrite H3, H10 in *.
-      inversion H15.
-      (** KEY EXCEPTION *)
-        + pose (P2 := H 0 (Nat.lt_0_succ n) (inr ex0) (eff5)).
-          apply length_zero_iff_nil in H14. subst.
-          apply length_zero_iff_nil in H13. subst.
-          simpl in P2, H18.
-          pose (P3 := P2 _ H18). inversion P3. inversion H13.
-      (** VALUE EXCEPTION *)
-        + destruct H18.
-          pose (P2 := H 0 (Nat.lt_0_succ n) (inl val0) (eff5)).
-          apply length_zero_iff_nil in H14. subst.
-          apply length_zero_iff_nil in H13. subst.
-          simpl in P2, H18.
-          pose (P3 := P2 _ H18).
-          inversion P3.
-          pose (P4 := H0 0 (Nat.lt_0_succ n) (inr ex0) (eff6)). simpl in P4.
-          destruct H14. subst.
-          pose (P5 := P4 _ H19).
-          inversion P5. inversion H14.
-
-    - intros. rewrite H3, H10 in *.
-      pose (EE2 := element_exist n kvals0 (eq_sym H11)).
-      pose (EE3 := element_exist n vvals0 (eq_sym H3)).
-      pose (EE4 := element_exist n0 kvals (eq_sym H4)).
-      pose (EE5 := element_exist n0 vvals (eq_sym H10)).
-      pose (EE6 := element_exist _ eff (eq_sym H6)).
-      pose (EE7 := element_exist _ eff7 (eq_sym H13)).
-      pose (EE8 := element_exist _ _ (eq_sym H7)).
-      pose (EE9 := element_exist _ _ (eq_sym H14)).
-      inversion EE2 as [kv']. inversion EE3 as [vv']. inversion EE4 as [kv]. 
-      inversion EE5 as [vv]. inversion EE6 as [e1]. inversion EE7 as [e1'].
-      inversion EE8 as [id01]. inversion EE9 as [id01'].
-      inversion H18. inversion H19. inversion H20. inversion H21.
-      inversion H22. inversion H23. inversion H24. inversion H25. subst.
-      inversion H6. inversion H13. inversion H7. inversion H14.
-      pose (EE10 := element_exist _ x3 (eq_sym H27)).
-      pose (EE11 := element_exist _ x4 (eq_sym H28)).
-      pose (EE12 := element_exist _ x5 (eq_sym H29)).
-      pose (EE13 := element_exist _ x6 (eq_sym H30)).
-      inversion EE10 as [e2]. inversion EE11 as [e2'].
-      inversion EE12 as [id02]. inversion EE13 as [id02'].
-      inversion H26. inversion H31. inversion H32. inversion H33. subst.
-      clear EE10. clear EE11. clear EE12. clear EE13.
-      clear EE6. clear EE7. clear EE8. clear EE9.
-      (** FIRST ELEMENTS ARE EQUAL *)
-      pose (F1 := H8 0 (Nat.lt_0_succ n)).
-      pose (F2 := H 0 (Nat.lt_0_succ n0) _ _ _ F1). inversion F2. inversion H34.
-      destruct H35. simpl in H36.
-      simpl in H35. subst.
-      pose (F3 := H9 0 (Nat.lt_0_succ n)).
-      pose (F4 := H0 0 (Nat.lt_0_succ n0) _ _ _ F3). inversion F4. inversion H35.
-      destruct H36. simpl in H37.
-      simpl in H36. subst.
-      (** OTHER ELEMETS *)
-      assert (n0 = n /\ x1 = x /\ x2 = x0 /\ x7 = x8 /\ x9 = x10).
-      {
-        eapply IHkl with (* (eff1 := eff1 ++ e1' ++ e2') *) (ex0 := ex0) (eff5 := eff5) (eff2 := eff2) 
-                        (ex := ex) (vl := ves) (eff6 := eff6) (val0 := val0); auto.
-        * intros. assert (S j < S n0). { omega. } pose (P3 := H (S j) H38 v2 eff'').
-          simpl mult in H37, P3. rewrite Nat.add_0_r in H37, P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          pose (P4 := P3 _ H37). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. assert (S j < S n0). { omega. }
-          pose (P3 := H0 (S j) H38 v2 eff''). simpl in P3.
-          simpl mult in H37, P3. rewrite Nat.add_0_r in H37, P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          pose (P4 := P3 _ H37). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. pose (P3 := H1 v2 eff'').
-          rewrite <- last_element_equal, <- last_element_equal,
-                  <- last_element_equal, <- last_element_equal in P3. simpl in P3.
-          simpl.
-          simpl mult in P3.
-          apply (P3 _ H36).
-        * simpl in H5. omega.
-        * intros. assert (S j < S n). { omega. }
-          pose (P3 := H8 (S j) H37). simpl mult in P3. rewrite Nat.add_0_r in P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          simpl. rewrite Nat.add_0_r. assumption.
-        * intros. assert (S j < S n). { omega. }
-          pose (P3 := H9 (S j) H37).
-          simpl mult in P3. rewrite Nat.add_0_r in P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          simpl. rewrite Nat.add_0_r. assumption.
-        * simpl in H11. omega.
-        * rewrite <- last_element_equal, <- last_element_equal,
-                  <- last_element_equal, <- last_element_equal in H15.
-          exact H15.
-      }
-      destruct H36. destruct H37. destruct H38. destruct H39. subst. auto.
-Qed.
-
-(** Map lists are equal until ith value *)
-Lemma map_lists_equal_until_i_val {env : Environment} {kl : list Expression} : 
-   forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (i i0 : nat) 
-   (eff1 : SideEffectList) (eff eff7 : list SideEffectList) (ex0 : Exception) 
-   (eff5 eff2 eff4 eff6 : SideEffectList) (val val0 : Value) (ex : Exception)
-   (id id1 id2 id1' id2' : nat) (ids ids0 : list nat),
-(forall j : nat,
-     j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 (2*j), nth j kl ErrorExp, nth_def eff eff1 [] (2 * j) | -e> | id'', v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ nth_def eff eff1 [] (S (2 * j)) = eff'' /\
-     nth_def ids id 0 (S (2*j)) = id'')
-->
-(forall j : nat,
-     j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 (S (2*j)), nth j vl ErrorExp, nth_def eff eff1 [] (S (2 * j)) | -e> | id'', v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ nth_def eff eff1 [] (S (S (2 * j))) = eff'' /\
-     nth_def ids id 0 (S (S (2*j))) = id'')
-->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-         | env, last ids id, nth i kl ErrorExp, last eff eff1 | -e> | id'', v2, eff'' | ->
-         inl val = v2 /\ eff2 = eff'' /\ id1 = id'')
-->
-(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-         | env, id1, nth i vl ErrorExp, eff2 | -e> | id'', v2, eff'' | ->
-         inr ex = v2 /\ eff4 = eff'' /\ id2 = id'')
-->
-Datatypes.length kl = Datatypes.length vl ->
-Datatypes.length vvals = i ->
-Datatypes.length kvals = i ->
-i <= Datatypes.length kl ->
-Datatypes.length eff = (i * 2)%nat ->
-Datatypes.length ids = (i * 2)%nat ->
-(forall j : nat,
-      j < i0 ->
-      | env, nth_def ids0 id 0 (2*j), nth j kl ErrorExp, nth_def eff7 eff1 [] (2 * j) | -e>
-      | nth_def ids0 id 0 (S (2*j)), inl (nth j kvals0 ErrorValue),
-      nth_def eff7 eff1 [] (S (2 * j)) |)
-->
-(forall j : nat,
-  j < i0 ->
-  | env, nth_def ids0 id 0 (S (2*j)), nth j vl ErrorExp, nth_def eff7 eff1 [] (S (2 * j)) | -e>
-  | nth_def ids0 id 0 (S (S (2*j))), inl (nth j vvals0 ErrorValue), nth_def eff7 eff1 [] (S (S (2 * j))) |)
-->
-Datatypes.length vvals0 = i0 ->
-Datatypes.length kvals0 = i0->
-i0 <= Datatypes.length kl ->
-Datatypes.length eff7 = (i0 * 2)%nat ->
-Datatypes.length ids0 = (i0 * 2)%nat ->
-(| env, last ids0 id, nth i0 kl ErrorExp, last eff7 eff1 | -e>
-| id1', inr ex0, eff5 |
-\/
-(| env, last ids0 id, nth i0 kl ErrorExp, last eff7 eff1 | -e> | id1', inl val0,
-      eff5 | /\
-| env, id1', nth i0 vl ErrorExp, eff5 | -e> | 
-      id2', inr ex0, eff6 |)
-)
-->
-i = i0 /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7 /\ ids = ids0.
-Proof.
-  induction kl.
-  * intros. inversion H3.
-    apply eq_sym, length_zero_iff_nil in H18. subst.
-    inversion H13. apply length_zero_iff_nil in H11. subst.
-    inversion H6. apply length_zero_iff_nil in H11. subst.
-    inversion H5. apply length_zero_iff_nil in H11. subst.
-    inversion H7. apply length_zero_iff_nil in H11. subst.
-    inversion H8. apply length_zero_iff_nil in H11. subst.
-    inversion H14. apply length_zero_iff_nil in H11. subst. 
-    inversion H15. apply length_zero_iff_nil in H11. subst.
-    inversion H12. apply length_zero_iff_nil in H11. subst.
-    auto.
-  * intros. inversion H3.
-    pose (EE1 := element_exist (length kl) vl H18).
-    inversion EE1 as [ve]. inversion H17 as [ves]. subst.
-    case_eq (length vvals); case_eq (length vvals0).
-    - intros.
-      apply length_zero_iff_nil in H4.
-      apply length_zero_iff_nil in H11. subst.
-      apply length_zero_iff_nil in H5.
-      apply length_zero_iff_nil in H7.
-      apply length_zero_iff_nil in H8.
-      apply length_zero_iff_nil in H12.
-      apply length_zero_iff_nil in H14.
-      apply length_zero_iff_nil in H15.
-      subst. auto.
-    - intros. rewrite H4, H11 in *.
-      apply length_zero_iff_nil in H7.
-      pose (EE2 := element_exist _ eff7 (eq_sym H14)).
-      inversion EE2. inversion H19. subst.
-      inversion H14. 
-      pose (EE3 := element_exist _ x0 (eq_sym H20)). 
-      inversion EE3. inversion H7.
-      subst.
-      pose (P1 := H9 0 (Nat.lt_0_succ n)).
-      pose (P2 := H10 0 (Nat.lt_0_succ n)). simpl in P1, P2.
-      apply length_zero_iff_nil in H8. subst.
-      pose (P3 := H1 _ _ _ P1). inversion P3.
-      inversion H8. destruct H21. subst.
-      pose (P4 := H2 _ _ _ P2). inversion P4. inversion H21.
-    - intros. rewrite H4, H11 in *.
-      inversion H16.
-      (** KEY EXCEPTION *)
-        + pose (P2 := H 0 (Nat.lt_0_succ n) (inr ex0) (eff5)).
-          apply length_zero_iff_nil in H15. subst.
-          apply length_zero_iff_nil in H14. subst.
-          simpl in P2, H19.
-          pose (P3 := P2 _ H19). inversion P3. inversion H14.
-      (** VALUE EXCEPTION *)
-        + pose (P2 := H 0 (Nat.lt_0_succ n) (inl val0) (eff5)).
-          apply length_zero_iff_nil in H15. subst.
-          apply length_zero_iff_nil in H14. subst.
-          destruct H19.
-          pose (P3 := P2 _ H14).
-          inversion P3. destruct H20. subst.
-          pose (P4 := H0 0 (Nat.lt_0_succ n) (inr ex0) (eff6)).
-          simpl in P4.
-          pose (P5 := P4 _ H15).
-          inversion P5. inversion H20.
-
-    - intros. rewrite H4, H11 in *.
-      pose (EE2 := element_exist n kvals0 (eq_sym H12)).
-      pose (EE3 := element_exist n vvals0 (eq_sym H4)).
-      pose (EE4 := element_exist n0 kvals (eq_sym H5)).
-      pose (EE5 := element_exist n0 vvals (eq_sym H11)).
-      pose (EE6 := element_exist _ eff (eq_sym H7)).
-      pose (EE7 := element_exist _ eff7 (eq_sym H14)).
-      pose (EE8 := element_exist _ _ (eq_sym H8)).
-      pose (EE9 := element_exist _ _ (eq_sym H15)).
-      inversion EE2 as [kv']. inversion EE3 as [vv']. inversion EE4 as [kv]. 
-      inversion EE5 as [vv]. inversion EE6 as [e1]. inversion EE7 as [e1'].
-      inversion EE8 as [id01]. inversion EE9 as [id01'].
-      inversion H19. inversion H20. inversion H21. inversion H22.
-      inversion H23. inversion H24. inversion H25. inversion H26. subst.
-      inversion H7. inversion H14. inversion H8. inversion H15.
-      pose (EE10 := element_exist _ x3 (eq_sym H28)).
-      pose (EE11 := element_exist _ x4 (eq_sym H29)).
-      pose (EE12 := element_exist _ x5 (eq_sym H30)).
-      pose (EE13 := element_exist _ x6 (eq_sym H31)).
-      inversion EE10 as [e2]. inversion EE11 as [e2'].
-      inversion EE12 as [id02]. inversion EE13 as [id02'].
-      inversion H27. inversion H32. inversion H33. inversion H34. subst.
-      clear EE10. clear EE11. clear EE12. clear EE13.
-      clear EE6. clear EE7. clear EE8. clear EE9.
-      (** FIRST ELEMENTS ARE EQUAL *)
-      pose (F1 := H9 0 (Nat.lt_0_succ n)).
-      pose (F2 := H 0 (Nat.lt_0_succ n0) _ _ _ F1). inversion F2. inversion H35.
-      destruct H36. simpl in H37, H36.
-      subst.
-      pose (F3 := H10 0 (Nat.lt_0_succ n)).
-      pose (F4 := H0 0 (Nat.lt_0_succ n0) _ _ _ F3). inversion F4. 
-      inversion H36. destruct H37. simpl in H38, H37. subst.
-      (** OTHER ELEMETS *)
-      assert (n0 = n /\ x1 = x /\ x2 = x0 /\ x7 = x8 /\ x9 = x10).
-      {
-        eapply IHkl with (* (eff1 := eff1 ++ e1' ++ e2') *) (ex0 := ex0) (eff5 := eff5)
-             (eff4 := eff4) (eff2 := eff2) (val := val) (ex := ex) (vl := ves) (eff6 := eff6) (val0 := val0); auto.
-        * intros. assert (S j < S n0). { omega. } pose (P3 := H (S j) H39 v2 eff''). simpl in P3.
-          simpl mult in H38, P3. rewrite Nat.add_0_r in H38, P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          pose (P4 := P3 _ H38). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. assert (S j < S n0). { omega. } pose (P3 := H0 (S j) H39 v2 eff''). simpl in P3.
-          simpl mult in H38, P3. rewrite Nat.add_0_r in H38, P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          pose (P4 := P3 _ H38). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. pose (P3 := H1 v2 eff'').
-          rewrite <- last_element_equal, <- last_element_equal,
-                  <- last_element_equal, <- last_element_equal in P3. simpl in P3.
-          apply (P3 _ H37).
-        * intros. pose (P3 := H2 v2 eff''). simpl in P3.
-          simpl in H37.
-          apply (P3 _ H37).
-        * simpl in H6. omega.
-        * intros. assert (S j < S n). { omega. } pose (P3 := H9 (S j) H38). simpl in P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          simpl. rewrite Nat.add_0_r in *. assumption.
-        * intros. assert (S j < S n). { omega. } pose (P3 := H10 (S j) H38). simpl in P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          simpl. rewrite Nat.add_0_r in *. assumption.
-        * simpl in H12. omega.
-        * rewrite <- last_element_equal, <- last_element_equal,
-                  <- last_element_equal, <- last_element_equal in H16. simpl in H16. 
-          exact H16.
-      }
-      destruct H37. destruct H38. destruct H39. destruct H40. subst. auto.
-Qed.
-
-(** Map generalised until i-th element equality *)
-Lemma map_lists_equal_until_i_key_or_val {env : Environment} {kl : list Expression} : 
-forall {vl : list Expression} (kvals vvals kvals0 vvals0 : list Value) (i : nat) (eff1 : SideEffectList) 
-      (eff eff7 : list SideEffectList) (eff2 eff4 : SideEffectList) (val : Value) (ex : Exception)
-      (ids ids0 : list nat) (id id1 id2: nat),
-(forall j : nat,
-     j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 (2*j), nth j kl ErrorExp, nth_def eff eff1 [] (2 * j) | -e>
-     | id'', v2, eff'' | ->
-     inl (nth j kvals ErrorValue) = v2 /\ nth_def eff eff1 [] (S (2 * j)) = eff'' /\
-     nth_def ids id 0 (S (2*j)) = id'')
-->
-(forall j : nat,
-     j < i ->
-     forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-     | env, nth_def ids id 0 (S (2*j)), nth j vl ErrorExp, nth_def eff eff1 [] (S (2 * j)) | -e>
-     | id'', v2, eff'' | ->
-     inl (nth j vvals ErrorValue) = v2 /\ nth_def eff eff1 [] (S (S (2 * j))) = eff'' /\
-     nth_def ids id 0 (S (S (2*j))) = id'')
-->
-(
-(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-         | env, last ids id, nth i kl ErrorExp, last eff eff1 | -e>
-         | id'', v2, eff'' | ->
-         inr ex = v2 /\ eff2 = eff'' /\ id1 = id'')
-\/
-(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-         | env, last ids id, nth i kl ErrorExp, last eff eff1 | -e>
-         | id'', v2, eff'' | ->
-         inl val = v2 /\ eff2 = eff'' /\ id1 = id'')
-/\
-(forall (v2 : Value + Exception) (eff'' : SideEffectList) (id'' : nat),
-         | env, id1, nth i vl ErrorExp, eff2 | -e>
-         | id'', v2, eff'' | ->
-         inr ex = v2 /\ eff4 = eff'' /\ id2 = id''))
-->
-Datatypes.length kl = Datatypes.length vl ->
-Datatypes.length vvals = i ->
-Datatypes.length kvals = i ->
-i <= Datatypes.length kl ->
-Datatypes.length eff = (i * 2)%nat ->
-Datatypes.length ids = (i * 2)%nat ->
-(forall j : nat,
-      j < length vl ->
-      | env, nth_def ids0 id 0 (2*j), nth j kl ErrorExp, nth_def eff7 eff1 [] (2 * j) | -e>
-      | nth_def ids0 id 0 (S (2*j)), inl (nth j kvals0 ErrorValue),
-      nth_def eff7 eff1 [] (S (2 * j)) |)
-->
-(forall j : nat,
-  j < length vl ->
-  | env, nth_def ids0 id 0 (S (2*j)), nth j vl ErrorExp, nth_def eff7 eff1 [] (S (2 * j)) | -e>
-  | nth_def ids0 id 0 (S (S (2*j))), inl (nth j vvals0 ErrorValue), nth_def eff7 eff1 [] (S (S (2 * j))) |)
-->
-length kl = Datatypes.length vvals0 ->
-length kl = Datatypes.length kvals0 ->
-Datatypes.length eff7 = (length kl * 2)%nat ->
-Datatypes.length ids0 = (length kl * 2)%nat
-->
-i = length vl /\ kvals = kvals0 /\ vvals = vvals0 /\ eff = eff7 /\ ids = ids0.
-Proof.
-  induction kl.
-  * intros. simpl in *. subst. inversion H5.
-    apply eq_sym, length_zero_iff_nil in H2.
-    apply eq_sym, length_zero_iff_nil in H10.
-    apply eq_sym, length_zero_iff_nil in H11.
-    subst.
-    apply length_zero_iff_nil in H12.
-    apply length_zero_iff_nil in H13.
-    apply length_zero_iff_nil in H14.
-    subst.
-    apply length_zero_iff_nil in H6.
-    apply length_zero_iff_nil in H7.
-    apply length_zero_iff_nil in H4.
-    subst. auto.
-  * intros. inversion H2.
-    pose (EE1 := element_exist (length kl) vl H15).
-    inversion EE1 as [ve]. inversion H14 as [ves]. subst.
-    case_eq (length vvals).
-    - intros. apply length_zero_iff_nil in H3. subst. simpl length in *.
-      apply length_zero_iff_nil in H6.
-      apply length_zero_iff_nil in H7.
-      apply length_zero_iff_nil in H4. subst.
-      pose (E1 := H8 0 (Nat.lt_0_succ (length ves))).
-      pose (E2 := H9 0 (Nat.lt_0_succ (length ves))).
-    (** CASE SEPARATION, KEY EXCEPTION OR VALUE EXCEPTION HAPPENED *)
-      inversion H1.
-      + pose (P1 := H3 _ _ _ E1). inversion P1. inversion H4.
-      + inversion H3. pose (P1 := H4 _ _ _ E1). inversion P1. inversion H7. destruct H16.
-        rewrite <- H16 in E2. subst.
-        pose (P2 := H6 _ _ _ E2). inversion P2. inversion H16.
-
-    - intros. rewrite H3 in *.
-      pose (EE2 := element_exist _ kvals0 H11).
-      pose (EE3 := element_exist _ vvals0 H10).
-      pose (EE4 := element_exist _ kvals (eq_sym H4)).
-      pose (EE5 := element_exist _ vvals (eq_sym H3)).
-      pose (EE6 := element_exist _ eff (eq_sym H6)).
-      pose (EE7 := element_exist _ eff7 (eq_sym H12)).
-      pose (EE8 := element_exist _ _ (eq_sym H7)).
-      pose (EE9 := element_exist _ _ (eq_sym H13)).
-      inversion EE2 as [kv']. inversion EE3 as [vv']. inversion EE4 as [kv]. 
-      inversion EE5 as [vv]. inversion EE6 as [e1]. inversion EE7 as [e1']. 
-      inversion EE8 as [id01]. inversion EE9 as [id01'].
-      inversion H16. inversion H17. inversion H18. inversion H19. 
-      inversion H20. inversion H21. inversion H22. inversion H23. subst.
-
-      inversion H6. inversion H12. inversion H7. inversion H13.
-      pose (EE10 := element_exist _ _ (eq_sym H25)).
-      pose (EE11 := element_exist _ _ (eq_sym H26)).
-      pose (EE12 := element_exist _ _ (eq_sym H27)).
-      pose (EE13 := element_exist _ _ (eq_sym H28)).
-      inversion EE10 as [e2]. inversion EE11 as [e2']. inversion EE12 as [id02].
-      inversion EE13 as [id02'].
-      inversion H24. inversion H29. inversion H30. inversion H31. subst.
-      (** FIRST ELEMENTS ARE EQUAL *)
-      pose (F1 := H8 0 (Nat.lt_0_succ (length ves))).
-      pose (F2 := H 0 (Nat.lt_0_succ n) _ _ _ F1). inversion F2. inversion H32.
-      destruct H33. simpl in H34, H33. subst.
-      pose (F3 := H9 0 (Nat.lt_0_succ (length ves))).
-      pose (F4 := H0 0 (Nat.lt_0_succ n) _ _ _ F3). inversion F4. inversion H33.
-      destruct H34. simpl in H35, H34. subst.
-      clear EE10. clear EE11. clear EE12. clear EE13.
-      clear EE6. clear EE7. clear EE8. clear EE9. clear EE2. clear EE3.
-      (** OTHER ELEMETS *)
-      assert (n = length ves /\ x1 = x /\ x2 = x0 /\ x7 = x8 /\ x9 = x10).
-      {
-        eapply IHkl with (* (eff1 := eff1 ++ e1' ++ e2') *) (eff4 := eff4) (eff2 := eff2)
-                (val := val) (ex := ex) (vl := ves) (id := id02') (id1 := id1) (id2 := id2); auto; clear IHkl.
-        * intros. assert (S j < S n). { omega. }
-          pose (P3 := H (S j) H36 v2 eff'').
-          simpl mult in H35, P3. rewrite Nat.add_0_r in H35, P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          pose (P4 := P3 _ H35). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. assert (S j < S n). { omega. }
-          pose (P3 := H0 (S j) H36 v2 eff''). simpl in P3.
-          simpl mult in H35, P3. rewrite Nat.add_0_r in H35, P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          pose (P4 := P3 _ H35). simpl. rewrite Nat.add_0_r. assumption.
-        * intros. destruct H1 as [Def| Def'].
-          - left. intros. simpl mult in Def, H1. simpl mult.
-            apply Def.
-            repeat (rewrite <- last_element_equal). simpl. assumption.
-          - right. simpl mult in Def'.
-            rewrite <- last_element_equal, <- last_element_equal, 
-                  <- last_element_equal, <- last_element_equal in Def'. simpl in Def'. inversion Def'.
-            split.
-            + intros. simpl mult. apply H1. simpl mult in H35.
-              assumption.
-            + intros. apply H34. simpl mult in H35. assumption.
-
-        * simpl in H5. omega.
-        * intros. assert (S j < S (length ves)). { omega. } pose (P3 := H8 (S j) H35).
-          simpl in P3.
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          simpl. rewrite Nat.add_0_r in *. assumption.
-        * intros. assert (S j < S (length ves)). { omega. }
-          pose (P3 := H9 (S j) H35). simpl in P3. 
-          rewrite Nat.add_succ_r in P3. simpl in P3.
-          simpl. rewrite Nat.add_0_r in *. assumption.
-      }
-      destruct H34. destruct H35. destruct H36. destruct H37. subst. auto.
+      pose (P1 := con_n_equality_single exps vals vals0 eff1 eff6 i i0 ids ids0 id _ _ _
+                 H H2 H1 H5 H4 H3 H6 H7 H8 H9 H10 l0). inversion P1.
+    - intros. subst. pose (list_equal_until_i_single exps vals vals0 eff6 eff1 _ _ _
+                            H H2 e H5 H8 H7 H9 H10). auto.
+  * pose (P := con_n_equality_rev_single exps vals vals0 eff1 eff6 i i0 id ids ids0 _ _ _
+               H H2 H5 H4 H3 H6 H7 H8 H9 H10 g H0). inversion P.
 Qed.
 
 End Determinism_Helpers.

--- a/src/Core_Erlang_Determinism_Helpers.v
+++ b/src/Core_Erlang_Determinism_Helpers.v
@@ -1,6 +1,6 @@
 Require Core_Erlang_Tactics.
 
-From Coq Require Import Arith.PeanoNat.
+From Coq Require Export Arith.PeanoNat.
 
 (** Helper lemmas for determinism *)
 Module Determinism_Helpers.

--- a/src/Core_Erlang_Environment.v
+++ b/src/Core_Erlang_Environment.v
@@ -22,7 +22,7 @@ Fixpoint get_value (env : Environment) (key : (Var + FunctionIdentifier))
    : (Value + Exception) :=
 match env with
 | [ ] => inr novar
-| (k,v)::xs => if uequal key k then inl v else get_value xs key
+| (k,v)::xs => if var_funid_eqb key k then inl v else get_value xs key
 end.
 
 (** Insert *)
@@ -30,7 +30,7 @@ Fixpoint insert_value (env : Environment) (key : (Var + FunctionIdentifier))
    (value : Value) : Environment :=
 match env with
   | [] => [(key, value)]
-  | (k,v)::xs => if uequal k key then (key,value)::xs else (k,v)::(insert_value xs key value)
+  | (k,v)::xs => if var_funid_eqb k key then (key,value)::xs else (k,v)::(insert_value xs key value)
 end.
 
 (** Add additional bindings *)
@@ -57,7 +57,7 @@ Fixpoint insert_function (id : nat) (v : FunctionIdentifier) (p : list Var) (b :
     : list (nat * FunctionIdentifier * FunctionExpression) :=
 match l with
 | [] => [(id, v, (p, b))]
-| (id', k, v0)::xs => if equal k v then (id', k, v0)::xs 
+| (id', k, v0)::xs => if funid_eqb k v then (id', k, v0)::xs 
                                    else (id', k, v0)::(insert_function id v p b xs)
 end.
 
@@ -97,15 +97,15 @@ Compute append_vars_to_env ["A"%string; "A"%string]
                            [(VEmptyMap); (VEmptyTuple)]
                            [(inl "A"%string, VEmptyMap)].
 
-Compute append_funs_to_env [(("f1"%string,0), ([], ErrorExp)) ; 
-                            (("f2"%string,0), ([], ErrorExp)) ;
-                            (("f1"%string,0), ([], ErrorExp)) ]
+Compute append_funs_to_env [(("f1"%string,0), ([], ^ErrorExp)) ; 
+                            (("f2"%string,0), ([], ^ErrorExp)) ;
+                            (("f1"%string,0), ([], ^ErrorExp)) ]
                            [(inl "X"%string, ErrorValue)] 0.
 
 Compute insert_function 2 ("f1"%string, 0) [] ErrorExp (list_functions
                               [("f1"%string,0); ("f2"%string,0); ("f1"%string, 0)]
                               [[];[];[]]
-                              [ErrorExp; ErrorExp; ErrorExp] 0).
+                              [^ErrorExp; ^ErrorExp; ^ErrorExp] 0).
 
 (** Environment construction from the extension and the reference *)
 Fixpoint get_env_base (env def : Environment) 

--- a/src/Core_Erlang_Environment.v
+++ b/src/Core_Erlang_Environment.v
@@ -50,6 +50,17 @@ match vl, el with
 | _, _ => []
 end.
 
+
+Definition append_try_vars_to_env (vl : list Var) (el : list Value) (d : Environment) 
+   : Environment :=
+match el with
+| [] => []
+| e::es =>
+if length vl =? 2 then append_vars_to_env vl es d else append_vars_to_env vl el d
+end.
+
+Compute append_try_vars_to_env ["X"%string; "Y"%string] [VNil; VNil; VNil] [].
+
 (** Not Overwriting insert *)
 (** Overwriting does not fit with this recursion *)
 Fixpoint insert_function (id : nat) (v : FunctionIdentifier) (p : list Var) (b : Expression) 

--- a/src/Core_Erlang_Environment.v
+++ b/src/Core_Erlang_Environment.v
@@ -19,10 +19,10 @@ end.
 
 (** Get *)
 Fixpoint get_value (env : Environment) (key : (Var + FunctionIdentifier)) 
-   : (Value + Exception) :=
+   : (ValueSequence + Exception) :=
 match env with
 | [ ] => inr novar
-| (k,v)::xs => if var_funid_eqb key k then inl v else get_value xs key
+| (k,v)::xs => if var_funid_eqb key k then inl [v] else get_value xs key
 end.
 
 (** Insert *)

--- a/src/Core_Erlang_Equivalence_Proofs.v
+++ b/src/Core_Erlang_Equivalence_Proofs.v
@@ -6,7 +6,6 @@ Export Core_Erlang_Proofs.Proofs.
 
 Import Core_Erlang_Tactics.Tactics.
 Import ListNotations.
-(* Import Coq.Init.Logic. *)
 
 Theorem equivalence : forall env id eff e1 e2 id1 id2 res1 res2 eff1 eff2,
   | env, id, e1, eff | -e> |id1, res1, eff1 | ->
@@ -31,30 +30,30 @@ forall  env eff res eff',
 
 Example call_comm : forall (e e' : Expression) (x1 x2 t : Value) 
                            (env : Environment) (id : nat),
-  |env, id, e, []| -e> |id, inl x1, []| ->
-  |env, id, e', []| -e> | id, inl x2, []| ->
-  |env, id, ECall "+"%string [e ; e'], []| -e> | id, inl t, []| ->
-  |env, id, ECall "+"%string [e' ; e], []| -e> | id, inl t, []|.
+  |env, id, e, []| -e> |id, inl [x1], []| ->
+  |env, id, e', []| -e> | id, inl [x2], []| ->
+  |env, id, ECall "+"%string [e ; e'], []| -e> | id, inl [t], []| ->
+  |env, id, ECall "+"%string [e' ; e], []| -e> | id, inl [t], []|.
 Proof.
   intros. 
   (* List elements *)
-  inversion H1. subst.
+  inversion H1. subst. inversion H5. subst.
   pose (EE1 := element_exist _ _ H4).
   inversion EE1. inversion H2. subst. inversion H4.
-  pose (EE2 := element_exist 0 x0 H8).
+  pose (EE2 := element_exist 0 x0 H9).
   inversion EE2. inversion H3. subst. simpl in H4. inversion H4.
-  apply eq_sym, length_zero_iff_nil in H11. subst.
-  pose (WD1 := determinism H).
-  pose (WD2 := determinism H0).
-  pose (P1 := H7 0 Nat.lt_0_2).
-  pose (P2 := H7 1 Nat.lt_1_2).
-  apply WD1 in P1; inversion P1; simpl in H9.
-  destruct H11.
-  rewrite H12 in *.
-  inversion H9. subst. rewrite <- H11 in P2. subst.
+  apply eq_sym, length_zero_iff_nil in H12. subst.
+  pose (WD1 := eval_expr_determinism H).
+  pose (WD2 := eval_expr_determinism H0).
+  pose (P1 := H8 0 Nat.lt_0_2).
+  pose (P2 := H8 1 Nat.lt_1_2).
+  apply WD1 in P1; inversion P1. inversion H10.
+  destruct H12. subst.
+  simpl in P2, H12, H13.
+  rewrite <- H12, <- H13 in P2. subst.
   apply WD2 in P2. inversion P2. destruct H14.
-  inversion H13. rewrite <- H12 in *. subst.
-  eapply eval_call with (vals := [x3; x]) (eff := [[];[]]) (ids := [id; id]); auto.
+  inversion H13. rewrite <- H15 in *. subst.
+  eapply eval_single, eval_call with (vals := [x3; x]) (eff := [[];[]]) (ids := [nth 0 ids 0; nth 0 ids 0]); auto.
   * intros. inversion H17.
     - assumption.
     - inversion H19.
@@ -63,287 +62,230 @@ Proof.
   * rewrite (@plus_comm_basic x x3 t). 
       - reflexivity.
       - simpl last.
-        pose (EE3 := element_exist _ _ H5).
+        pose (EE3 := element_exist _ _ H6).
         inversion EE3. inversion H17.
-        subst. inversion H5.
+        subst. inversion H6.
         pose (EE4 := element_exist _ _ H19).
         inversion EE4. inversion H18.
-        subst. inversion H5. apply eq_sym, length_zero_iff_nil in H21. subst.
-        simpl in H11, H14. subst.
-        exact H10.
+        subst. inversion H6. apply eq_sym, length_zero_iff_nil in H21. subst.
+        simpl in H12, H14. subst.
+        exact H11.
 Qed.
 
 
 Example let_1_comm (e1 e2 : Expression) (t x1 x2 : Value) (id : nat) :
-  |[], id, e1, []| -e> |id, inl x1, []| ->
-  | [(inl "X"%string, x1)], id, e2, []| -e> |id, inl x2, []| ->
-  |[], id, ELet [("X"%string, e1)] (ECall "+"%string [EVar "X"%string ; e2]), []| 
-  -e> | id, inl t, []| ->
-  |[], id, ELet [("X"%string, e1)] (ECall "+"%string [e2 ; EVar "X"%string]), []| 
-  -e> |id, inl t, []|.
+  |[], id, e1, []| -e> |id, inl [x1], []| ->
+  | [(inl "X"%string, x1)], id, e2, []| -e> |id, inl [x2], []| ->
+  |[], id, ELet ["X"%string] e1 (ECall "+"%string [^EVar "X"%string ; e2]), []| 
+  -e> | id, inl [t], []| ->
+  |[], id, ELet ["X"%string] e1 (ECall "+"%string [e2 ; ^EVar "X"%string]), []| 
+  -e> |id, inl [t], []|.
 Proof.
-  * intros. inversion H1. subst.
-    pose (EE1 := element_exist 0 vals H4).
+  * intros. inversion H1. inversion H5. subst.
+    pose (EE1 := element_exist 0 vals H20).
     inversion EE1. inversion H2. subst.
-    inversion H4. apply eq_sym, length_zero_iff_nil in H7. subst.
-    pose (EE2 := element_exist 0 _ H5). inversion EE2. inversion H3. subst.
-    inversion H5. apply eq_sym, length_zero_iff_nil in H8. subst.
-    pose (EE3 := element_exist 0 _ H6). inversion EE3. inversion H7. subst.
-    inversion H6. apply eq_sym, length_zero_iff_nil in H10. subst.
-    eapply eval_let with (vals := [x]) (eff := [[]]) (eff2 := []) (ids := [id]); auto.
-    - intros. inversion H8. 2: inversion H11.
-      simpl. pose (P1 := H9 0 Nat.lt_0_1). simpl in P1.
-      pose (WD1 := determinism H). apply WD1 in P1 as P2. destruct P2.
-      inversion H10.
-      destruct H12.
-      subst. exact P1.
-    - apply call_comm with (x1 := x) (x2 := x2).
-      + apply eval_var. reflexivity.
-      + pose (P1 := H9 0 Nat.lt_0_1). simpl in P1.
-        pose (WD1 := determinism H). apply WD1 in P1 as P2. destruct P2. destruct H10.
-        inversion H8.
-        subst. exact H0.
-      + pose (P1 := H9 0 Nat.lt_0_1). simpl in P1.
-        pose (WD1 := determinism H). apply WD1 in P1 as P2. destruct P2.
-        inversion H8. destruct H10. subst. exact H14.
+    inversion H20. apply eq_sym, length_zero_iff_nil in H4. subst.
+    pose (P := eval_expr_determinism H15 _ _ _ H).
+    destruct P, H4. inversion H3. subst.
+    eapply eval_single, eval_let; auto.
+    - exact H15.
+    - reflexivity.
+    - eapply (call_comm _ _ _ _ _ _ _ _ _ H21).
+      Unshelve.
+      exact x1.
+      exact x2.
+      apply eval_single, eval_var. simpl. auto.
+      auto.
 Qed.
 
 Example call_comm_ex : forall (e e' : Expression) (x1 x2 : Value) (env : Environment)
        (t t' : Value) (id : nat),
-  |env, id, e, []| -e> |id, inl x1, []| ->
-  |env, id, e', []| -e> |id, inl x2, []| ->
-  |env, id, ECall "+"%string [e ; e'], []| -e> |id, inl t, []| ->
-  |env, id, ECall "+"%string [e' ; e], []| -e> |id, inl t', []| ->
+  |env, id, e, []| -e> |id, inl [x1], []| ->
+  |env, id, e', []| -e> |id, inl [x2], []| ->
+  |env, id, ECall "+"%string [e ; e'], []| -e> |id, inl [t], []| ->
+  |env, id, ECall "+"%string [e' ; e], []| -e> |id, inl [t'], []| ->
   t = t'.
 Proof.
   intros. pose (P := call_comm e e' x1 x2 t env _ H H0 H1). 
-  pose (DET := determinism P _ _ _ H2). inversion DET. inversion H3. reflexivity.
+  pose (DET := eval_expr_determinism P _ _ _ H2). inversion DET. inversion H3. reflexivity.
 Qed.
 
-Example let_2_comm_concrete_alternate_proof (t : Value + Exception) :
-  |[], 0,  ELet [("X"%string, ELit (Integer 5))] (ELet [("Y"%string, ELit (Integer 6))]
-           (ECall "+"%string [EVar "X"%string ; EVar "Y"%string])), []| -e> |0, t, []|
-<->
-|[], 0, ELet [("X"%string, ELit (Integer 6))] (ELet [("Y"%string, ELit (Integer 5))]
-           (ECall "+"%string [EVar "X"%string ; EVar "Y"%string])), []| -e> |0, t, []|
-.
-Proof.
-  split; intros.
-  * (* let values *)
-    assert (|[], 0, ELet [("X"%string, ELit (Integer 5))]
-      (ELet [("Y"%string, ELit (Integer 6))] (ECall "+" [EVar "X"%string; EVar "Y"%string])), []|
-      -e> |0, inl (VLit (Integer 11)), []|).
-    {
-      solve.
-    }
-    apply @determinism with (v1 := inl (VLit (Integer 11))) (eff' := []) (id' := 0) in H.
-    inversion H. inversion H1. subst.
-    {
-      solve.
-    } assumption.
-    
-    
-    (* Other way, basically the same*)
-    * (* let values *)
-    assert (|[], 0, ELet [("X"%string, ELit (Integer 6))]
-      (ELet [("Y"%string, ELit (Integer 5))] (ECall "+" [EVar "X"%string; EVar "Y"%string])), []|
-      -e>  |0, inl (VLit (Integer 11)), []|).
-    {
-      solve.
-    }
-    apply @determinism with (v1 := inl (VLit (Integer 11))) (eff' := []) (id' := 0) in H.
-    inversion H. inversion H1. subst.
-    {
-      solve.
-    } assumption.
-Qed.
-
-Example let_1_comm_2_list (env: Environment) (e1 e2 : Expression) (t t' v1 v2 : Value) 
+Example let_1_comm_2_list (env: Environment) (e1 e2 : SingleExpression) (t t' v1 v2 : Value) 
    (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B) (id id1 id2 : nat)
-(Hypo1 : |env, id, e1, eff| -e> | id + id1, inl v1, eff ++ eff1|)
-(Hypo2 : |env, id + id2, e1, eff ++ eff2| -e> | id + id1 + id2, inl v1, eff ++ eff2 ++ eff1|)
-(Hypo1' : |env, id, e2, eff| -e> | id + id2, inl v2, eff ++ eff2|)
-(Hypo2' : |env, id + id1, e2, eff ++ eff1| -e> | id + id2 + id1, inl v2, eff ++ eff1 ++ eff2|) :
-|env, id, ELet [(A, e1); (B, e2)]
-     (ECall "+"%string [EVar A ; EVar B]), eff| -e> |id + id1 + id2, inl t, eff ++ eff1 ++ eff2|
+(Hypo1 : |env, id, e1, eff| -s> | id + id1, inl [v1], eff ++ eff1|)
+(Hypo2 : |env, id + id2, e1, eff ++ eff2| -s> | id + id1 + id2, inl [v1], eff ++ eff2 ++ eff1|)
+(Hypo1' : |env, id, e2, eff| -s> | id + id2, inl [v2], eff ++ eff2|)
+(Hypo2' : |env, id + id1, e2, eff ++ eff1| -s> | id + id2 + id1, inl [v2], eff ++ eff1 ++ eff2|) :
+|env, id, ELet [A; B] (EValues [e1; e2])
+     (ECall "+"%string [^EVar A ; ^EVar B]), eff| -e> |id + id1 + id2, inl [t], eff ++ eff1 ++ eff2|
 ->
-|env, id, ELet [(A, e2); (B, e1)]
-     (ECall "+"%string [EVar A ; EVar B]), eff| -e> |id + id2 + id1, inl t', eff ++ eff2 ++ eff1|
+|env, id, ELet [A; B] (EValues [e2; e1])
+     (ECall "+"%string [^EVar A ; ^EVar B]), eff| -e> |id + id2 + id1, inl [t'], eff ++ eff2 ++ eff1|
 ->
 t = t'.
 Proof.
   intros.
   (* FROM LET HYPO1 *)
-  inversion H. subst. simpl in H4, H5, H3.
-  pose (EE1 := element_exist 1 vals H3).
-  inversion EE1 as [v1']. inversion H1. subst. inversion H3.
-  pose (EE2 := element_exist 0 x H6).
-  inversion EE2 as [v2']. inversion H2. subst. inversion H3. 
-  apply eq_sym, length_zero_iff_nil in H9. subst.
-  pose (EE3 := element_exist _ _ H4). inversion EE3 as [eff1']. inversion H7. subst. inversion H4.
-  pose (EE4 := element_exist _ _ H10). inversion EE4 as [eff2']. inversion H9. subst. inversion H4.
-  apply eq_sym, length_zero_iff_nil in H12. subst.
-  pose (EE5 := element_exist _ _ H5). inversion EE5 as [id1']. inversion H11. subst. inversion H5.
-  pose (EE6 := element_exist _ _ H14). inversion EE6 as [id2']. inversion H12. subst. inversion H5.
-  apply eq_sym, length_zero_iff_nil in H16. subst.
+  inversion H. inversion H4. subst. simpl in H19.
+  pose (EE1 := element_exist 1 vals H19).
+  inversion EE1 as [v1']. inversion H1. subst. inversion H19.
+  pose (EE2 := element_exist 0 x H3).
+  inversion EE2 as [v2']. inversion H2. subst. inversion H19.
+  apply eq_sym, length_zero_iff_nil in H6. subst.
+  inversion H14. subst.
+  pose (EE3 := element_exist _ _ H8). inversion EE3 as [eff1']. inversion H5. subst. inversion H8.
+  pose (EE4 := element_exist _ _ H11). inversion EE4 as [eff2']. inversion H6. subst. inversion H8.
+  apply eq_sym, length_zero_iff_nil in H13. subst.
+  pose (EE5 := element_exist _ _ H9). inversion EE5 as [id1']. inversion H12. subst. inversion H9.
+  pose (EE6 := element_exist _ _ H15). inversion EE6 as [id2']. inversion H13. subst. inversion H9.
+  apply eq_sym, length_zero_iff_nil in H17. subst.
   (* FROM LET HYPO2 *)
-  inversion H0. subst. simpl in H19, H17, H18.
-  pose (EE1' := element_exist _ _ H17). inversion EE1' as [v2'']. inversion H15. subst. inversion H17.
-  pose (EE2' := element_exist _ _ H20). inversion EE2' as [v1'']. inversion H16. subst. inversion H17.
+  inversion H0. inversion H21. subst.
+  pose (EE1' := element_exist _ _ H36). inversion EE1' as [v2'']. inversion H16. subst. inversion H36.
+  pose (EE2' := element_exist _ _ H18). inversion EE2' as [v1'']. inversion H17. subst. inversion H36.
   apply eq_sym, length_zero_iff_nil in H23. subst.
-  pose (EE3' := element_exist _ _ H18). inversion EE3' as [eff2'']. inversion H21. subst. inversion H18.
-  pose (EE4' := element_exist _ _ H24). inversion EE4' as [eff1'']. inversion H23. subst. inversion H18.
-  apply eq_sym, length_zero_iff_nil in H26. subst.
-
-  pose (EE5' := element_exist _ _ H19). inversion EE5' as [id2'']. inversion H25. subst. inversion H19.
-  pose (EE6' := element_exist _ _ H28). inversion EE6' as [id1'']. inversion H26. subst. inversion H19.
+  inversion H31. subst.
+  pose (EE3' := element_exist _ _ H25). inversion EE3' as [eff2'']. inversion H22. subst. inversion H25.
+  pose (EE4' := element_exist _ _ H28). inversion EE4' as [eff1'']. inversion H23. subst. inversion H25.
   apply eq_sym, length_zero_iff_nil in H30. subst.
 
+  pose (EE5' := element_exist _ _ H26). inversion EE5' as [id2'']. inversion H29. subst. inversion H26.
+  pose (EE6' := element_exist _ _ H32). inversion EE6' as [id1'']. inversion H30. subst. inversion H26.
+  apply eq_sym, length_zero_iff_nil in H34. subst.
+  clear EE1. clear EE2. clear EE3. clear EE4. clear EE5. clear EE6.
+  clear EE1'. clear EE2'. clear EE3'. clear EE4'. clear EE5'. clear EE6'.
+  
   (* assert (v1' = v1 /\ eff1' = eff1).
   { *)
-    pose (P1 := H8 0 Nat.lt_0_2).
+    pose (P1 := H10 0 Nat.lt_0_2).
     simpl in P1.
-    pose (WD1 := determinism Hypo1).
+    pose (WD1 := eval_singleexpr_determinism Hypo1).
     pose (PC1 := WD1 _ _ _ P1).
-    destruct PC1. destruct H30. inversion H29. subst.
+    destruct PC1. destruct H34. inversion H33. subst.
   (* } *)
   
   (* assert (v2'' = v2 /\ eff2'' = eff2).
   { *)
-    pose (P2 := H22 0 Nat.lt_0_2).
+    pose (P2 := H27 0 Nat.lt_0_2).
     simpl in P2.
-    pose (WD2 := determinism Hypo1').
+    pose (WD2 := eval_singleexpr_determinism Hypo1').
     pose (PC2 := WD2 _ _ _ P2).
-    destruct PC2. destruct H31. inversion H30. subst.
+    destruct PC2. destruct H35. inversion H34. subst.
   (* } *)
 
   (* assert (v1'' = v1 /\ v2' = v2 /\ eff1'' = eff1 /\ eff2' = eff2).
   { *)
-    pose (P3 := H22 1 Nat.lt_1_2).
+    pose (P3 := H27 1 Nat.lt_1_2).
     simpl in P3.
-    pose (WD3 := determinism Hypo2).
+    pose (WD3 := eval_singleexpr_determinism Hypo2).
     pose (PC3 := WD3 _ _ _ P3).
-    inversion PC3. inversion H31. destruct H32. subst.
-    pose (P4 := H8 1 Nat.lt_1_2).
+    inversion PC3. inversion H35. destruct H38. subst.
+    pose (P4 := H10 1 Nat.lt_1_2).
     simpl in P4.
-    pose (WD4 := determinism Hypo2').
+    pose (WD4 := eval_singleexpr_determinism Hypo2').
     pose (PC4 := WD4 _ _ _ P4).
-    inversion PC4. inversion H33. inversion H32. subst.
-    clear EE1. clear EE2. clear EE3. clear EE4. clear EE5. clear EE6.
+    inversion PC4. destruct H39. inversion H38. subst.
   (* } *)
+  clear dependent P1. clear dependent P2. clear dependent P3. clear dependent P4.
 
   (* FROM CALL HYPOS *)
  (* FROM CALL HYPO1 *)
-  inversion H13. subst. simpl in H36, H37, H38.
-  pose (EC1 := element_exist _ _ H36). inversion EC1 as [v10]. inversion H34. subst. 
-  inversion H36.
-  pose (EC2 := element_exist _ _ H40). inversion EC2 as [v20]. inversion H35. subst. 
-  inversion H36.
-  apply eq_sym, length_zero_iff_nil in H43. subst.
-  pose (EC3 := element_exist _ _ H37). inversion EC3 as [eff10]. inversion H41. subst.
-  inversion H37.
-  pose (EC4 := element_exist _ _ H44). inversion EC4 as [eff20]. inversion H43. subst.
-  inversion H37.
-  apply eq_sym, length_zero_iff_nil in H46. subst.
-  pose (EC5 := element_exist _ _ H38). inversion EC5 as [id10]. inversion H45. subst.
-  inversion H38.
-  pose (EC6 := element_exist _ _ H48). inversion EC6 as [id20]. inversion H46. subst.
-  inversion H38.
-  apply eq_sym, length_zero_iff_nil in H50. subst.
+  inversion H20. inversion H42. subst.
+  pose (EC1 := element_exist _ _ H49). inversion EC1 as [v10]. inversion H39. subst. 
+  inversion H49.
+  pose (EC2 := element_exist _ _ H41). inversion EC2 as [v20]. inversion H40. subst. 
+  inversion H49.
+  apply eq_sym, length_zero_iff_nil in H44. subst.
+  pose (EC3 := element_exist _ _ H50). inversion EC3 as [eff10]. inversion H43. subst.
+  inversion H50.
+  pose (EC4 := element_exist _ _ H45). inversion EC4 as [eff20]. inversion H44. subst.
+  inversion H50.
+  apply eq_sym, length_zero_iff_nil in H47. subst.
+  pose (EC5 := element_exist _ _ H51). inversion EC5 as [id10]. inversion H46. subst.
+  inversion H51.
+  pose (EC6 := element_exist _ _ H48). inversion EC6 as [id20]. inversion H47. subst.
+  inversion H51.
+  apply eq_sym, length_zero_iff_nil in H54. subst.
   (* FROM CALL HYPO2 *)
-  inversion H27. subst. simpl in H51, H52, H53.
-  pose (EC1' := element_exist _ _ H51). inversion EC1' as [v20']. inversion H49. subst.
-  inversion H51.
-  pose (EC2' := element_exist _ _ H55). inversion EC2' as [v10']. inversion H50. subst.
-  inversion H51.
-  apply eq_sym, length_zero_iff_nil in H58. subst.
-  pose (EC3' := element_exist _ _ H52). inversion EC3' as [eff20']. inversion H56. subst.
-  inversion H52.
-  pose (EC4' := element_exist _ _ H59). inversion EC4' as [eff10']. inversion H58. subst.
-  inversion H52.
-  apply eq_sym, length_zero_iff_nil in H61. subst.
-  pose (EC5' := element_exist _ _ H53). inversion EC5' as [id20']. inversion H60. subst.
-  inversion H53.
-  pose (EC6' := element_exist _ _ H63). inversion EC6' as [id10']. inversion H61. subst.
-  inversion H53.
-  apply eq_sym, length_zero_iff_nil in H65. subst.
+  inversion H37. inversion H57. subst.
+  pose (EC1' := element_exist _ _ H65). inversion EC1' as [v20']. inversion H53. subst.
+  inversion H65.
+  pose (EC2' := element_exist _ _ H56). inversion EC2' as [v10']. inversion H54. subst.
+  inversion H65.
+  apply eq_sym, length_zero_iff_nil in H59. subst.
+  pose (EC3' := element_exist _ _ H66). inversion EC3' as [eff20']. inversion H58. subst.
+  inversion H66.
+  pose (EC4' := element_exist _ _ H61). inversion EC4' as [eff10']. inversion H59. subst.
+  inversion H66.
+  apply eq_sym, length_zero_iff_nil in H63. subst.
+  pose (EC5' := element_exist _ _ H67). inversion EC5' as [id20']. inversion H62. subst.
+  inversion H67.
+  pose (EC6' := element_exist _ _ H64). inversion EC6' as [id10']. inversion H63. subst.
+  inversion H67.
+  apply eq_sym, length_zero_iff_nil in H70. subst.
 
-  pose (PUM1 := plus_effect_unmodified _ _ _ H42).
-  pose (PUM2 := plus_effect_unmodified _ _ _ H57).
-  inversion PUM1. inversion PUM2. simpl in H64, H65. subst.
+
+  pose (PUM1 := plus_effect_unmodified _ _ _ H55).
+  pose (PUM2 := plus_effect_unmodified _ _ _ H71).
+  inversion PUM1. inversion PUM2. simpl in H69, H70. subst.
   (* EVERYTHING IS EQUAL *)
   (* assert (v1' = v1 /\ v1'' = v1 /\ v2' = v2 /\ v2'' = v2).
   { *)
-    clear P1. clear P2.
-    pose (P1 := H39 0 Nat.lt_0_2).
-    pose (P2 := H39 1 Nat.lt_1_2).
-    pose (P1' := H54 1 Nat.lt_1_2).
-    pose (P2' := H54 0 Nat.lt_0_2).
+    pose (P1 := H52 0 Nat.lt_0_2).
+    pose (P2 := H52 1 Nat.lt_1_2).
+    pose (P1' := H68 1 Nat.lt_1_2).
+    pose (P2' := H68 0 Nat.lt_0_2).
     simpl in P1, P2, P1', P2'.
     inversion P1. inversion P2. inversion P1'. inversion P2'. subst.
-    rewrite get_value_there in H67, H91.
+    inversion H73. inversion H82. inversion H90. inversion H98. subst.
+    rewrite get_value_there in H74, H102.
     2-3 : congruence.
-    rewrite get_value_here in H67, H75, H83, H91.
-    inversion H67. inversion H75. inversion H83. inversion H91. subst.
+    rewrite get_value_here in H74, H84, H93, H102.
+    inversion H74. inversion H84. inversion H93. inversion H102. subst.
 (* } *)
   clear PUM1. clear PUM2.
-  apply (plus_comm_basic_value _ (eff ++ eff2 ++ eff1)) in H42.
-  simpl last in H57.
-  rewrite H42 in H57. inversion H57.
+  apply (plus_comm_basic_value _ (eff ++ eff2 ++ eff1)) in H55.
+  simpl last in H71.
+  rewrite H55 in H71. inversion H71.
   reflexivity.
 Qed.
 
 Example exp_to_fun (e : Expression) (x : Var) (id id' : nat):
-  strong_equivalent e (ELet [(x, EFun [] e)] (EApp (EVar x) [])) (S id) id' id id'.
+  strong_equivalent e (ELet [x] (EFun [] e) (EApp (EVar x) [])) (S id) id' id id'.
 Proof.
   unfold strong_equivalent.
   split; intros.
-  * apply eval_let with (vals := [VClos env [] id [] e]) (eff := [eff]) (eff2 := eff') (ids := [S id]); auto.
-    - intros. inversion H0; inversion H2. simpl. apply eval_fun.
-    - simpl. eapply eval_app with (vals := []) (var_list := []) (body := e) (ref := env)
-                                    (ext := []) (eff := []) (eff2 := eff) (eff3 := eff') (ids := []); auto.
-      + assert (get_value (insert_value env (inl x) (VClos env [] id [] e)) (inl x) 
-                = inl (VClos env [] id [] e)). { apply get_value_here. }
-        rewrite <- H0. apply eval_var. reflexivity.
+  * eapply eval_single, eval_let; auto.
+    - apply eval_single, eval_fun.
+    - reflexivity.
+    - eapply eval_single, eval_app with (vals := []) (eff := []) (ids := []); auto.
+      + eapply eval_single, eval_var. simpl. rewrite get_value_here. reflexivity.
+      + auto.
       + intros. inversion H0.
-      + simpl. unfold get_env. simpl. assumption.
-  * inversion H.
-    - pose (EE1 := element_exist 0 vals H2). inversion EE1. inversion H13. subst.
-      inversion H2. apply eq_sym, length_zero_iff_nil in H1.
-      pose (EE2 := element_exist _ _ H3). inversion EE2. inversion H0. subst. inversion H3.
-      apply eq_sym, length_zero_iff_nil in H5.
-      pose (EE3 := element_exist _ _ H4). inversion EE3. inversion H1. subst. inversion H4.
-      apply eq_sym, length_zero_iff_nil in H6. subst.
-      (* assert (x2 = []).
-      { *)
-        pose (P := H7 0 Nat.lt_0_1). simpl in P. inversion P.
-        subst.
-      (* } *)
-      (* assert (x0 = VClos env [] (count_closures env) [] e).
-      { *)
-        (* assert (In (EFun [] e, x0) (combine [EFun [] e] [x0])). { simpl. auto. } 
-        pose (P1 := H6 0 Nat.lt_0_1). simpl in P1. inversion P1. reflexivity.  *)
-      (* } *)
-      subst. inversion H12.
+      + unfold get_env. simpl. auto.
+  * inversion H. inversion H3; subst.
+    - pose (EE1 := element_exist 0 vals H18). inversion EE1. inversion H0. subst.
+      inversion H18. apply eq_sym, length_zero_iff_nil in H2. subst.
+      inversion H13. subst. inversion H5. subst.
+
+      inversion H19. inversion H6.
       + subst.
-        apply eq_sym, length_zero_iff_nil in H11. subst.
+        apply eq_sym, length_zero_iff_nil in H17. subst.
+        apply eq_sym, length_zero_iff_nil in H20. subst.
         apply eq_sym, length_zero_iff_nil in H14. subst.
-        apply eq_sym, length_zero_iff_nil in H8. subst.
-        simpl in H9.
-        simpl in H22.
-        subst.
-        inversion H9.
-        (* inversion H7. *) rewrite get_value_here in H11. inversion H11. subst.
-        unfold get_env in H22. simpl in H22. assumption.
-      + subst. inversion H16. simpl in H9. rewrite get_value_here in H9. congruence.
-      + subst. inversion H8.
-      + subst. inversion H11. simpl in H17. rewrite get_value_here in H17. inversion H17. subst.
-        pose (P1 := H15 env [] [] e). congruence.
-      + subst. inversion H11. simpl in H17. rewrite get_value_here in H17. inversion H17. subst.
-        rewrite <- H8 in H15. contradiction.
-    - simpl in H2. inversion H2.
-      + subst. rewrite H15 in H13. inversion H13.
-      + inversion H15.
+        inversion H15. inversion H7. subst. simpl in H20.
+        rewrite get_value_here in H20. inversion H20. subst.
+
+        unfold get_env in H28. simpl in H28. assumption.
+      + subst. inversion H22. inversion H7. subst. simpl in H16. rewrite get_value_here in H16. congruence.
+      + subst. inversion H14.
+      + subst. inversion H17. inversion H7. subst.
+        simpl in H24. rewrite get_value_here in H24. inversion H24. subst.
+        congruence.
+      + subst. inversion H17. inversion H7. subst.
+        simpl in H24. rewrite get_value_here in H24. inversion H24. subst.
+        contradiction.
+    - inversion H17. inversion H4.
 Qed.
 
 Lemma X_neq_Y :
@@ -360,129 +302,107 @@ Qed.
 
 Example let_2_comm (env: Environment)(e1 e2 : Expression) (t x x0 : Value) 
     (eff eff1 eff2 : SideEffectList) (id0 id1 id2 : nat) (A B : Var) (VarHyp : A <> B) :
-  |env, id0, e2, eff| -e> |id0 + id2, inl x0, eff ++ eff2|
+  |env, id0, e2, eff| -e> |id0 + id2, inl [x0], eff ++ eff2|
  -> 
   |append_vars_to_env [A] [x] env, id0 + id1, e2, eff ++ eff1|
-  -e> | id0 + id1 + id2, inl x0, eff ++ eff1 ++ eff2|
+  -e> | id0 + id1 + id2, inl [x0], eff ++ eff1 ++ eff2|
  ->
-  |env, id0, e1, eff| -e> |id0 + id1, inl x, eff ++ eff1|
+  |env, id0, e1, eff| -e> |id0 + id1, inl [x], eff ++ eff1|
  -> 
   |append_vars_to_env [A] [x0] env, id0 + id2, e1, eff ++ eff2|
-  -e> |id0 + id2 + id1, inl x, eff ++ eff2 ++ eff1| 
+  -e> |id0 + id2 + id1, inl [x], eff ++ eff2 ++ eff1| 
  ->
-  |env, id0, ELet [(A, e1)] (ELet [(B, e2)] 
-        (ECall "+"%string [EVar A ; EVar B])), eff| -e>
-  | id0 + id1 + id2, inl t, eff ++ eff1 ++ eff2|
+  |env, id0, ELet [A] e1 (ELet [B] e2 
+        (ECall "+"%string [^EVar A ; ^EVar B])), eff| -e>
+  | id0 + id1 + id2, inl [t], eff ++ eff1 ++ eff2|
 ->
-  |env, id0, ELet [(A, e2)] (ELet [(B, e1)]
-        (ECall "+"%string [EVar A ; EVar B])), eff| -e>
-  | id0 + id2 + id1, inl t, eff ++ eff2 ++ eff1|
+  |env, id0, ELet [A] e2 (ELet [B] e1
+        (ECall "+"%string [^EVar A ; ^EVar B])), eff| -e>
+  | id0 + id2 + id1, inl [t], eff ++ eff2 ++ eff1|
 .
 Proof.
-  * intros. inversion H3. subst.
-    pose (EE1 := element_exist 0 vals H6).
-    pose (EE2 := element_exist 0 _ H7).
-    pose (EE3 := element_exist 0 _ H8).
-    inversion EE1 as [x']. inversion EE2 as [eff1']. inversion EE3 as [id1'].
-    inversion H4. inversion H5. inversion H9. subst. 
-    inversion H7. inversion H8. inversion H6.
-    apply eq_sym, length_zero_iff_nil in H12.
-    apply eq_sym, length_zero_iff_nil in H13.
-    apply eq_sym, length_zero_iff_nil in H14. subst.
+  * intros. inversion H3. inversion H7. subst.
+    pose (EE1 := element_exist 0 vals H22).
+    inversion EE1 as [x'].
+    inversion H4. subst. 
+    inversion H22. apply eq_sym, length_zero_iff_nil in H6. subst.
 (*     assert (x' = x /\ eff1' = eff ++ eff1 /\ id1' = (id0 + id1)%nat).
     { *)
-      pose (P := H11 0 Nat.lt_0_1). simpl in P.
-      pose (WD := determinism H1 _ _ _ P). destruct WD. destruct H12. inversion H10.
+      pose (WD := eval_expr_determinism H1 _ _ _ H17). destruct WD. destruct H6. inversion H5.
       subst.
 (*     } *)
-    inversion H16. subst.
-    pose (EE1' := element_exist 0 vals H14).
-    pose (EE2' := element_exist 0 _ H15).
-    pose (EE3' := element_exist 0 _ H17).
-    inversion EE1' as [x0']. inversion EE2' as [eff2']. inversion EE3' as [id2'].
-    inversion H12. inversion H13. inversion H18. subst. 
-    inversion H14. inversion H15. inversion H17.
-    apply eq_sym, length_zero_iff_nil in H21.
-    apply eq_sym, length_zero_iff_nil in H22.
-    apply eq_sym, length_zero_iff_nil in H23. subst.
+    inversion H23. inversion H10. subst.
+    pose (EE1' := element_exist 0 vals H28).
+    inversion EE1' as [x0'].
+    inversion H6. subst. inversion H28.
+    apply eq_sym, length_zero_iff_nil in H9.
 (*     assert (x0' = x0 /\ eff2' = eff ++ eff1 ++ eff2 /\ id2' = (id0 + id1 + id2)%nat).
     { *)
-      pose (P2 := H20 0 Nat.lt_0_1). simpl in P.
-      pose (WD := determinism H0 _ _ _ P2). 
-      destruct WD. destruct H21. inversion H19.
-      simpl in H21. simpl in H22. subst.
+      pose (WD := eval_expr_determinism H0 _ _ _ H21). 
+      destruct WD. destruct H11. inversion H8.
+      subst.
 (*     } *)
    (*proving starts*)
-   apply eval_let with (vals := [x0']) (eff := [eff ++ eff2]) (eff2 := eff ++ eff2 ++ eff1) 
-                       (ids := [(id0 + id2)%nat]); auto.
-   - intros. inversion H21.
-     + assumption.
-     + inversion H23.
-   - apply eval_let with (vals := [x']) (eff := [eff ++ eff2 ++ eff1]) (eff2 := eff ++ eff2 ++ eff1)
-                         (ids := [(id0 + id2 + id1)%nat]); auto.
-     + intros. inversion H21.
-       ** subst. simpl. assumption.
-       ** inversion H23.
+   eapply eval_single, eval_let; auto.
+   - exact H.
+   - auto.
+   - eapply eval_single, eval_let; auto.
+     + exact H2.
+     + auto.
    (* call information *)
-     + inversion H25. subst.
-       pose (EC1 := element_exist 1 _ H23).
-       pose (EC2 := element_exist 1 _ H24).
-       pose (EC3 := element_exist 1 _ H26).
+     + inversion H29. inversion H13. subst.
+       pose (EC1 := element_exist 1 _ H25).
+       pose (EC2 := element_exist 1 _ H26).
+       pose (EC3 := element_exist 1 _ H27).
        inversion EC1 as [x'']. inversion EC2 as [eff1'']. inversion EC3 as [id1''].
-       inversion H21. inversion H22. inversion H28. subst. 
-       inversion H23. inversion H24. inversion H26.
-       pose (EC1' := element_exist 0 _ H31).
-       pose (EC2' := element_exist 0 _ H32).
-       pose (EC3' := element_exist 0 _ H33).
+       inversion H9. inversion H11. inversion H12. subst.
+       inversion H25. inversion H26. inversion H27.
+       pose (EC1' := element_exist 0 _ H16).
+       pose (EC2' := element_exist 0 _ H18).
+       pose (EC3' := element_exist 0 _ H19).
        inversion EC1' as [x0'']. inversion EC2' as [eff2'']. inversion EC3' as [id2''].
-       inversion H29. inversion H34. inversion H36. subst. 
-       inversion H31. inversion H32. inversion H33.
-       apply eq_sym, length_zero_iff_nil in H38.
-       apply eq_sym, length_zero_iff_nil in H39.
-       apply eq_sym, length_zero_iff_nil in H40. subst.
-         
-         pose (P1' := H27 0 Nat.lt_0_2).
-         pose (P2' := H27 1 Nat.lt_1_2).
-         inversion P1'. inversion P2'. simpl in H51, H52, H50, H49. subst.
-         
-         simpl in H42, H44, H40, H48. subst.
-         
-         rewrite get_value_there in H40. 2: congruence.
-         rewrite get_value_here in H40. inversion H40.
-         rewrite get_value_here in H48. inversion H48. subst.
-       
+       inversion H14. inversion H20. inversion H24. subst.
+       inversion H16. inversion H18. inversion H19.
+       apply eq_sym, length_zero_iff_nil in H32.
+       apply eq_sym, length_zero_iff_nil in H34.
+       apply eq_sym, length_zero_iff_nil in H35. subst.
+
+         pose (P1' := H30 0 Nat.lt_0_2).
+         pose (P2' := H30 1 Nat.lt_1_2).
+         inversion P1'. inversion P2'. simpl in H45, H46, H47, H48. subst.
+
+         inversion H35. inversion H44. subst.
+         simpl in H36, H39, H41, H46, H48, H50.
+
+         rewrite get_value_there in H36. 2: congruence.
+         rewrite get_value_here in H36. inversion H36.
+         rewrite get_value_here in H46. inversion H46. subst.
+
        (* BACK TO CALL PROOF *)
-       apply eval_call with (vals := [x0' ; x']) (eff := [eff ++ eff2 ++ eff1;eff ++ eff2 ++ eff1]) 
+       eapply eval_single, eval_call with (vals := [x0' ; x']) (eff := [eff ++ eff2 ++ eff1;eff ++ eff2 ++ eff1]) 
                     (ids := [(id0 + id2 + id1)%nat; (id0 + id2 + id1)%nat]); auto.
-       ** intros. inversion H37. 2: inversion H39. 3: inversion H42.
-         -- simpl. assert (get_value (insert_value (insert_value env (inl A) x0') 
-                                     (inl B) x') (inl B) = inl x'). 
-                                     { apply get_value_here. }
-            rewrite <- H38. apply eval_var. reflexivity.
-         -- simpl. subst. assert (get_value (insert_value (insert_value env (inl A) x0') 
-                                           (inl B) x') (inl A) = inl x0').
-                                           { rewrite get_value_there. apply get_value_here.
-                                             unfold not. intros. inversion H33.
-                                             congruence. }
-            rewrite <- H38. apply eval_var. reflexivity.
+       ** intros. inversion H31. 2: inversion H34.
+         -- simpl. eapply eval_single, eval_var. rewrite get_value_here. auto.
+         -- simpl. eapply eval_single, eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+         -- inversion H39.
        ** apply plus_comm_basic_value with (eff0 := eff ++ eff1 ++ eff2). assumption.
 Qed.
 
 Example let_2_comm_eq (env: Environment)(e1 e2 : Expression) (t x x0 : Value) 
     (eff eff1 eff2 : SideEffectList) (id0 id1 id2 : nat) (A B : Var) (VarHyp : A <> B) :
-  |env, id0, e2, eff| -e> |id0 + id2, inl x0, eff ++ eff2| -> 
+  |env, id0, e2, eff| -e> |id0 + id2, inl [x0], eff ++ eff2| -> 
   |append_vars_to_env [A] [x] env, id0 + id1, e2, eff ++ eff1|
-  -e> | id0 + id1 + id2, inl x0, eff ++ eff1 ++ eff2| ->
-  |env, id0, e1, eff| -e> |id0 + id1, inl x, eff ++ eff1| -> 
+  -e> | id0 + id1 + id2, inl [x0], eff ++ eff1 ++ eff2| ->
+  |env, id0, e1, eff| -e> |id0 + id1, inl [x], eff ++ eff1| -> 
   |append_vars_to_env [A] [x0] env, id0 + id2, e1, eff ++ eff2|
-  -e> |id0 + id2 + id1, inl x, eff ++ eff2 ++ eff1| ->
-  |env, id0, ELet [(A, e1)] (ELet [(B, e2)] 
-        (ECall "+"%string [EVar A ; EVar B])), eff| -e> 
-  | id0 + id1 + id2, inl t, eff ++ eff1 ++ eff2|
+  -e> |id0 + id2 + id1, inl [x], eff ++ eff2 ++ eff1| ->
+  |env, id0, ELet [A] e1 (ELet [B] e2
+        (ECall "+"%string [^EVar A ; ^EVar B])), eff| -e> 
+  | id0 + id1 + id2, inl [t], eff ++ eff1 ++ eff2|
 <->
-  |env, id0, ELet [(A, e2)] (ELet [(B, e1)]
-        (ECall "+"%string [EVar A ; EVar B])), eff| -e>
-  | id0 + id2 + id1, inl t, eff ++ eff2 ++ eff1|
+  |env, id0, ELet [A] e2 (ELet [B] e1
+        (ECall "+"%string [^EVar A ; ^EVar B])), eff| -e>
+  | id0 + id2 + id1, inl [t], eff ++ eff2 ++ eff1|
 .
 Proof.
   split.
@@ -500,901 +420,408 @@ t = t'. *)
 
 Example let_2_binding_swap (env: Environment)(e1 e2 : Expression) (t x x0 : Value) 
     (eff eff1 eff2 : SideEffectList) (A B : Var) (id0 id1 id2 : nat) (VarHyp : A <> B) :
-  |env, id0, e2, eff| -e> |id0 + id2, inl x0, eff ++ eff2| -> 
+  |env, id0, e2, eff| -e> |id0 + id2, inl [x0], eff ++ eff2| -> 
   |append_vars_to_env [A] [x] env, id0 + id1, e2, eff ++ eff1| -e>
-  | id0 + id1 + id2, inl x0, eff ++ eff1 ++ eff2| ->
-  |env, id0, e1, eff| -e> |id0 + id1, inl x, eff ++ eff1| -> 
+  | id0 + id1 + id2, inl [x0], eff ++ eff1 ++ eff2| ->
+  |env, id0, e1, eff| -e> |id0 + id1, inl [x], eff ++ eff1| -> 
   |append_vars_to_env [B] [x0] env, id0 + id2, e1, eff ++ eff2| -e>
-  |id0 + id2 + id1, inl x, eff ++ eff2 ++ eff1|
+  |id0 + id2 + id1, inl [x], eff ++ eff2 ++ eff1|
 ->
-  |env, id0, ELet [(A, e1)] (ELet [(B, e2)] 
-        (ECall "+"%string [EVar A ; EVar B])), eff| -e>
-  |id0 + id1 + id2, inl t, eff ++ eff1 ++ eff2|
+  |env, id0, ELet [A] e1 (ELet [B] e2
+        (ECall "+"%string [^EVar A ; ^EVar B])), eff| -e>
+  |id0 + id1 + id2, inl [t], eff ++ eff1 ++ eff2|
 <->
-  |env, id0, ELet [(B, e2)] (ELet [(A, e1)]
-        (ECall "+"%string [EVar A ; EVar B])), eff| -e>
-  |id0 + id2 + id1, inl t, eff ++ eff2 ++ eff1|
+  |env, id0, ELet [B] e2 (ELet [A] e1
+        (ECall "+"%string [^EVar A ; ^EVar B])), eff| -e>
+  |id0 + id2 + id1, inl [t], eff ++ eff2 ++ eff1|
 .
 Proof.
   split.
-  * intros. inversion H3. subst.
-    pose (EE1 := element_exist 0 vals H6).
-    pose (EE2 := element_exist 0 _ H7).
-    pose (EE3 := element_exist 0 _ H8).
-    inversion EE1 as [x']. inversion EE2 as [eff1']. inversion EE3 as [id1'].
-    inversion H4. inversion H5. inversion H9. subst. 
-    inversion H7. inversion H8. inversion H6.
-    apply eq_sym, length_zero_iff_nil in H12.
-    apply eq_sym, length_zero_iff_nil in H13.
-    apply eq_sym, length_zero_iff_nil in H14. subst.
-      pose (P := H11 0 Nat.lt_0_1). simpl in P.
-      pose (WD := determinism H1 _ _ _ P). destruct WD. destruct H12. inversion H10.
+  * intros. inversion H3. inversion H7. subst.
+    pose (EE1 := element_exist 0 vals H22).
+    inversion EE1 as [x'].
+    inversion H4. subst. 
+    inversion H22. apply eq_sym, length_zero_iff_nil in H6. subst.
+(*     assert (x' = x /\ eff1' = eff ++ eff1 /\ id1' = (id0 + id1)%nat).
+    { *)
+      pose (WD := eval_expr_determinism H1 _ _ _ H17). destruct WD. destruct H6. inversion H5.
       subst.
-    inversion H16. subst.
-    pose (EE1' := element_exist 0 vals H14).
-    pose (EE2' := element_exist 0 _ H15).
-    pose (EE3' := element_exist 0 _ H17).
-    inversion EE1' as [x0']. inversion EE2' as [eff2']. inversion EE3' as [id2'].
-    inversion H12. inversion H13. inversion H18. subst. 
-    inversion H14. inversion H15. inversion H17.
-    apply eq_sym, length_zero_iff_nil in H22.
-    apply eq_sym, length_zero_iff_nil in H23.
-    apply eq_sym, length_zero_iff_nil in H21. subst.
-      pose (P2 := H20 0 Nat.lt_0_1). simpl in P2.
-      pose (WD := determinism H0 _ _ _ P2). 
-      destruct WD. destruct H21. inversion H19. subst.
+(*     } *)
+    inversion H23. inversion H10. subst.
+    pose (EE1' := element_exist 0 vals H28).
+    inversion EE1' as [x0'].
+    inversion H6. subst. inversion H28.
+    apply eq_sym, length_zero_iff_nil in H9.
+(*     assert (x0' = x0 /\ eff2' = eff ++ eff1 ++ eff2 /\ id2' = (id0 + id1 + id2)%nat).
+    { *)
+      pose (WD := eval_expr_determinism H0 _ _ _ H21). 
+      destruct WD. destruct H11. inversion H8.
+      subst.
+(*     } *)
    (*proving starts*)
-   apply eval_let with (vals := [x0']) (eff := [eff ++ eff2]) (eff2 := eff ++ eff2 ++ eff1) 
-                       (ids := [(id0 + id2)%nat]); auto.
-   - intros. inversion H21.
-     + assumption.
-     + inversion H23.
-   - apply eval_let with (vals := [x']) (eff := [eff ++ eff2 ++ eff1]) (eff2 := eff ++ eff2 ++ eff1)
-                         (ids := [(id0 + id2 + id1)%nat]); auto.
-     + intros. inversion H21.
-       ** subst. assumption.
-       ** inversion H23.
+   eapply eval_single, eval_let; auto.
+   - exact H.
+   - auto.
+   - eapply eval_single, eval_let; auto.
+     + exact H2.
+     + auto.
    (* call information *)
-     + inversion H25. subst.
-       pose (EC1 := element_exist 1 _ H23).
-       pose (EC2 := element_exist 1 _ H24).
-       pose (EC3 := element_exist 1 _ H26).
+     + inversion H29. inversion H13. subst.
+       pose (EC1 := element_exist 1 _ H25).
+       pose (EC2 := element_exist 1 _ H26).
+       pose (EC3 := element_exist 1 _ H27).
        inversion EC1 as [x'']. inversion EC2 as [eff1'']. inversion EC3 as [id1''].
-       inversion H21. inversion H22. inversion H28. subst. 
-       inversion H23. inversion H24. inversion H26.
-       pose (EC1' := element_exist 0 _ H31).
-       pose (EC2' := element_exist 0 _ H32).
-       pose (EC3' := element_exist 0 _ H33).
+       inversion H9. inversion H11. inversion H12. subst.
+       inversion H25. inversion H26. inversion H27.
+       pose (EC1' := element_exist 0 _ H16).
+       pose (EC2' := element_exist 0 _ H18).
+       pose (EC3' := element_exist 0 _ H19).
        inversion EC1' as [x0'']. inversion EC2' as [eff2'']. inversion EC3' as [id2''].
-       inversion H29. inversion H34. inversion H36. subst. 
-       inversion H31. inversion H32. inversion H33.
-       apply eq_sym, length_zero_iff_nil in H38.
-       apply eq_sym, length_zero_iff_nil in H39.
-       apply eq_sym, length_zero_iff_nil in H40. subst.
-         pose (P1' := H27 0 Nat.lt_0_2).
-         pose (P2' := H27 1 Nat.lt_1_2).
-         inversion P1'. inversion P2'. subst.
-         
-         simpl in H40, H42, H44, H48, H50, H52. subst.
-         
-         rewrite get_value_there in H40. 2: congruence.
-         rewrite get_value_here in H40. inversion H40.
-         rewrite get_value_here in H48. inversion H48.
-         subst.
-       
+       inversion H14. inversion H20. inversion H24. subst.
+       inversion H16. inversion H18. inversion H19.
+       apply eq_sym, length_zero_iff_nil in H32.
+       apply eq_sym, length_zero_iff_nil in H34.
+       apply eq_sym, length_zero_iff_nil in H35. subst.
+
+         pose (P1' := H30 0 Nat.lt_0_2).
+         pose (P2' := H30 1 Nat.lt_1_2).
+         inversion P1'. inversion P2'. simpl in H45, H46, H47, H48. subst.
+
+         inversion H35. inversion H44. subst.
+         simpl in H36, H39, H41, H46, H48, H50.
+
+         rewrite get_value_there in H36. 2: congruence.
+         rewrite get_value_here in H36. inversion H36.
+         rewrite get_value_here in H46. inversion H46. subst.
+
        (* BACK TO CALL PROOF *)
-       apply eval_call with (vals := [x' ; x0']) (eff := [eff ++ eff2 ++ eff1;eff ++ eff2 ++ eff1]) 
+       eapply eval_single, eval_call with (vals := [x' ; x0']) (eff := [eff ++ eff2 ++ eff1;eff ++ eff2 ++ eff1]) 
                     (ids := [(id0 + id2 + id1)%nat; (id0 + id2 + id1)%nat]); auto.
-       ** intros. inversion H37. 2: inversion H39. 3: inversion H42.
-         -- simpl. assert (get_value (insert_value (insert_value env (inl B) x0') (inl A) x') (inl B) = inl x0'). 
-                                     { rewrite get_value_there. apply get_value_here.
-                                             unfold not. intros. inversion H33.
-                                             congruence. }
-            rewrite <- H38. apply eval_var. reflexivity.
-         -- simpl. subst. assert (get_value (insert_value (insert_value env (inl B) x0') (inl A) x') (inl A) = inl x').
-                                           { apply get_value_here. }
-            rewrite <- H38. apply eval_var. reflexivity.
+       ** intros. inversion H31. 2: inversion H34.
+         -- simpl. eapply eval_single, eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+         -- simpl. eapply eval_single, eval_var. rewrite get_value_here. auto.
+         -- inversion H39.
        ** apply plus_effect_changeable with (eff0 := eff ++ eff1 ++ eff2). assumption.
-  * intros. inversion H3. subst.
-    pose (EE1 := element_exist 0 vals H6).
-    pose (EE2 := element_exist 0 _ H7).
-    pose (EE3 := element_exist 0 _ H8).
-    inversion EE1 as [x0']. inversion EE2 as [eff2']. inversion EE3 as [id2'].
-    inversion H4. inversion H5. inversion H9. subst. 
-    inversion H7. inversion H8. inversion H6.
-    apply eq_sym, length_zero_iff_nil in H12.
-    apply eq_sym, length_zero_iff_nil in H13.
-    apply eq_sym, length_zero_iff_nil in H14. subst.
-      pose (P := H11 0 Nat.lt_0_1). simpl in P.
-      pose (WD := determinism H _ _ _ P). destruct WD. destruct H12. inversion H10.
+  * intros. inversion H3. inversion H7. subst.
+    pose (EE1 := element_exist 0 vals H22).
+    inversion EE1 as [x'].
+    inversion H4. subst. 
+    inversion H22. apply eq_sym, length_zero_iff_nil in H6. subst.
+(*     assert (x' = x /\ eff1' = eff ++ eff1 /\ id1' = (id0 + id1)%nat).
+    { *)
+      pose (WD := eval_expr_determinism H _ _ _ H17). destruct WD. destruct H6. inversion H5.
       subst.
-    inversion H16. subst.
-    pose (EE1' := element_exist 0 vals H14).
-    pose (EE2' := element_exist 0 _ H15).
-    pose (EE3' := element_exist 0 _ H17).
-    inversion EE1' as [x']. inversion EE2' as [eff1']. inversion EE3' as [id1'].
-    inversion H12. inversion H13. inversion H18. subst. 
-    inversion H14. inversion H15. inversion H17.
-    apply eq_sym, length_zero_iff_nil in H21.
-    apply eq_sym, length_zero_iff_nil in H23.
-    apply eq_sym, length_zero_iff_nil in H22. subst.
-      pose (P2 := H20 0 Nat.lt_0_1). simpl in P2.
-      pose (WD := determinism H2 _ _ _ P2). 
-      destruct WD. destruct H21. inversion H19. subst.
+(*     } *)
+    inversion H23. inversion H10. subst.
+    pose (EE1' := element_exist 0 vals H28).
+    inversion EE1' as [x0'].
+    inversion H6. subst. inversion H28.
+    apply eq_sym, length_zero_iff_nil in H9.
+(*     assert (x0' = x0 /\ eff2' = eff ++ eff1 ++ eff2 /\ id2' = (id0 + id1 + id2)%nat).
+    { *)
+      pose (WD := eval_expr_determinism H2 _ _ _ H21). 
+      destruct WD. destruct H11. inversion H8.
+      subst.
+(*     } *)
    (*proving starts*)
-   apply eval_let with (vals := [x']) (eff := [eff ++ eff1]) (eff2 := eff ++ eff1 ++ eff2) 
-                       (ids := [(id0 + id1)%nat]); auto.
-   - intros. inversion H21.
-     + assumption.
-     + inversion H23.
-   - apply eval_let with (vals := [x0']) (eff := [eff ++ eff1 ++ eff2]) (eff2 := eff ++ eff1 ++ eff2)
-                         (ids := [(id0 + id1 + id2)%nat]); auto.
-     + intros. inversion H21.
-       ** subst. assumption.
-       ** inversion H23.
+   eapply eval_single, eval_let; auto.
+   - exact H1.
+   - auto.
+   - eapply eval_single, eval_let; auto.
+     + exact H0.
+     + auto.
    (* call information *)
-     + inversion H25. subst.
-       pose (EC1 := element_exist 1 _ H23).
-       pose (EC2 := element_exist 1 _ H24).
-       pose (EC3 := element_exist 1 _ H26).
+     + inversion H29. inversion H13. subst.
+       pose (EC1 := element_exist 1 _ H25).
+       pose (EC2 := element_exist 1 _ H26).
+       pose (EC3 := element_exist 1 _ H27).
        inversion EC1 as [x'']. inversion EC2 as [eff1'']. inversion EC3 as [id1''].
-       inversion H21. inversion H22. inversion H28. subst. 
-       inversion H23. inversion H24. inversion H26.
-       pose (EC1' := element_exist 0 _ H31).
-       pose (EC2' := element_exist 0 _ H32).
-       pose (EC3' := element_exist 0 _ H33).
+       inversion H9. inversion H11. inversion H12. subst.
+       inversion H25. inversion H26. inversion H27.
+       pose (EC1' := element_exist 0 _ H16).
+       pose (EC2' := element_exist 0 _ H18).
+       pose (EC3' := element_exist 0 _ H19).
        inversion EC1' as [x0'']. inversion EC2' as [eff2'']. inversion EC3' as [id2''].
-       inversion H29. inversion H34. inversion H36. subst. 
-       inversion H31. inversion H32. inversion H33.
-       apply eq_sym, length_zero_iff_nil in H38.
-       apply eq_sym, length_zero_iff_nil in H39.
-       apply eq_sym, length_zero_iff_nil in H40. subst.
-         pose (P1' := H27 0 Nat.lt_0_2).
-         pose (P2' := H27 1 Nat.lt_1_2).
-         inversion P1'. inversion P2'. subst.
-         
-         simpl in H40, H42, H44, H48, H50, H52. subst.
-         
-         rewrite get_value_here in H40.
-         rewrite get_value_there, get_value_here in H48. 2: congruence.
-         inversion H40. inversion H48. subst.
-       
+       inversion H14. inversion H20. inversion H24. subst.
+       inversion H16. inversion H18. inversion H19.
+       apply eq_sym, length_zero_iff_nil in H32.
+       apply eq_sym, length_zero_iff_nil in H34.
+       apply eq_sym, length_zero_iff_nil in H35. subst.
+
+         pose (P1' := H30 0 Nat.lt_0_2).
+         pose (P2' := H30 1 Nat.lt_1_2).
+         inversion P1'. inversion P2'. simpl in H45, H46, H47, H48. subst.
+
+         inversion H35. inversion H44. subst.
+         simpl in H36, H39, H41, H46, H48, H50.
+
+         rewrite get_value_there in H46. 2: congruence.
+         rewrite get_value_here in H46. inversion H46.
+         rewrite get_value_here in H36. inversion H36. subst.
+
        (* BACK TO CALL PROOF *)
-       apply eval_call with (vals := [x' ; x0']) (eff := [eff ++ eff1 ++ eff2;eff ++ eff1 ++ eff2]) 
+       eapply eval_single, eval_call with (vals := [x0' ; x']) (eff := [eff ++ eff1 ++ eff2;eff ++ eff1 ++ eff2]) 
                     (ids := [(id0 + id1 + id2)%nat; (id0 + id1 + id2)%nat]); auto.
-       ** intros. inversion H37. 2: inversion H39. 3: inversion H42.
-         -- simpl. assert (get_value (insert_value (insert_value env (inl A) x') (inl B) x0') (inl B) = inl x0'). 
-                                     { apply get_value_here. }
-            rewrite <- H38. apply eval_var. reflexivity.
-         -- simpl. subst. assert (get_value (insert_value (insert_value env (inl A) x') (inl B) x0') (inl A) = inl x').
-                                           { rewrite get_value_there. apply get_value_here. congruence. }
-            rewrite <- H38. apply eval_var. reflexivity.
+       ** intros. inversion H31. 2: inversion H34.
+         -- simpl. eapply eval_single, eval_var. rewrite get_value_here. auto.
+         -- simpl. eapply eval_single, eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+         -- inversion H39.
        ** apply plus_effect_changeable with (eff0 := eff ++ eff2 ++ eff1). assumption.
 Qed.
 
-(* Example let_1_binding_swap_2_list (env: Environment) (e1 e2 : Expression) (t t' v1 v2 : Value) 
-   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B) (id id1 id2 : nat)
-(Hypo1 : |env, id, e1, eff| -e> | id + id1, inl v1, eff ++ eff1|)
-(Hypo2 : |env, id + id2, e1, eff ++ eff2| -e> | id + id1 + id2, inl v1, eff ++ eff2 ++ eff1|)
-(Hypo1' : |env, id, e2, eff| -e> | id + id2, inl v2, eff ++ eff2|)
-(Hypo2' : |env, id + id1, e2, eff ++ eff1| -e> | id + id2 + id1, inl v2, eff ++ eff1 ++ eff2|) :
-|env, id, ELet [(A, e1); (B, e2)]
-     (ECall "+"%string [EVar A ; EVar B]), eff| -e> | id + id1 + id2, inl t, eff ++ eff1 ++ eff2|
-->
-|env, id, ELet [(B, e2); (A, e1)]
-     (ECall "+"%string [EVar B ; EVar A]), eff| -e> |id + id2 + id1, inl t', eff ++ eff2 ++ eff1|
-->
-t = t'.
-Proof.
-  intros.
-  (* FROM LET HYPO1 *)
-  inversion H. subst. simpl in H4, H5, H3.
-  pose (EE1 := element_exist Value 1 vals H3).
-  inversion EE1 as [v1']. inversion H1. subst. inversion H3.
-  pose (EE2 := element_exist Value 0 x H7).
-  inversion EE2 as [v2']. inversion H2. subst. inversion H3. 
-  apply eq_sym, length_zero_iff_nil in H10. subst.
-  pose (EE3 := element_exist _ _ _ H4). inversion EE3 as [eff1']. inversion H8. subst. inversion H4.
-  pose (EE4 := element_exist _ _ _ H11). inversion EE4 as [eff2']. inversion H10. subst. inversion H4.
-  apply eq_sym, length_zero_iff_nil in H13. subst.
-  pose (EE5 := element_exist nat _ _ H5). inversion EE5 as [id1']. inversion H12. subst. inversion H5.
-  pose (EE6 := element_exist _ _ _ H15). inversion EE6 as [id2']. inversion H13. subst. inversion H5.
-  apply eq_sym, length_zero_iff_nil in H17. subst.
-  (* FROM LET HYPO2 *)
-  inversion H0. subst. simpl in H19, H20, H18.
-  pose (EE1' := element_exist _ _ _ H18). inversion EE1' as [v2'']. inversion H16. subst. inversion H18.
-  pose (EE2' := element_exist _ _ _ H22). inversion EE2' as [v1'']. inversion H17. subst. inversion H18.
-  apply eq_sym, length_zero_iff_nil in H25. subst.
-  pose (EE3' := element_exist _ _ _ H19). inversion EE3' as [eff2'']. inversion H23. subst. inversion H19.
-  pose (EE4' := element_exist _ _ _ H26). inversion EE4' as [eff1'']. inversion H25. subst. inversion H19.
-  apply eq_sym, length_zero_iff_nil in H28. subst.
-
-  pose (EE5' := element_exist _ _ _ H20). inversion EE5' as [id2'']. inversion H27. subst. inversion H20.
-  pose (EE6' := element_exist _ _ _ H30). inversion EE6' as [id1'']. inversion H28. subst. inversion H20.
-  apply eq_sym, length_zero_iff_nil in H32. subst.
-
-  (* assert (v1' = v1 /\ eff1' = eff1).
-  { *)
-    pose (P1 := H6 0 Nat.lt_0_2).
-    unfold concatn in P1. simpl in P1. rewrite app_nil_r, app_nil_r in P1.
-    pose (WD1 := determinism Hypo1).
-    pose (PC1 := WD1 _ _ _ P1).
-    destruct PC1. destruct H32. apply app_inv_head in H32. inversion H31. subst.
-  (* } *)
-  
-  (* assert (v2'' = v2 /\ eff2'' = eff2).
-  { *)
-    pose (P2 := H21 0 Nat.lt_0_2).
-    unfold concatn in P2. simpl in P2. rewrite app_nil_r, app_nil_r in P2.
-    pose (WD2 := determinism Hypo1').
-    pose (PC2 := WD2 _ _ _ P2).
-    destruct PC2. destruct H33. inversion H32. apply app_inv_head in H33. subst. auto.
-  (* } *)
-
-  (* assert (v1'' = v1 /\ v2' = v2 /\ eff1'' = eff1 /\ eff2' = eff2).
-  { *)
-    pose (P3 := H21 1 Nat.lt_1_2).
-    unfold concatn in P3. simpl in P3. rewrite app_nil_r, app_nil_r in P3.
-    pose (WD3 := determinism Hypo2).
-    pose (PC3 := WD3 _ _ _ P3).
-    inversion PC3. inversion H34. inversion H33. apply app_inv_head, app_inv_head in H35. subst.
-    pose (P4 := H6 1 Nat.lt_1_2).
-    unfold concatn in P4. simpl in P4. rewrite app_nil_r, app_nil_r in P4.
-    pose (WD4 := determinism Hypo2').
-    pose (PC4 := WD4 _ _ _ P4).
-    inversion PC4. inversion H36. inversion H35. apply app_inv_head, app_inv_head in H37. subst.
-    clear EE1. clear EE2. clear EE3. clear EE4. clear EE5. clear EE6.
-  (* } *)
-
-  (* FROM CALL HYPOS *)
- (* FROM CALL HYPO1 *)
-  inversion H14. subst. simpl in H39, H40, H41.
-  pose (EC1 := element_exist _ _ _ H39). inversion EC1 as [v10]. inversion H37. subst. 
-  inversion H39.
-  pose (EC2 := element_exist _ _ _ H43). inversion EC2 as [v20]. inversion H38. subst. 
-  inversion H39.
-  apply eq_sym, length_zero_iff_nil in H46. subst.
-  pose (EC3 := element_exist _ _ _ H40). inversion EC3 as [eff10]. inversion H44. subst.
-  inversion H40.
-  pose (EC4 := element_exist _ _ _ H47). inversion EC4 as [eff20]. inversion H46. subst.
-  inversion H40.
-  apply eq_sym, length_zero_iff_nil in H49. subst.
-  pose (EC5 := element_exist _ _ _ H41). inversion EC5 as [id10]. inversion H48. subst.
-  inversion H41.
-  pose (EC6 := element_exist _ _ _ H51). inversion EC6 as [id20]. inversion H49. subst.
-  inversion H41.
-  apply eq_sym, length_zero_iff_nil in H53. subst.
-  (* FROM CALL HYPO2 *)
-  inversion H29. subst. simpl in H54, H55, H56.
-  pose (EC1' := element_exist _ _ _ H54). inversion EC1' as [v20']. inversion H52. subst.
-  inversion H54.
-  pose (EC2' := element_exist _ _ _ H58). inversion EC2' as [v10']. inversion H53. subst.
-  inversion H54.
-  apply eq_sym, length_zero_iff_nil in H61. subst.
-  pose (EC3' := element_exist _ _ _ H55). inversion EC3' as [eff20']. inversion H59. subst.
-  inversion H55.
-  pose (EC4' := element_exist _ _ _ H62). inversion EC4' as [eff10']. inversion H61. subst.
-  inversion H55.
-  apply eq_sym, length_zero_iff_nil in H64. subst.
-  pose (EC5' := element_exist _ _ _ H56). inversion EC5' as [id20']. inversion H63. subst.
-  inversion H56.
-  pose (EC6' := element_exist _ _ _ H66). inversion EC6' as [id10']. inversion H64. subst.
-  inversion H56.
-  apply eq_sym, length_zero_iff_nil in H68. subst.
-
-  unfold concatn in H45, H60. simpl app in H45, H60.
-  pose (PUM1 := plus_effect_unmodified _ _ _ H45).
-  pose (PUM2 := plus_effect_unmodified _ _ _ H60).
-  rewrite app_nil_r, app_nil_r, <- app_nil_r in PUM1, PUM2.
-  apply app_inv_head in PUM1. apply app_inv_head in PUM2.
-  apply app_eq_nil in PUM1. apply app_eq_nil in PUM2.
-  inversion PUM1. inversion PUM2. subst.
-  (* EVERYTHING IS EQUAL *)
-  (* assert (v1' = v1 /\ v1'' = v1 /\ v2' = v2 /\ v2'' = v2).
-  { *)
-    clear P1. clear P2.
-    pose (P1 := H42 0 Nat.lt_0_2).
-    pose (P2 := H42 1 Nat.lt_1_2).
-    pose (P1' := H57 1 Nat.lt_1_2).
-    pose (P2' := H57 0 Nat.lt_0_2).
-    unfold concatn in P1, P2, P1', P2'. simpl in P1, P2, P1', P2'.
-    rewrite app_nil_r, app_nil_r in P1, P1', P2, P2'.
-    inversion P1. inversion P2. inversion P1'. inversion P2'. subst.
-    rewrite get_value_there in H73, H91.
-    2-3 : congruence.
-    rewrite get_value_here in H73, H79, H85, H91.
-    inversion H73. inversion H79. inversion H85. inversion H91. subst.
-(* } *)
-  rewrite app_nil_r, app_nil_r in H45, H60.
-  
-  apply (plus_comm_basic_value _ (eff ++ eff2' ++ eff1'')) in H45.
-  rewrite H45 in H60. inversion H60.
-  reflexivity.
-Qed. *)
-
-Example let_1_comm_2_list_alt (env: Environment) (e1 e2 : Expression) (t v1 v2 : Value) 
-   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B) (id id1 id2 : nat)
-(Hypo1 : |env, id, e1, eff| -e> | id + id1, inl v1, eff ++ eff1|)
-(Hypo2 : |env, id + id2, e1, eff ++ eff2| -e> | id + id2 + id1, inl v1, eff ++ eff2 ++ eff1|)
-(Hypo1' : |env, id, e2, eff| -e> | id + id2, inl v2, eff ++ eff2|)
-(Hypo2' : |env, id + id1, e2, eff ++ eff1| -e> | id + id1 + id2, inl v2, eff ++ eff1 ++ eff2|) :
-|env, id, ELet [(A, e1); (B, e2)]
-     (ECall "+"%string [EVar A ; EVar B]), eff| -e> | id + id1 + id2, inl t, eff ++ eff1 ++ eff2|
-->
-|env, id, ELet [(A, e2); (B, e1)]
-     (ECall "+"%string [EVar A ; EVar B]), eff| -e> | id + id2 + id1, inl t, eff ++ eff2 ++ eff1|.
-Proof.
-  intros.
-  (* FROM LET HYPO *)
-  inversion H. subst. simpl in H3, H4, H2.
-  pose (EE1 := element_exist 1 vals H2). inversion EE1 as [v1']. inversion H0. subst. inversion H2.
-  pose (EE2 := element_exist 0 x H5). inversion EE2 as [v2']. inversion H1. subst. inversion H2.
-  apply eq_sym, length_zero_iff_nil in H8. subst.
-  pose (EE3 := element_exist _ _ H3). inversion EE3 as [eff1']. inversion H6. subst. inversion H3.
-  pose (EE4 := element_exist _ _ H9). inversion EE4 as [eff2']. inversion H8. subst. inversion H3.
-  apply eq_sym, length_zero_iff_nil in H11. subst.
-  pose (EE5 := element_exist _ _ H4). inversion EE5 as [id1']. inversion H10. subst. inversion H4.
-  pose (EE6 := element_exist _ _ H13). inversion EE6 as [id2']. inversion H11. subst. inversion H4.
-  apply eq_sym, length_zero_iff_nil in H15. subst.
-  clear dependent H2. clear dependent H4. clear dependent H3.
-  clear dependent H9. clear dependent H13. clear dependent H5.
-  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = eff1 /\ eff2' = eff2).
-  { *)
-    pose (P1 := H7 0 Nat.lt_0_2).
-    pose (P2 := H7 1 Nat.lt_1_2).
-    pose (D1 := determinism Hypo1 _ _ _ P1).
-    destruct D1. destruct H3. inversion H2. simpl in H3, H4. subst.
-    pose (D2 := determinism Hypo2' _ _ _ P2).
-    destruct D2. destruct H4. inversion H3. simpl in H4, H5. subst.
-  (* } *)
-
-  (* Deconstruct call *)
-
-  inversion H12. subst.
-  pose (EE1' := element_exist 1 vals H9). inversion EE1' as [v1''].
-  inversion H4. subst. inversion H9.
-  pose (EE2' := element_exist 0 x H16). inversion EE2' as [v2''].
-  inversion H5. subst. inversion H9.
-  apply eq_sym, length_zero_iff_nil in H19. subst.
-  pose (EE3' := element_exist _ _ H13). inversion EE3' as [eff1'']. inversion H17. subst. inversion H13.
-  pose (EE4' := element_exist _ _ H20). inversion EE4' as [eff2'']. inversion H19. subst. inversion H13.
-  apply eq_sym, length_zero_iff_nil in H22. subst.
-  pose (EE5' := element_exist _ _ H14). inversion EE5' as [id1'']. inversion H21. subst. inversion H14.
-  pose (EE6' := element_exist _ _ H24). inversion EE6' as [id2'']. inversion H22. subst. inversion H14.
-  apply eq_sym, length_zero_iff_nil in H26. subst.
-  clear dependent H13. clear dependent H10. clear dependent H21.
-  clear dependent H14. clear dependent H16. clear dependent H20.
-  clear dependent H23. clear P1. clear dependent P2.
-  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
-  { *)
-    pose (P1 := H15 0 Nat.lt_0_2).
-    pose (P2 := H15 1 Nat.lt_1_2).
-    inversion P1.
-    inversion P2.
-    simpl in H30, H31, H32, H33. subst.
-    simpl in H16, H29.
-    rewrite get_value_here in H29. inversion H29.
-    rewrite get_value_there in H16. rewrite get_value_here in H16. inversion H16.
-    simpl in H21, H25.
-    subst.
-    2: congruence.
-  (* } *)
-
-  (* construct derivation tree *)
-  apply eval_let with (vals := [v2'; v1']) (eff := [eff ++ eff2; eff ++ eff2 ++ eff1]) (eff2 := eff ++ eff2 ++ eff1) 
-                      (ids := [(id + id2)%nat; (id + id2 + id1)%nat]); auto.
-  * intros. inversion H10. 2: inversion H14.
-    - simpl. exact Hypo2.
-    - simpl. exact Hypo1'.
-    - inversion H21.
-  * apply eval_call with (vals := [v2'; v1']) (eff := [eff ++ eff2 ++ eff1;eff ++ eff2 ++ eff1])
-                             (ids := [(id + id2 + id1)%nat; (id + id2 + id1)%nat]); auto.
-    - intros. inversion H10. 2: inversion H14.
-      + apply eval_var. simpl. rewrite get_value_here. reflexivity.
-      + simpl. apply eval_var. rewrite get_value_there. rewrite get_value_here. auto. congruence.
-      + inversion H21.
-    - simpl last in *. apply (plus_comm_basic_value _ _ H18).
-Qed.
-
-Example let_1_comm_2_list_alt_eq (env: Environment) (e1 e2 : Expression) (t v1 v2 : Value) 
-   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B) (id id1 id2 : nat)
-(Hypo1 : |env, id, e1, eff| -e> | id + id1, inl v1, eff ++ eff1|)
-(Hypo2 : |env, id + id2, e1, eff ++ eff2| -e> | id + id2 + id1, inl v1, eff ++ eff2 ++ eff1|)
-(Hypo1' : |env, id, e2, eff| -e> | id + id2, inl v2, eff ++ eff2|)
-(Hypo2' : |env, id + id1, e2, eff ++ eff1| -e> | id + id1 + id2, inl v2, eff ++ eff1 ++ eff2|) :
-|env, id, ELet [(A, e1); (B, e2)]
-     (ECall "+"%string [EVar A ; EVar B]), eff| -e> | id + id1 + id2, inl t, eff ++ eff1 ++ eff2|
-<->
-|env, id, ELet [(A, e2); (B, e1)]
-     (ECall "+"%string [EVar A ; EVar B]), eff| -e> | id + id2 + id1, inl t, eff ++ eff2 ++ eff1|.
-Proof.
-  split.
-  * apply let_1_comm_2_list_alt with (v1 := v1) (v2 := v2); assumption.
-  * apply let_1_comm_2_list_alt with (v1 := v2) (v2 := v1); assumption.
-Qed.
-
-Example let_1_binding_swap_2_list_alt (env: Environment) (e1 e2 : Expression) (t v1 v2 : Value) 
-   (eff eff1 eff2 : SideEffectList) (A B : Var) (VarHyp : A <> B) (id id1 id2 : nat)
-(Hypo1 : |env, id, e1, eff| -e> | id + id1, inl v1, eff ++ eff1|)
-(Hypo2 : |env, id + id2, e1, eff ++ eff2| -e> | id + id2 + id1, inl v1, eff ++ eff2 ++ eff1|)
-(Hypo1' : |env, id, e2, eff| -e> | id + id2, inl v2, eff ++ eff2|)
-(Hypo2' : |env, id + id1, e2, eff ++ eff1| -e> | id + id1 + id2, inl v2, eff ++ eff1 ++ eff2|) :
-|env, id, ELet [(A, e1); (B, e2)]
-     (ECall "+"%string [EVar A ; EVar B]), eff| -e> | id + id1 + id2, inl t, eff ++ eff1 ++ eff2|
-<->
-|env, id, ELet [(B, e2); (A, e1)]
-     (ECall "+"%string [EVar B ; EVar A]), eff| -e> | id + id2 + id1, inl t, eff ++ eff2 ++ eff1|.
-Proof.
-  split.
-  * intros.
-  (* FROM LET HYPO *)
-  inversion H. subst. simpl in H3, H4, H2.
-  pose (EE1 := element_exist 1 vals H2). inversion EE1 as [v1']. inversion H0. subst. inversion H2.
-  pose (EE2 := element_exist 0 x H5). inversion EE2 as [v2']. inversion H1. subst. inversion H2.
-  apply eq_sym, length_zero_iff_nil in H8. subst.
-  pose (EE3 := element_exist _ _ H3). inversion EE3 as [eff1']. inversion H6. subst. inversion H3.
-  pose (EE4 := element_exist _ _ H9). inversion EE4 as [eff2']. inversion H8. subst. inversion H3.
-  apply eq_sym, length_zero_iff_nil in H11. subst.
-  pose (EE5 := element_exist _ _ H4). inversion EE5 as [id1']. inversion H10. subst. inversion H4.
-  pose (EE6 := element_exist _ _ H13). inversion EE6 as [id2']. inversion H11. subst. inversion H4.
-  apply eq_sym, length_zero_iff_nil in H15. subst.
-  clear dependent H2. clear dependent H4. clear dependent H3.
-  clear dependent H9. clear dependent H13. clear dependent H5.
-  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = eff1 /\ eff2' = eff2).
-  { *)
-    pose (P1 := H7 0 Nat.lt_0_2).
-    pose (P2 := H7 1 Nat.lt_1_2).
-    pose (D1 := determinism Hypo1 _ _ _ P1).
-    destruct D1. destruct H3. inversion H2. simpl in H3, H4. subst.
-    pose (D2 := determinism Hypo2' _ _ _ P2).
-    destruct D2. destruct H4. inversion H3. simpl in H4, H5. subst.
-  (* } *)
-
-  (* Deconstruct call *)
-
-  inversion H12. subst.
-  pose (EE1' := element_exist 1 vals H9). inversion EE1' as [v1''].
-  inversion H4. subst. inversion H9.
-  pose (EE2' := element_exist 0 x H16). inversion EE2' as [v2''].
-  inversion H5. subst. inversion H9.
-  apply eq_sym, length_zero_iff_nil in H19. subst.
-  pose (EE3' := element_exist _ _ H13). inversion EE3' as [eff1'']. inversion H17. subst. inversion H13.
-  pose (EE4' := element_exist _ _ H20). inversion EE4' as [eff2'']. inversion H19. subst. inversion H13.
-  apply eq_sym, length_zero_iff_nil in H22. subst.
-  pose (EE5' := element_exist _ _ H14). inversion EE5' as [id1'']. inversion H21. subst. inversion H14.
-  pose (EE6' := element_exist _ _ H24). inversion EE6' as [id2'']. inversion H22. subst. inversion H14.
-  apply eq_sym, length_zero_iff_nil in H26. subst.
-  clear dependent H13. clear dependent H9. clear dependent H20.
-  clear dependent H14. clear dependent H16. clear dependent H22.
-  clear dependent H24. clear P1. clear dependent P2.
-  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
-  { *)
-    pose (P1 := H15 0 Nat.lt_0_2).
-    pose (P2 := H15 1 Nat.lt_1_2).
-    inversion P1.
-    inversion P2.
-    simpl in H30, H31, H32, H33. subst.
-    simpl in H23. subst.
-    simpl in H29, H16.
-    rewrite get_value_here in H29. inversion H29.
-    rewrite get_value_there in H16. rewrite get_value_here in H16. inversion H16.
-    simpl in H22, H25.
-    subst.
-    2: congruence.
-  (* } *)
-
-  (* construct derivation tree *)
-  apply eval_let with (vals := [v2'; v1']) (eff := [eff ++ eff2; eff ++ eff2 ++ eff1]) (eff2 := eff ++ eff2 ++ eff1) 
-                      (ids := [(id + id2)%nat; (id + id2 + id1)%nat]); auto.
-  - intros. inversion H9. 2: inversion H14.
-    + simpl. exact Hypo2.
-    + assumption.
-    + inversion H23.
-  - apply eval_call with (vals := [v2'; v1']) (eff := [eff ++ eff2 ++ eff1; eff ++ eff2 ++ eff1])
-                             (ids := [(id + id2 + id1)%nat; (id + id2 + id1)%nat]); auto.
-    + intros. inversion H9. 2: inversion H14.
-      ** simpl.
-         apply eval_var.
-         rewrite get_value_here.
-         auto.
-      ** simpl.
-         apply eval_var.
-         rewrite get_value_there. rewrite get_value_here. auto. congruence.
-      ** inversion H23.
-    + simpl last in *.
-      apply (plus_comm_basic_value _ _ H18).
-  * intros.
-  (* FROM LET HYPO *)
-  inversion H. subst. simpl in H3, H4, H2.
-  pose (EE1 := element_exist 1 vals H2). inversion EE1 as [v2']. inversion H0. subst. inversion H2.
-  pose (EE2 := element_exist 0 x H5). inversion EE2 as [v1']. inversion H1. subst. inversion H2.
-  apply eq_sym, length_zero_iff_nil in H8. subst.
-  pose (EE3 := element_exist _ _ H3). inversion EE3 as [eff2']. inversion H6. subst. inversion H3.
-  pose (EE4 := element_exist _ _ H9). inversion EE4 as [eff1']. inversion H8. subst. inversion H3.
-  apply eq_sym, length_zero_iff_nil in H11. subst.
-  pose (EE5 := element_exist _ _ H4). inversion EE5 as [id2']. inversion H10. subst. inversion H4.
-  pose (EE6 := element_exist _ _ H13). inversion EE6 as [id1']. inversion H11. subst. inversion H4.
-  apply eq_sym, length_zero_iff_nil in H15. subst.
-  clear dependent H2. clear dependent H4. clear dependent H3.
-  clear dependent H9. clear dependent H13. clear dependent H5.
-  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = eff1 /\ eff2' = eff2).
-  { *)
-    pose (P1 := H7 0 Nat.lt_0_2).
-    pose (P2 := H7 1 Nat.lt_1_2).
-    pose (D1 := determinism Hypo1' _ _ _ P1).
-    destruct D1. destruct H3. inversion H2. simpl in H3, H4. subst.
-    pose (D2 := determinism Hypo2 _ _ _ P2).
-    destruct D2. destruct H4. inversion H3. simpl in H4, H5. subst.
-  (* } *)
-
-  (* Deconstruct call *)
-
-  inversion H12. subst.
-  pose (EE1' := element_exist 1 vals H9). inversion EE1' as [v2''].
-  inversion H4. subst. inversion H9.
-  pose (EE2' := element_exist 0 x H16). inversion EE2' as [v1''].
-  inversion H5. subst. inversion H9.
-  apply eq_sym, length_zero_iff_nil in H19. subst.
-  pose (EE3' := element_exist _ _ H13). inversion EE3' as [eff2'']. inversion H17. subst. inversion H13.
-  pose (EE4' := element_exist _ _ H20). inversion EE4' as [eff1'']. inversion H19. subst. inversion H13.
-  apply eq_sym, length_zero_iff_nil in H22. subst.
-  pose (EE5' := element_exist _ _ H14). inversion EE5' as [id2'']. inversion H21. subst. inversion H14.
-  pose (EE6' := element_exist _ _ H24). inversion EE6' as [id1'']. inversion H22. subst. inversion H14.
-  apply eq_sym, length_zero_iff_nil in H26. subst.
-  clear dependent H13. clear dependent H10. clear dependent H20.
-  clear dependent H14. clear dependent H16. clear dependent H21.
-  clear dependent H24. clear P1. clear dependent P2.
-  (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
-  { *)
-    pose (P1 := H15 0 Nat.lt_0_2).
-    pose (P2 := H15 1 Nat.lt_1_2).
-    inversion P1.
-    inversion P2.
-    simpl in H30, H31, H32, H33. subst.
-    simpl in H23.
-    simpl in H16, H29.
-    simpl in H21, H25.
-    rewrite get_value_here in H29. inversion H29.
-    rewrite get_value_there in H16. rewrite get_value_here in H16. inversion H16.
-    subst.
-    2: congruence.
-  (* } *)
-
-  (* construct derivation tree *)
-  apply eval_let with (vals := [v1'; v2']) (eff := [eff ++ eff1; eff ++ eff1 ++ eff2]) (eff2 := eff ++ eff1 ++ eff2) 
-                      (ids := [(id + id1)%nat; (id + id1 + id2)%nat]); auto.
-  - intros. inversion H10. 2: inversion H14.
-    + simpl. exact Hypo2'.
-    + assumption.
-    + inversion H23.
-  - simpl. apply eval_call with (vals := [v1'; v2']) (eff := [eff ++ eff1 ++ eff2;eff ++ eff1 ++ eff2])
-                             (ids := [(id + id1 + id2)%nat; (id + id1 + id2)%nat]); auto.
-    + intros. inversion H10. 2: inversion H14.
-      ** simpl.
-         apply eval_var.
-         rewrite get_value_here.
-         auto.
-      ** simpl.
-         apply eval_var.
-         rewrite get_value_there. rewrite get_value_here. auto. congruence.
-      ** inversion H23.
-    + simpl last in *.
-      apply (plus_comm_basic_value _ _ H18).
-Qed.
-
 Example let_2_apply_effect_free (env: Environment)(e1 e2 exp : Expression) (v1 v2 : Value) 
-       (v0 t : Value + Exception) (A B : Var) (VarHyp : A <> B) (id : nat) (eff : SideEffectList)
+       (v0 t : ValueSequence + Exception) (A B : Var) (VarHyp : A <> B) (id: nat) (eff : SideEffectList)
 (E1 : | append_vars_to_env [A] [v1] (append_vars_to_env [B] [v2] env), id, exp, eff | -e> |id, v0, eff|)
 (E2 : | append_vars_to_env [B] [v2] (append_vars_to_env [A] [v1] env), id, exp, eff | -e> |id, v0, eff|)
     :
-  |env, id, e2, eff| -e> |id, inl v2, eff| -> 
-  |append_vars_to_env [A] [v1] env, id, e2, eff| -e> | id, inl v2, eff| ->
-  |env, id, e1, eff| -e> | id, inl v1, eff| -> 
-  |append_vars_to_env [B] [v2] env, id, e1, eff| -e> | id, inl v1, eff|
+  |env, id, e2, eff | -e> |id, inl [v2], eff| -> 
+  |append_vars_to_env [A] [v1] env, id, e2, eff| -e> | id, inl [v2], eff| ->
+  |env, id, e1, eff | -e> | id, inl [v1], eff| -> 
+  |append_vars_to_env [B] [v2] env, id, e1, eff| -e> | id , inl [v1], eff |
 ->
-  |env, id, ELet [(A, e1)] (ELet [(B, e2)] 
-        (EApp exp [EVar A ; EVar B])), eff| -e> |id, t, eff|
+  |env, id, ELet [A] e1 (ELet [B] e2
+        (EApp exp [^EVar A ; ^EVar B])), eff| -e> |id , t, eff|
   <->
-  |env, id, ELet [(B, e2)] (ELet [(A, e1)]
-        (EApp exp [EVar A ; EVar B])), eff| -e> |id, t, eff|
+  |env, id, ELet [B] e2 (ELet [A] e1
+        (EApp exp [^EVar A ; ^EVar B])), eff| -e> |id, t, eff |
 .
 Proof.
   split;intros.
    (** Deconstruct ELet-s *)
-  * inversion H3. subst.
-    pose (EE1 := element_exist 0 vals H6). inversion EE1 as [v1'].
-    inversion H4. subst. inversion H6.
-    apply eq_sym, length_zero_iff_nil in H9. subst.
-    pose (EE2 := element_exist 0 _ H7). inversion EE2 as [eff1'].
-    inversion H5. subst. inversion H7.
-    apply eq_sym, length_zero_iff_nil in H10. subst.
-    pose (EE3 := element_exist 0 _ H8). inversion EE3 as [id1'].
-    inversion H9. subst. inversion H8.
-    apply eq_sym, length_zero_iff_nil in H12. subst.
+  * inversion H3. inversion H7. subst.
+    pose (EE1 := element_exist 0 vals H22). inversion EE1 as [v1'].
+    inversion H4. subst. inversion H22.
+    apply eq_sym, length_zero_iff_nil in H6. subst.
     (* assert (v1' = v1 /\ eff1' = []).
     { *)
-      pose (P := H11 0 Nat.lt_0_1).
-      pose (WD := determinism H1 _ _ _ P). destruct WD. destruct H12. inversion H10.
-      simpl in H13, H12.
+      pose (WD := eval_expr_determinism H1 _ _ _ H17). destruct WD. destruct H6. inversion H5.
       subst.
     (* } *)
-    inversion H16. subst.
-    pose (EE4 := element_exist 0 vals H14).
-    inversion EE4 as [v2']. inversion H12. subst. inversion H14.
-    apply eq_sym, length_zero_iff_nil in H18. subst.
-    pose (EE5 := element_exist _ _ H15).
-    inversion EE5 as [eff2']. inversion H13. subst.
-    inversion H15.
-    apply eq_sym, length_zero_iff_nil in H19. subst.
-    pose (EE6 := element_exist _ _ H17). inversion EE6 as [id2']. 
-    inversion H18. subst.
-    inversion H17. apply eq_sym, length_zero_iff_nil in H21. subst.
-    clear dependent H14. clear dependent H15. clear dependent H17.
-    clear dependent P.
+    inversion H23. inversion H10. subst.
+    pose (EE4 := element_exist 0 vals H28).
+    inversion EE4 as [v2']. inversion H6. subst. inversion H28.
+    apply eq_sym, length_zero_iff_nil in H9. subst.
     (* assert (v2' = v2 /\ eff2' = []). 
     { *)
-      pose (P := H20 0 Nat.lt_0_1).
-      pose (WD := determinism H0 _ _ _ P). destruct WD. destruct H15.
-      inversion H14.
-      simpl in H15, H17.
+      pose (WD := eval_expr_determinism H0 _ _ _ H21). destruct WD. destruct H9.
+      inversion H8.
       subst.
     (* } *)
-    apply eval_let with (vals := [v2']) (eff := [eff2']) (eff2 := eff2') (ids := [id2']); auto.
-     - intros. inversion H15.
-       + assumption.
-       + inversion H19.
-     - apply eval_let with (vals := [v1']) (eff := [eff2']) (eff2 := eff2') (ids := [id2']); auto.
-       + intros. inversion H15.
-         ** assumption.
-         ** inversion H19.
+    eapply eval_single, eval_let; auto.
+     - exact H.
+     - auto.
+     - eapply eval_single, eval_let; auto.
+       + exact H2.
+       + auto.
      (** Destruct application hypothesis *)
-       + inversion H25; subst.
-         ** pose (WD3 := determinism E2 _ _ _ H21). destruct WD3.
-            inversion H15. destruct H17. subst.
-            pose (EEA := element_exist _ _ H19).
-            inversion EEA as [v1'']. inversion H15. subst. inversion H19. 
-            pose (EEA2 := element_exist _ _ H27).
-            inversion EEA2 as [v2'']. inversion H17. subst. inversion H19.
-            apply eq_sym, length_zero_iff_nil in H30. subst.
-            pose (EEE := element_exist _ _ H23).
-            inversion EEE as [eff1'']. inversion H29. subst. inversion H23.
-            pose (EEE2 := element_exist _ _ H31).
-            inversion EEE2 as [eff2'']. inversion H30. subst. inversion H23.
+       + inversion H29. inversion H13; subst.
+         ** pose (WD3 := eval_expr_determinism E2 _ _ _ H25). destruct WD3.
+            inversion H9. destruct H11. subst.
+            pose (EEA := element_exist _ _ H24).
+            inversion EEA as [v1'']. inversion H9. subst. inversion H24.
+            pose (EEA2 := element_exist _ _ H14).
+            inversion EEA2 as [v2'']. inversion H11. subst. inversion H24.
+            apply eq_sym, length_zero_iff_nil in H16. subst.
+            pose (EEE := element_exist _ _ H27).
+            inversion EEE as [eff1'']. inversion H15. subst. inversion H27.
+            pose (EEE2 := element_exist _ _ H18).
+            inversion EEE2 as [eff2'']. inversion H16. subst. inversion H27.
+            apply eq_sym, length_zero_iff_nil in H20. subst.
+            pose (EEI := element_exist _ _ H30).
+            inversion EEI as [id1'']. inversion H19. subst. inversion H30.
+            pose (EEI2 := element_exist _ _ H31).
+            inversion EEI2 as [id2'']. inversion H20. subst. inversion H30.
             apply eq_sym, length_zero_iff_nil in H34. subst.
-            pose (EEI := element_exist _ _ H24).
-            inversion EEI as [id1'']. inversion H32. subst. inversion H24.
-            pose (EEI2 := element_exist _ _ H35).
-            inversion EEI2 as [id2'']. inversion H34. subst. inversion H24.
-            apply eq_sym, length_zero_iff_nil in H37. subst.
-            clear dependent H19. clear dependent H35. clear dependent H23.
-            clear dependent H29. clear dependent H32. clear dependent H31.
-            clear dependent P.
+            clear dependent H24. clear dependent H14. clear dependent H27.
+            clear dependent H18. clear dependent H30. clear dependent H31.
             (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
             { *)
-              pose (P := H28 0 Nat.lt_0_2).
-              inversion P.
-              simpl in H29, H23, H35, H31, H32, H36, H37. subst.
-              rewrite get_value_there in H31. 2: congruence. 
-              rewrite get_value_here in H31.
-              inversion H31.
+              pose (P := H33 0 Nat.lt_0_2).
+              inversion P. inversion H27.
+              simpl in H40, H41, H42, H43, H39, H37. subst.
+              rewrite get_value_there in H39. 2: congruence. 
+              rewrite get_value_here in H39.
+              inversion H39.
               subst.
 
-              pose (P2 := H28 1 Nat.lt_1_2).
-              inversion P2.
-              simpl in H23, H29, H32, H35, H36, H37, H38.
-              rewrite get_value_here in H32. inversion H32.
+              pose (P2 := H33 1 Nat.lt_1_2).
+              inversion P2. inversion H30.
+              simpl in H42, H43, H44, H45, H41, H40.
+              rewrite get_value_here in H41. inversion H41.
               subst.
+
             (* } *)
-            eapply eval_app with (vals := [v1'; v2']) (eff := [eff2''; eff2''])
+            eapply eval_single, eval_app with (vals := [v1'; v2']) (eff := [eff2''; eff2''])
                                    (ids := [id2'';id2'']); auto.
             -- exact E1.
             -- auto.
-            -- intros. inversion H19. 2: inversion H29.
-              ++ simpl. apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
-              ++ simpl. apply eval_var. rewrite get_value_here. auto.
-              ++ inversion H36.
-            -- exact H33.
-         ** eapply eval_app_closure_ex; try(reflexivity).
-            -- pose (WD := determinism E2 _ _ _ H27). destruct WD. destruct H17. subst.
+            -- intros. inversion H14. 2: inversion H24.
+              ++ simpl. apply eval_single, eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+              ++ simpl. eapply eval_single, eval_var. rewrite get_value_here. auto.
+              ++ inversion H32.
+            -- simpl in H38. exact H38.
+         ** eapply eval_single, eval_app_closure_ex; try(reflexivity).
+            -- pose (WD := eval_expr_determinism E2 _ _ _ H32). destruct WD. destruct H11. subst.
                exact E1.
-         ** inversion H19.
-            -- pose (EEA := element_exist _ _  (eq_sym H17)). inversion EEA as [v1''].
-               inversion H15. subst.
-               inversion H17. apply length_zero_iff_nil in H26. subst. 
-               simpl in H33. inversion H33.
-               rewrite get_value_here in H29. congruence.
-            -- inversion H17.
-              ++ rewrite H26 in *. simpl in H33. inversion H33.
-               rewrite get_value_there, get_value_here in H30; congruence.
-              ++ inversion H26.
-         ** pose (WD := determinism E2 _ _ _ H23).
-            destruct WD. destruct H17.
+         ** inversion H24.
+            -- pose (EEA := element_exist _ _  (eq_sym H11)). inversion EEA as [v1''].
+               inversion H9. subst.
+               inversion H11. apply length_zero_iff_nil in H14. subst. 
+               simpl in H38. inversion H38. inversion H16. subst.
+               rewrite get_value_here in H35. congruence.
+            -- inversion H11.
+              ++ rewrite H14 in *. simpl in H38. inversion H38. inversion H18.
+               rewrite get_value_there, get_value_here in H36; congruence.
+              ++ inversion H14.
+         ** pose (WD := eval_expr_determinism E2 _ _ _ H27).
+            destruct WD. destruct H11.
             subst.
-            eapply eval_app_badfun_ex with (vals := [v1'; v2']) (eff := [last eff eff2; last eff eff2])
-                                              (ids := [id';id']); auto.
+            eapply eval_single, eval_app_badfun_ex with (vals := [v1'; v2']) (eff := [eff2; eff2])
+                                              (ids := [id'0;id'0]); auto.
            -- exact E1.
-           -- intros. inversion H15. 2: inversion H29.
+           -- intros. inversion H9. 2: inversion H15.
               ++ simpl.
-                 apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
-              ++ simpl.
-                 rewrite H27.
-                 apply eval_var. rewrite get_value_here. auto.
-              ++ inversion H31.
-         ** pose (WD := determinism E2 _ _ _ H23).
-            inversion WD. destruct H17. subst.
-            eapply eval_app_badarity_ex with (vals := [v1'; v2']) (eff := [last eff eff2;last eff eff2])
-                                   (ids := [id'; id']); auto.
+                 apply eval_single, eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+              ++ simpl. rewrite H12, H11.
+                 apply eval_single, eval_var. rewrite get_value_here. auto.
+              ++ inversion H18.
+         ** pose (WD := eval_expr_determinism E2 _ _ _ H27).
+            inversion WD. destruct H11. subst.
+            eapply eval_single, eval_app_badarity_ex with (vals := [v1'; v2']) (eff := [eff2;eff2])
+                                   (ids := [id'0; id'0]); auto.
            -- exact E1.
-           -- intros. inversion H15. 2: inversion H29.
+           -- intros. inversion H9. 2: inversion H15.
               ++ simpl.
-                 apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+                 apply eval_single, eval_var. rewrite get_value_there, get_value_here. auto. congruence.
               ++ simpl.
-                 rewrite H27.
-                 apply eval_var. rewrite get_value_here. auto.
-              ++ inversion H31.
-           -- rewrite <- H19 in H26. auto.
-      - subst. inversion H14.
-        rewrite H13 in *.
-        apply length_zero_iff_nil in H13.
-        apply length_zero_iff_nil in H18.
-        apply length_zero_iff_nil in H17. subst.
-        pose (WD := determinism H0 _ _ _ H26).
-        destruct WD. destruct H13. inversion H12.
-        inversion H13.
-      - subst. inversion H6. rewrite H5 in *.
-        apply length_zero_iff_nil in H9.
-        apply length_zero_iff_nil in H8.
-        apply length_zero_iff_nil in H5. subst.
-        pose (WD := determinism H1 _ _ _ H17).
-        destruct WD. inversion H4.
-        inversion H5.
-    * inversion H3. subst.
-    pose (EE1 := element_exist 0 vals H6). inversion EE1 as [v2'].
-    inversion H4. subst. inversion H6.
-    apply eq_sym, length_zero_iff_nil in H9. subst.
-    pose (EE2 := element_exist 0 _ H7). inversion EE2 as [eff2'].
-    inversion H5. subst. inversion H7.
-    apply eq_sym, length_zero_iff_nil in H10. subst.
-    pose (EE3 := element_exist 0 _ H8). inversion EE3 as [id2'].
-    inversion H9. subst. inversion H8.
-    apply eq_sym, length_zero_iff_nil in H12. subst.
+                 rewrite H12, H11.
+                 apply eval_single, eval_var. rewrite get_value_here. auto.
+              ++ inversion H18.
+           -- rewrite <- H24 in H31. auto.
+      - subst.
+        pose (WD := eval_expr_determinism H0 _ _ _ H27).
+        destruct WD. destruct H8. inversion H6.
+      - subst.
+        pose (WD := eval_expr_determinism H1 _ _ _ H21).
+        destruct WD. inversion H5.
+        inversion H4.
+    * inversion H3. inversion H7. subst.
+    pose (EE1 := element_exist 0 vals H22). inversion EE1 as [v1'].
+    inversion H4. subst. inversion H22.
+    apply eq_sym, length_zero_iff_nil in H6. subst.
     (* assert (v1' = v1 /\ eff1' = []).
     { *)
-      pose (P := H11 0 Nat.lt_0_1).
-      pose (WD := determinism H _ _ _ P). destruct WD. destruct H12. inversion H10.
-      simpl in H13, H12.
+      pose (WD := eval_expr_determinism H _ _ _ H17). destruct WD. destruct H6. inversion H5.
       subst.
     (* } *)
-    inversion H16. subst.
-    pose (EE4 := element_exist 0 vals H14).
-    inversion EE4 as [v1']. inversion H12. subst. inversion H14.
-    apply eq_sym, length_zero_iff_nil in H18. subst.
-    pose (EE5 := element_exist _ _ H15).
-    inversion EE5 as [eff1']. inversion H13. subst.
-    inversion H15.
-    apply eq_sym, length_zero_iff_nil in H19. subst.
-    pose (EE6 := element_exist _ _ H17). inversion EE6 as [id1']. 
-    inversion H18. subst.
-    inversion H17. apply eq_sym, length_zero_iff_nil in H21. subst.
-    clear dependent H14. clear dependent H15. clear dependent H17.
-    clear dependent P.
+    inversion H23. inversion H10. subst.
+    pose (EE4 := element_exist 0 vals H28).
+    inversion EE4 as [v2']. inversion H6. subst. inversion H28.
+    apply eq_sym, length_zero_iff_nil in H9. subst.
     (* assert (v2' = v2 /\ eff2' = []). 
     { *)
-      pose (P := H20 0 Nat.lt_0_1).
-      pose (WD := determinism H2 _ _ _ P). destruct WD. destruct H15.
-      inversion H14.
-      simpl in H15, H17.
+      pose (WD := eval_expr_determinism H2 _ _ _ H21). destruct WD. destruct H9.
+      inversion H8.
       subst.
     (* } *)
-    apply eval_let with (vals := [v1']) (eff := [eff1']) (eff2 := eff1') (ids := [id1']); auto.
-     - intros. inversion H15.
-       + assumption.
-       + inversion H19.
-     - apply eval_let with (vals := [v2']) (eff := [eff1']) (eff2 := eff1') (ids := [id1']); auto.
-       + intros. inversion H15.
-         ** assumption.
-         ** inversion H19.
+    eapply eval_single, eval_let; auto.
+     - exact H1.
+     - auto.
+     - eapply eval_single, eval_let; auto.
+       + exact H0.
+       + auto.
      (** Destruct application hypothesis *)
-       + inversion H25; subst.
-         ** pose (WD3 := determinism E1 _ _ _ H21). destruct WD3.
-            inversion H15. destruct H17. subst.
-            pose (EEA := element_exist _ _ H19).
-            inversion EEA as [v1'']. inversion H15. subst. inversion H19. 
-            pose (EEA2 := element_exist _ _ H27).
-            inversion EEA2 as [v2'']. inversion H17. subst. inversion H19.
-            apply eq_sym, length_zero_iff_nil in H30. subst.
-            pose (EEE := element_exist _ _ H23).
-            inversion EEE as [eff1'']. inversion H29. subst. inversion H23.
-            pose (EEE2 := element_exist _ _ H31).
-            inversion EEE2 as [eff2'']. inversion H30. subst. inversion H23.
+       + inversion H29. inversion H13; subst.
+         ** pose (WD3 := eval_expr_determinism E1 _ _ _ H25). destruct WD3.
+            inversion H9. destruct H11. subst.
+            pose (EEA := element_exist _ _ H24).
+            inversion EEA as [v1'']. inversion H9. subst. inversion H24.
+            pose (EEA2 := element_exist _ _ H14).
+            inversion EEA2 as [v2'']. inversion H11. subst. inversion H24.
+            apply eq_sym, length_zero_iff_nil in H16. subst.
+            pose (EEE := element_exist _ _ H27).
+            inversion EEE as [eff1'']. inversion H15. subst. inversion H27.
+            pose (EEE2 := element_exist _ _ H18).
+            inversion EEE2 as [eff2'']. inversion H16. subst. inversion H27.
+            apply eq_sym, length_zero_iff_nil in H20. subst.
+            pose (EEI := element_exist _ _ H30).
+            inversion EEI as [id1'']. inversion H19. subst. inversion H30.
+            pose (EEI2 := element_exist _ _ H31).
+            inversion EEI2 as [id2'']. inversion H20. subst. inversion H30.
             apply eq_sym, length_zero_iff_nil in H34. subst.
-            pose (EEI := element_exist _ _ H24).
-            inversion EEI as [id1'']. inversion H32. subst. inversion H24.
-            pose (EEI2 := element_exist _ _ H35).
-            inversion EEI2 as [id2'']. inversion H34. subst. inversion H24.
-            apply eq_sym, length_zero_iff_nil in H37. subst.
-            clear dependent H19. clear dependent H35. clear dependent H23.
-            clear dependent H29. clear dependent H32. clear dependent H31.
-            clear dependent P.
+            clear dependent H24. clear dependent H14. clear dependent H27.
+            clear dependent H18. clear dependent H30. clear dependent H31.
             (* assert (v1' = v1 /\ v2' = v2 /\ eff1' = [] /\ eff2' = []).
             { *)
-              pose (P := H28 0 Nat.lt_0_2).
-              inversion P.
-              simpl in H29, H23, H35, H31, H32, H36, H37. subst.
-              rewrite get_value_here in H31.
-              inversion H31.
+              pose (P := H33 0 Nat.lt_0_2).
+              inversion P. inversion H27.
+              simpl in H40, H41, H42, H43, H39, H37. subst.
+              rewrite get_value_here in H39.
+              inversion H39.
               subst.
 
-              pose (P2 := H28 1 Nat.lt_1_2).
-              inversion P2.
-              simpl in H23, H29, H32, H35, H36, H37, H38.
-              rewrite get_value_there, get_value_here in H32. inversion H32.
-              2: congruence.
+              pose (P2 := H33 1 Nat.lt_1_2).
+              inversion P2. inversion H30.
+              simpl in H42, H43, H44, H45, H41, H40.
+              rewrite get_value_there in H41. 2: congruence. 
+              rewrite get_value_here in H41. inversion H41.
               subst.
+
             (* } *)
-            eapply eval_app with (vals := [v1'; v2']) (eff := [eff2''; eff2''])
+            eapply eval_single, eval_app with (vals := [v2'; v1']) (eff := [eff2''; eff2''])
                                    (ids := [id2'';id2'']); auto.
             -- exact E2.
             -- auto.
-            -- intros. inversion H19. 2: inversion H29.
-              ++ simpl. apply eval_var. rewrite get_value_here. auto.
-              ++ simpl. apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
-              ++ inversion H36.
-            -- exact H33.
-         ** eapply eval_app_closure_ex; try(reflexivity).
-            -- pose (WD := determinism E1 _ _ _ H27). destruct WD. destruct H17. subst.
+            -- intros. inversion H14. 2: inversion H24.
+              ++ simpl. apply eval_single, eval_var. rewrite get_value_here. auto.
+              ++ simpl. eapply eval_single, eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+              ++ inversion H32.
+            -- simpl in H38. exact H38.
+         ** eapply eval_single, eval_app_closure_ex; try(reflexivity).
+            -- pose (WD := eval_expr_determinism E1 _ _ _ H32). destruct WD. destruct H11. subst.
                exact E2.
-         ** inversion H19.
-            -- pose (EEA := element_exist _ _  (eq_sym H17)). inversion EEA as [v1''].
-               inversion H15. subst.
-               inversion H17. apply length_zero_iff_nil in H26. subst. 
-               simpl in H33. inversion H33.
-               rewrite get_value_there, get_value_here in H29; congruence.
-            -- inversion H17.
-              ++ rewrite H26 in *. simpl in H33. inversion H33.
-               rewrite get_value_here in H30. congruence.
-              ++ inversion H26.
-         ** pose (WD := determinism E1 _ _ _ H23).
-            destruct WD. destruct H17.
+         ** inversion H24.
+            -- pose (EEA := element_exist _ _  (eq_sym H11)). inversion EEA as [v1''].
+               inversion H9. subst.
+               inversion H11. apply length_zero_iff_nil in H14. subst. 
+               simpl in H38. inversion H38. inversion H16. subst.
+               rewrite get_value_there, get_value_here in H35; congruence.
+            -- inversion H11.
+              ++ rewrite H14 in *. simpl in H38. inversion H38. inversion H18.
+               rewrite get_value_here in H36; congruence.
+              ++ inversion H14.
+         ** pose (WD := eval_expr_determinism E1 _ _ _ H27).
+            destruct WD. destruct H11.
             subst.
-            eapply eval_app_badfun_ex with (vals := [v1'; v2']) (eff := [last eff eff2; last eff eff2])
-                                              (ids := [id';id']); auto.
+            eapply eval_single, eval_app_badfun_ex with (vals := [v2'; v1']) (eff := [eff2; eff2])
+                                              (ids := [id'0;id'0]); auto.
            -- exact E2.
-           -- intros. inversion H15. 2: inversion H29.
+           -- intros. inversion H9. 2: inversion H15.
               ++ simpl.
-                 apply eval_var. rewrite get_value_here. auto.
-              ++ simpl.
-                 rewrite H27.
-                 apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
-              ++ inversion H31.
-         ** pose (WD := determinism E1 _ _ _ H23).
-            inversion WD. destruct H17. subst.
-            eapply eval_app_badarity_ex with (vals := [v1'; v2']) (eff := [last eff eff2;last eff eff2])
-                                   (ids := [id'; id']); auto.
+                 apply eval_single, eval_var. rewrite get_value_here. auto.
+              ++ simpl. rewrite H12, H11.
+                 apply eval_single, eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+              ++ inversion H18.
+         ** pose (WD := eval_expr_determinism E1 _ _ _ H27).
+            inversion WD. destruct H11. subst.
+            eapply eval_single, eval_app_badarity_ex with (vals := [v2'; v1']) (eff := [eff2;eff2])
+                                   (ids := [id'0; id'0]); auto.
            -- exact E2.
-           -- intros. inversion H15. 2: inversion H29.
+           -- intros. inversion H9. 2: inversion H15.
               ++ simpl.
-                 apply eval_var. rewrite get_value_here. auto.
+                 apply eval_single, eval_var. rewrite get_value_here. auto.
               ++ simpl.
-                 rewrite H27.
-                 apply eval_var. rewrite get_value_there, get_value_here. auto. congruence.
-              ++ inversion H31.
-           -- rewrite <- H19 in H26. auto.
-      - subst. inversion H14.
-        rewrite H13 in *.
-        apply length_zero_iff_nil in H13.
-        apply length_zero_iff_nil in H18.
-        apply length_zero_iff_nil in H17. subst.
-        pose (WD := determinism H2 _ _ _ H26).
-        destruct WD. destruct H13. inversion H12.
-        inversion H13.
-      - subst. inversion H6. rewrite H5 in *.
-        apply length_zero_iff_nil in H9.
-        apply length_zero_iff_nil in H8.
-        apply length_zero_iff_nil in H5. subst.
-        pose (WD := determinism H _ _ _ H17).
-        destruct WD. inversion H4.
-        inversion H5.
+                 rewrite H12, H11.
+                 apply eval_single, eval_var. rewrite get_value_there, get_value_here. auto. congruence.
+              ++ inversion H18.
+           -- rewrite <- H24 in H31. auto.
+      - subst.
+        pose (WD := eval_expr_determinism H2 _ _ _ H27).
+        destruct WD. destruct H8. inversion H6.
+      - subst.
+        pose (WD := eval_expr_determinism H _ _ _ H21).
+        destruct WD. inversion H5.
+        inversion H4.
 Qed.
 
 End Equivalence_Proofs.

--- a/src/Core_Erlang_Functional_Big_Step.v
+++ b/src/Core_Erlang_Functional_Big_Step.v
@@ -15,7 +15,12 @@ Inductive ResultType : Type :=
 | Timeout
 | Failure.
 
-Fixpoint fbs_expr (env : Environment) (id : nat) (expr : Expression) (eff : SideEffectList) (clock : nat) : ResultType :=
+Inductive MapResultType : Type :=
+| MapResult (id : nat) (res : (ValueSequence * ValueSequence) + Exception) (eff : SideEffectList)
+| MapTimeout
+| MapFailure.
+
+Fixpoint fbs_expr (env : Environment) (id : nat) (expr : Expression) (eff : SideEffectList) (clock : nat) {struct clock} : ResultType :=
 match clock with
 | 0 => Timeout
 | S clock' =>
@@ -31,31 +36,198 @@ match clock with
                                   | Result id'' (inl xs') eff'' => Result id'' (inl (v::xs')) eff''
                                   | r => r
                                   end
+                              | Result id' (inl val) eff' => Failure (* undefined behaviour *)
                               | r => r
                               end
                    end
                    ) env id el eff
-   | ESingle e => fbs_single env id e eff clock
+   | ESingle e => fbs_single env id e eff clock'
   end
 end
-with fbs_single (env : Environment) (id : nat) (expr : SingleExpression) (eff : SideEffectList) (clock : nat) : ResultType :=
-match expr with
- | ENil => Result id (inl [VNil]) eff
- | ELit l => Result id (inl [VLit l]) eff
- | EVar v => Result id (get_value env (inl v)) eff
- | EFunId f => Result id (get_value env (inr f)) eff
- | EFun vl e => Result id (inl [VClos env [] id vl e]) eff
- | ECons hd tl => Result id (inr novar) eff
- | ETuple l => Result id (inr novar) eff
- | ECall f l => Result id (inr novar) eff
- | EPrimOp f l => Result id (inr novar) eff
- | EApp exp l => Result id (inr novar) eff
- | ECase e l => Result id (inr novar) eff
- | ELet l e1 e2 => Result id (inr novar) eff
- | ESeq e1 e2 => Result id (inr novar) eff
- | ELetRec l e => Result id (inr novar) eff
- | EMap l => Result id (inr novar) eff
- | ETry e1 vl1 e2 vl2 e0 => Result id (inr novar) eff
+with fbs_single (env : Environment) (id : nat) (expr : SingleExpression) (eff : SideEffectList) (clock : nat) {struct clock} : ResultType :=
+match clock with
+| 0 => Timeout
+| S clock' =>
+  match expr with
+   | ENil => Result id (inl [VNil]) eff
+   | ELit l => Result id (inl [VLit l]) eff
+   | EVar v => Result id (get_value env (inl v)) eff
+   | EFunId f => Result id (get_value env (inr f)) eff
+   | EFun vl e => Result (S id) (inl [VClos env [] id vl e]) eff
+   | ECons hd tl => 
+     match fbs_expr env id hd eff clock' with
+       | Result id' (inl [hdv]) eff' =>
+         match fbs_expr env id' tl eff' clock' with
+         | Result id'' (inl [tlv]) eff'' => Result id'' (inl [VCons hdv tlv]) eff''
+         | Result id'' (inl val) eff'' => Failure (* undefined behaviour *)
+         | r => r
+         end
+       | Result id' (inl val) eff' => Failure (* undefined behaviour *)
+       | r => r
+     end
+   | ETuple l =>
+     let res := 
+     (fix eval_list env id exps eff : ResultType := 
+         match exps with
+         | []    => Result id (inl []) eff
+         | x::xs => match fbs_expr env id x eff clock' with
+                    | Result id' (inl [v]) eff' => 
+                      let res := eval_list env id' xs eff' in
+                        match res with
+                        | Result id'' (inl xs') eff'' => Result id'' (inl (v::xs')) eff''
+                        | r => r
+                        end
+                    | Result id' (inl val) eff' => Failure (* undefined behaviour *)
+                    | r => r
+                    end
+         end
+         ) env id l eff
+       in
+       match res with
+       | Result id' (inl vl) eff' => Result id' (inl [VTuple vl]) eff'
+       | r => r
+       end
+   | ECall f l => 
+     let res := 
+     (fix eval_list env id exps eff : ResultType := 
+         match exps with
+         | []    => Result id (inl []) eff
+         | x::xs => match fbs_expr env id x eff clock' with
+                    | Result id' (inl [v]) eff' => 
+                      let res := eval_list env id' xs eff' in
+                        match res with
+                        | Result id'' (inl xs') eff'' => Result id'' (inl (v::xs')) eff''
+                        | r => r
+                        end
+                    | Result id' (inl val) eff' => Failure (* undefined behaviour *)
+                    | r => r
+                    end
+         end
+         ) env id l eff
+       in
+       match res with
+       | Result id' (inl vl) eff' => let (x, y) := eval f vl eff' in Result id' x y
+       | r => r
+       end
+   | EPrimOp f l =>
+     let res := 
+     (fix eval_list env id exps eff : ResultType := 
+         match exps with
+         | []    => Result id (inl []) eff
+         | x::xs => match fbs_expr env id x eff clock' with
+                    | Result id' (inl [v]) eff' => 
+                      let res := eval_list env id' xs eff' in
+                        match res with
+                        | Result id'' (inl xs') eff'' => Result id'' (inl (v::xs')) eff''
+                        | r => r
+                        end
+                    | Result id' (inl val) eff' => Failure (* undefined behaviour *)
+                    | r => r
+                    end
+         end
+         ) env id l eff
+       in
+       match res with
+       | Result id' (inl vl) eff' => let (x, y) := eval f vl eff' in Result id' x y
+       | r => r
+       end
+   | EApp exp l =>
+     match fbs_expr env id exp eff clock' with
+     | Result id' (inl [v]) eff' =>
+       let res := 
+       (fix eval_list env id exps eff : ResultType := 
+         match exps with
+         | []    => Result id (inl []) eff
+         | x::xs => match fbs_expr env id x eff clock' with
+                    | Result id' (inl [v]) eff' => 
+                      let res := eval_list env id' xs eff' in
+                        match res with
+                        | Result id'' (inl xs') eff'' => Result id'' (inl (v::xs')) eff''
+                        | r => r
+                        end
+                    | Result id' (inl val) eff' => Failure (* undefined behaviour *)
+                    | r => r
+                    end
+         end
+         ) env id' l eff'
+         in
+         match res with
+         | Result id'' (inl vl) eff'' => 
+           match v with
+           | VClos ref ext closid varl body =>
+              if Nat.eqb (length varl) (length vl)
+              then fbs_expr (append_vars_to_env varl vl (get_env ref ext)) id'' body eff'' clock'
+              else Result id'' (inr (badarity v)) eff''
+           | _ => Result id'' (inr (badfun v)) eff''
+           end
+         | r => r
+         end
+     | Result id' (inl val) eff' => Failure
+     | r => r
+     end
+   | ECase e l => Result id (inr novar) eff
+   | ELet l e1 e2 =>
+      match fbs_expr env id e1 eff clock' with
+      | Result id' (inl vals) eff' =>
+        if Nat.eqb (length vals) (length l)
+        then fbs_expr (append_vars_to_env l vals env) id' e2 eff' clock'
+        else Failure
+      | r => r
+      end
+   | ESeq e1 e2 =>
+      match fbs_expr env id e1 eff clock' with
+      | Result id' (inl [v]) eff' => fbs_expr env id' e2 eff' clock'
+      | Result id' (inl vals) eff' => Failure
+      | r => r
+      end
+   | ELetRec l e => fbs_expr (append_funs_to_env l env id) (id + length l) e eff clock'
+   | EMap l =>
+     let res :=
+     (fix eval_list_map env id exps eff : MapResultType :=
+       match exps with
+       | [] => MapResult id (inl ([], [])) eff
+       | (key, val)::xs =>
+         match fbs_expr env id key eff clock' with
+         | Result id' (inl [kval]) eff' =>
+            match fbs_expr env id' val eff' clock' with
+            | Result id'' (inl [vval]) eff'' => 
+               let res := eval_list_map env id'' xs eff''
+               in match res with
+               | MapResult id''' (inl (kvals, vvals)) eff''' =>
+                  MapResult id''' (inl (kval::kvals, vval::vvals)) eff'''
+               | r => r
+               end
+            | Result id'' (inl vals) eff'' => MapFailure
+            | Result id'' (inr ex) eff'' => MapResult id'' (inr ex) eff''
+            | Failure => MapFailure
+            | Timeout => MapTimeout
+            end
+         | Result id' (inl vals) eff' => MapFailure
+         | Result id'' (inr ex) eff'' => MapResult id'' (inr ex) eff''
+         | Failure => MapFailure
+         | Timeout => MapTimeout
+         end
+       end
+     ) env id l eff in
+     match res with
+     | MapResult id' (inl (kvals, vvals)) eff' =>
+       let (x, y) := make_value_map kvals vvals
+       in Result id' (inl [VMap (combine x y)]) eff'
+     | MapResult id' (inr ex) eff' => Result id' (inr ex) eff'
+     | MapFailure => Failure
+     | MapTimeout => Timeout
+     end
+   | ETry e1 vl1 e2 vl2 e3 =>
+     match fbs_expr env id e1 eff clock' with
+     | Result id' (inl vals) eff' =>
+       if Nat.eqb (length vals) (length vl1)
+       then fbs_expr (append_vars_to_env vl1 vals env) id' e2 eff' clock'
+       else Failure
+     | Result id' (inr ex) eff' =>
+       fbs_expr (append_try_vars_to_env vl2 [exclass_to_value (fst (fst ex)); snd (fst ex); snd ex] env) id' e3 eff' clock'
+     | r => r
+     end
+  end
 end
 .
 

--- a/src/Core_Erlang_Functional_Big_Step.v
+++ b/src/Core_Erlang_Functional_Big_Step.v
@@ -1,0 +1,62 @@
+Require Core_Erlang_Auxiliaries.
+
+(** The Semantics of Core Erlang *)
+Module Semantics.
+
+Export Core_Erlang_Auxiliaries.Auxiliaries.
+Export Core_Erlang_Environment.Environment.
+
+Module Functional_Big_Step.
+
+Import ListNotations.
+
+Inductive ResultType : Type :=
+| Result (id : nat) (res : ValueSequence + Exception) (eff : SideEffectList)
+| Timeout
+| Failure.
+
+Fixpoint fbs_expr (env : Environment) (id : nat) (expr : Expression) (eff : SideEffectList) (clock : nat) : ResultType :=
+match clock with
+| 0 => Timeout
+| S clock' =>
+  match expr with
+   | EValues el => 
+       (fix eval_list env id exps eff : ResultType := 
+                   match exps with
+                   | []    => Result id (inl []) eff
+                   | x::xs => match fbs_single env id x eff clock' with
+                              | Result id' (inl [v]) eff' => 
+                                let res := eval_list env id' xs eff' in
+                                  match res with
+                                  | Result id'' (inl xs') eff'' => Result id'' (inl (v::xs')) eff''
+                                  | r => r
+                                  end
+                              | r => r
+                              end
+                   end
+                   ) env id el eff
+   | ESingle e => fbs_single env id e eff clock
+  end
+end
+with fbs_single (env : Environment) (id : nat) (expr : SingleExpression) (eff : SideEffectList) (clock : nat) : ResultType :=
+match expr with
+ | ENil => Result id (inl [VNil]) eff
+ | ELit l => Result id (inl [VLit l]) eff
+ | EVar v => Result id (get_value env (inl v)) eff
+ | EFunId f => Result id (get_value env (inr f)) eff
+ | EFun vl e => Result id (inl [VClos env [] id vl e]) eff
+ | ECons hd tl => Result id (inr novar) eff
+ | ETuple l => Result id (inr novar) eff
+ | ECall f l => Result id (inr novar) eff
+ | EPrimOp f l => Result id (inr novar) eff
+ | EApp exp l => Result id (inr novar) eff
+ | ECase e l => Result id (inr novar) eff
+ | ELet l e1 e2 => Result id (inr novar) eff
+ | ESeq e1 e2 => Result id (inr novar) eff
+ | ELetRec l e => Result id (inr novar) eff
+ | EMap l => Result id (inr novar) eff
+ | ETry e1 vl1 e2 vl2 e0 => Result id (inr novar) eff
+end
+.
+
+End Functional_Big_Step.

--- a/src/Core_Erlang_Functional_Big_Step.v
+++ b/src/Core_Erlang_Functional_Big_Step.v
@@ -90,14 +90,14 @@ match clock with
    | EFunId f => Result id (get_value env (inr f)) eff
    | EFun vl e => Result (S id) (inl [VClos env [] id vl e]) eff
    | ECons hd tl => 
-     match fbs_expr clock' env id hd eff with
-       | Result id' (inl [hdv]) eff' =>
-         match fbs_expr clock' env id' tl eff' with
-         | Result id'' (inl [tlv]) eff'' => Result id'' (inl [VCons hdv tlv]) eff''
-         | Result id'' (inl val) eff'' => Failure (* undefined behaviour *)
+     match fbs_expr clock' env id tl eff with
+       | Result id' (inl [tlv]) eff' =>
+         match fbs_expr clock' env id' hd eff' with
+         | Result id'' (inl [hdv]) eff'' => Result id'' (inl [VCons hdv tlv]) eff''
+         | Result id'' (inl vals) eff'' => Failure (* undefined behaviour *)
          | r => r
          end
-       | Result id' (inl val) eff' => Failure (* undefined behaviour *)
+       | Result id' (inl vals) eff' => Failure (* undefined behaviour *)
        | r => r
      end
    | ETuple l =>

--- a/src/Core_Erlang_Functional_Big_Step.v
+++ b/src/Core_Erlang_Functional_Big_Step.v
@@ -39,13 +39,28 @@ Inductive MapResultType : Type :=
 | MapTimeout
 | MapFailure.
 
-Fixpoint fbs_expr (env : Environment) (id : nat) (expr : Expression) (eff : SideEffectList) (clock : nat) {struct clock} : ResultType :=
+Fixpoint fbs_values {A : Type} (f : Environment -> nat -> A -> SideEffectList -> ResultType) (env : Environment) (id : nat) (exps : list A) (eff : SideEffectList) : ResultType :=
+match exps with
+| []    => Result id (inl []) eff
+| x::xs => match f env id x eff with
+          | Result id' (inl [v]) eff' => 
+            let res := fbs_values f env id' xs eff' in
+              match res with
+              | Result id'' (inl xs') eff'' => Result id'' (inl (v::xs')) eff''
+              | r => r
+              end
+          | Result id' (inl val) eff' => Failure (* undefined behaviour *)
+          | r => r
+          end
+end.
+
+Fixpoint fbs_expr (clock : nat) (env : Environment) (id : nat) (expr : Expression) (eff : SideEffectList) {struct clock} : ResultType :=
 match clock with
 | 0 => Timeout
 | S clock' =>
   match expr with
    | EValues el => 
-       (fix eval_list env id exps eff : ResultType := 
+       (* (fix eval_list env id exps eff : ResultType := 
                    match exps with
                    | []    => Result id (inl []) eff
                    | x::xs => match fbs_single env id x eff clock' with
@@ -59,11 +74,12 @@ match clock with
                               | r => r
                               end
                    end
-                   ) env id el eff
-   | ESingle e => fbs_single env id e eff clock'
+                   ) *) 
+                   fbs_values (fbs_single clock') env id el eff
+   | ESingle e => fbs_single clock' env id e eff
   end
 end
-with fbs_single (env : Environment) (id : nat) (expr : SingleExpression) (eff : SideEffectList) (clock : nat) {struct clock} : ResultType :=
+with fbs_single (clock : nat) (env : Environment) (id : nat) (expr : SingleExpression) (eff : SideEffectList) {struct clock} : ResultType :=
 match clock with
 | 0 => Timeout
 | S clock' =>
@@ -74,9 +90,9 @@ match clock with
    | EFunId f => Result id (get_value env (inr f)) eff
    | EFun vl e => Result (S id) (inl [VClos env [] id vl e]) eff
    | ECons hd tl => 
-     match fbs_expr env id hd eff clock' with
+     match fbs_expr clock' env id hd eff with
        | Result id' (inl [hdv]) eff' =>
-         match fbs_expr env id' tl eff' clock' with
+         match fbs_expr clock' env id' tl eff' with
          | Result id'' (inl [tlv]) eff'' => Result id'' (inl [VCons hdv tlv]) eff''
          | Result id'' (inl val) eff'' => Failure (* undefined behaviour *)
          | r => r
@@ -85,97 +101,33 @@ match clock with
        | r => r
      end
    | ETuple l =>
-     let res := 
-     (fix eval_list env id exps eff : ResultType := 
-         match exps with
-         | []    => Result id (inl []) eff
-         | x::xs => match fbs_expr env id x eff clock' with
-                    | Result id' (inl [v]) eff' => 
-                      let res := eval_list env id' xs eff' in
-                        match res with
-                        | Result id'' (inl xs') eff'' => Result id'' (inl (v::xs')) eff''
-                        | r => r
-                        end
-                    | Result id' (inl val) eff' => Failure (* undefined behaviour *)
-                    | r => r
-                    end
-         end
-         ) env id l eff
-       in
+     let res := fbs_values (fbs_expr clock') env id l eff in
        match res with
        | Result id' (inl vl) eff' => Result id' (inl [VTuple vl]) eff'
        | r => r
        end
    | ECall f l => 
-     let res := 
-     (fix eval_list env id exps eff : ResultType := 
-         match exps with
-         | []    => Result id (inl []) eff
-         | x::xs => match fbs_expr env id x eff clock' with
-                    | Result id' (inl [v]) eff' => 
-                      let res := eval_list env id' xs eff' in
-                        match res with
-                        | Result id'' (inl xs') eff'' => Result id'' (inl (v::xs')) eff''
-                        | r => r
-                        end
-                    | Result id' (inl val) eff' => Failure (* undefined behaviour *)
-                    | r => r
-                    end
-         end
-         ) env id l eff
-       in
+     let res := fbs_values (fbs_expr clock') env id l eff in
        match res with
        | Result id' (inl vl) eff' => let (x, y) := eval f vl eff' in Result id' x y
        | r => r
        end
    | EPrimOp f l =>
-     let res := 
-     (fix eval_list env id exps eff : ResultType := 
-         match exps with
-         | []    => Result id (inl []) eff
-         | x::xs => match fbs_expr env id x eff clock' with
-                    | Result id' (inl [v]) eff' => 
-                      let res := eval_list env id' xs eff' in
-                        match res with
-                        | Result id'' (inl xs') eff'' => Result id'' (inl (v::xs')) eff''
-                        | r => r
-                        end
-                    | Result id' (inl val) eff' => Failure (* undefined behaviour *)
-                    | r => r
-                    end
-         end
-         ) env id l eff
-       in
+     let res := fbs_values (fbs_expr clock') env id l eff in
        match res with
        | Result id' (inl vl) eff' => let (x, y) := eval f vl eff' in Result id' x y
        | r => r
        end
    | EApp exp l =>
-     match fbs_expr env id exp eff clock' with
+     match fbs_expr clock' env id exp eff with
      | Result id' (inl [v]) eff' =>
-       let res := 
-       (fix eval_list env id exps eff : ResultType := 
-         match exps with
-         | []    => Result id (inl []) eff
-         | x::xs => match fbs_expr env id x eff clock' with
-                    | Result id' (inl [v]) eff' => 
-                      let res := eval_list env id' xs eff' in
-                        match res with
-                        | Result id'' (inl xs') eff'' => Result id'' (inl (v::xs')) eff''
-                        | r => r
-                        end
-                    | Result id' (inl val) eff' => Failure (* undefined behaviour *)
-                    | r => r
-                    end
-         end
-         ) env id' l eff'
-         in
+       let res := fbs_values (fbs_expr clock') env id' l eff' in
          match res with
          | Result id'' (inl vl) eff'' => 
            match v with
            | VClos ref ext closid varl body =>
               if Nat.eqb (length varl) (length vl)
-              then fbs_expr (append_vars_to_env varl vl (get_env ref ext)) id'' body eff'' clock'
+              then fbs_expr clock' (append_vars_to_env varl vl (get_env ref ext)) id'' body eff''
               else Result id'' (inr (badarity v)) eff''
            | _ => Result id'' (inr (badfun v)) eff''
            end
@@ -185,7 +137,7 @@ match clock with
      | r => r
      end
    | ECase e l =>
-     match fbs_expr env id e eff clock' with
+     match fbs_expr clock' env id e eff with
      | Result id' (inl vals) eff' =>
        (fix clause_eval l i' :=
          let i := (length l) - i' in
@@ -195,12 +147,12 @@ match clock with
            (* TODO: side effects cannot be produced here *)
              match match_clause vals l i with
              | Some (gg, bb, bindings) =>
-               match fbs_expr (add_bindings bindings env) id' gg eff' clock' with
+               match fbs_expr clock' (add_bindings bindings env) id' gg eff' with
                | Result id'' (inl [v]) eff'' =>  
                    match v with
                    | VLit (Atom "true"%string)  => 
                       if andb (Nat.eqb id'' id') (list_eqb effect_eqb eff' eff'')
-                      then fbs_expr (add_bindings bindings env) id' bb eff' clock'
+                      then fbs_expr clock' (add_bindings bindings env) id' bb eff'
                       else (* undef *) Failure
                    | VLit (Atom "false"%string) => clause_eval l i''
                    | _ => Failure
@@ -214,29 +166,39 @@ match clock with
      | r => r
      end
    | ELet l e1 e2 =>
-      match fbs_expr env id e1 eff clock' with
+      match fbs_expr clock' env id e1 eff with
       | Result id' (inl vals) eff' =>
         if Nat.eqb (length vals) (length l)
-        then fbs_expr (append_vars_to_env l vals env) id' e2 eff' clock'
+        then fbs_expr clock' (append_vars_to_env l vals env) id' e2 eff'
         else Failure
       | r => r
       end
    | ESeq e1 e2 =>
-      match fbs_expr env id e1 eff clock' with
-      | Result id' (inl [v]) eff' => fbs_expr env id' e2 eff' clock'
+      match fbs_expr clock' env id e1 eff with
+      | Result id' (inl [v]) eff' => fbs_expr clock' env id' e2 eff'
       | Result id' (inl vals) eff' => Failure
       | r => r
       end
-   | ELetRec l e => fbs_expr (append_funs_to_env l env id) (id + length l) e eff clock'
+   | ELetRec l e => fbs_expr clock' (append_funs_to_env l env id) (id + length l) e eff
    | EMap l =>
-     let res :=
-     (fix eval_list_map env id exps eff : MapResultType :=
+     let res := fbs_values (fbs_expr clock') env id (make_map_exps l) eff in
+       match res with
+       | Result id' (inl vals) eff' => 
+         match make_map_vals_inverse vals with
+         | None => Failure
+         | Some (kvals, vvals) =>
+           let (x, y) := make_value_map kvals vvals in 
+             Result id' (inl [VMap (combine x y)]) eff'
+         end
+       | r => r
+       end
+     (* (fix eval_list_map env id exps eff : MapResultType :=
        match exps with
        | [] => MapResult id (inl ([], [])) eff
        | (key, val)::xs =>
-         match fbs_expr env id key eff clock' with
+         match fbs_expr clock' env id key eff with
          | Result id' (inl [kval]) eff' =>
-            match fbs_expr env id' val eff' clock' with
+            match fbs_expr clock' env id' val eff' with
             | Result id'' (inl [vval]) eff'' => 
                let res := eval_list_map env id'' xs eff''
                in match res with
@@ -263,15 +225,15 @@ match clock with
      | MapResult id' (inr ex) eff' => Result id' (inr ex) eff'
      | MapFailure => Failure
      | MapTimeout => Timeout
-     end
+     end *)
    | ETry e1 vl1 e2 vl2 e3 =>
-     match fbs_expr env id e1 eff clock' with
+     match fbs_expr clock' env id e1 eff with
      | Result id' (inl vals) eff' =>
        if Nat.eqb (length vals) (length vl1)
-       then fbs_expr (append_vars_to_env vl1 vals env) id' e2 eff' clock'
+       then fbs_expr clock' (append_vars_to_env vl1 vals env) id' e2 eff'
        else Failure
      | Result id' (inr ex) eff' =>
-       fbs_expr (append_try_vars_to_env vl2 [exclass_to_value (fst (fst ex)); snd (fst ex); snd ex] env) id' e3 eff' clock'
+       fbs_expr clock' (append_try_vars_to_env vl2 [exclass_to_value (fst (fst ex)); snd (fst ex); snd ex] env) id' e3 eff'
      | r => r
      end
   end

--- a/src/Core_Erlang_Helpers.v
+++ b/src/Core_Erlang_Helpers.v
@@ -361,4 +361,14 @@ match l, l' with
 | _, _ => []
 end.
 
+Fixpoint make_map_vals_inverse (l : list Value) : option (list Value * list Value) :=
+match l with
+| [] => Some ([], [])
+| x::y::xs => match make_map_vals_inverse xs with
+              | Some (vals1, vals2) => Some (x::vals1, y::vals2)
+              | None => None
+              end
+| _ => None
+end.
+
 End Helpers.

--- a/src/Core_Erlang_Helpers.v
+++ b/src/Core_Erlang_Helpers.v
@@ -310,6 +310,7 @@ match e with
   | ECons hd tl => app (variables hd) (variables tl)
   | ETuple l => flat_map variables l
   | ECall f l => flat_map variables l
+  | EPrimOp f l => flat_map variables l
   | EApp exp l => app (variables exp) (flat_map variables l)
   | ECase e l => variables e ++ fold_right (fun '(a, b, c) r => app (app (variables b) (variables c)) r) [] l
   | ELet l e1 e2 => l ++ (variables e1) ++ (variables e2)

--- a/src/Core_Erlang_Helpers.v
+++ b/src/Core_Erlang_Helpers.v
@@ -353,6 +353,14 @@ match l with
 | (x, y)::xs => x::y::(make_map_exps xs)
 end.
 
+Lemma length_make_map_exps l :
+  length (make_map_exps l) = length l * 2.
+Proof.
+  induction l.
+  * simpl. auto.
+  * simpl. destruct a. simpl. lia.
+Qed.
+
 Fixpoint make_map_vals (l l' : list Value) : list Value  :=
 match l, l' with
 | [], [] => []
@@ -360,6 +368,58 @@ match l, l' with
 | k::ks, _ => [k]
 | _, _ => []
 end.
+
+Lemma length_make_map_vals l : forall l',
+  length l = length l' ->
+  length (make_map_vals l l') = length l * 2.
+Proof.
+  induction l; intros.
+  * apply eq_sym, length_zero_iff_nil in H. subst. auto.
+  * simpl in *. destruct l'.
+    - simpl in H. congruence.
+    - inversion H. simpl. rewrite (IHl l' H1). lia.
+Qed.
+
+Lemma length_make_map_vals2 l : forall l',
+  length l = S (length l') ->
+  length (make_map_vals l l') = length l' * 2 + 1.
+Proof.
+  induction l; intros.
+  * inversion H.
+  * simpl in *. destruct l'.
+    - simpl in H. apply Nat.succ_inj in H. apply length_zero_iff_nil in H.
+      subst. simpl. auto.
+    - inversion H. simpl. rewrite (IHl l' H1). lia.
+Qed.
+
+Lemma make_map_vals_eq kvals : forall kvals0 vvals vvals0,
+  length kvals = length vvals ->
+  length kvals0 = length vvals0 ->
+  length kvals = length kvals0 ->
+  make_map_vals kvals vvals = make_map_vals kvals0 vvals0
+->
+  kvals = kvals0 /\ vvals = vvals0.
+Proof.
+  induction kvals; intros.
+  * apply eq_sym, length_zero_iff_nil in H. apply eq_sym, length_zero_iff_nil in H1. subst.
+    apply eq_sym, length_zero_iff_nil in H0. subst.
+    auto.
+  * pose (element_exist _ _ H).
+    pose (element_exist _ _ H1). inversion e. inversion e0.
+    destruct H3, H4. subst. clear e. clear e0.
+    pose (element_exist _ _ H0). inversion e. destruct H3. clear e.
+    subst. simpl in H2. inversion H2. subst.
+    inversion H. inversion H0. inversion H1.
+    pose (IHkvals _ _ _ H4 H5 H7 H6). destruct a. subst. auto.
+Qed.
+
+Lemma make_map_vals_eq_rev kvals kvals0 vvals vvals0 :
+  kvals = kvals0 -> vvals = vvals0
+->
+  make_map_vals kvals vvals = make_map_vals kvals0 vvals0.
+Proof.
+  intros. subst. auto.
+Qed.
 
 Fixpoint make_map_vals_inverse (l : list Value) : option (list Value * list Value) :=
 match l with

--- a/src/Core_Erlang_Helpers.v
+++ b/src/Core_Erlang_Helpers.v
@@ -53,7 +53,7 @@ Section Nat_Proofs.
 
 Proposition nat_ge_or : forall {n m : nat}, n >= m <-> n = m \/ n > m.
 Proof.
-  intros. omega.
+  intros. lia.
 Qed.
 
 Lemma nat_lt_zero (i j : nat):
@@ -67,7 +67,7 @@ Qed.
 End Nat_Proofs.
 
 (** The matching function of two literals *)
-Fixpoint match_literals (l l' : Literal) : bool :=
+Definition match_literals (l l' : Literal) : bool :=
 match l, l' with
 | Atom s, Atom s' => eqb s s'
 | Integer x, Integer x' => Z.eqb x x'
@@ -118,7 +118,7 @@ end
 .
 
 (** Examples *)
-Compute match_value_to_pattern (VClos [] [] 0 [] ErrorExp) (PVar "X"%string).
+Compute match_value_to_pattern (VClos [] [] 0 [] (ESingle ErrorExp)) (PVar "X"%string).
 Compute match_value_to_pattern (VLit (Atom "a"%string)) (PVar "X"%string).
 Compute match_value_to_pattern (VLit (Atom "a"%string)) (PLit (Atom "a"%string)).
 Compute match_value_to_pattern (VLit (Atom "a"%string)) (PEmptyTuple).
@@ -226,7 +226,7 @@ end
 .
 
 (** Examples *)
-Compute match_value_bind_pattern (VClos [] [] 0 [] ErrorExp) (PVar "X"%string).
+Compute match_value_bind_pattern (VClos [] [] 0 [] (ESingle ErrorExp)) (PVar "X"%string).
 Compute match_value_bind_pattern (VLit (Atom "a"%string)) (PVar "X"%string).
 Compute match_value_bind_pattern (VLit (Atom "a"%string)) (PLit (Atom "alma"%string)).
 Compute match_value_bind_pattern (VLit (Atom "a"%string)) (PEmptyTuple).
@@ -242,7 +242,7 @@ Compute match_value_bind_pattern (VMap [(ttrue, ttrue); (ttrue, ffalse)])
                                (PMap [(PVar "X"%string, PVar "Y"%string); (PVar "Z"%string, PLit (Atom "false"))]).
 
 
-Fixpoint match_valuelist_to_patternlist (vl : list Value) (pl : list Pattern) : bool :=
+Fixpoint match_valuelist_to_patternlist (vl : ValueSequence) (pl : list Pattern) : bool :=
 match vl, pl with
 | [], [] => true
 | (v::vs), (p::ps) => match_value_to_pattern v p && match_valuelist_to_patternlist vs ps
@@ -255,7 +255,7 @@ Compute match_valuelist_to_patternlist [VLit (Atom "a"%string); VLit (Atom "a"%s
 Compute match_valuelist_to_patternlist [VLit (Atom "a"%string); VLit (Atom "a"%string)] 
                                        [PVar "X"%string; PLit (Integer 0)].
 
-Fixpoint match_valuelist_bind_patternlist (vl : list Value) (pl : list Pattern) : 
+Fixpoint match_valuelist_bind_patternlist (vl : ValueSequence) (pl : list Pattern) : 
    list (Var * Value) :=
 match vl, pl with
 | [], [] => []
@@ -272,7 +272,7 @@ Compute match_valuelist_bind_patternlist [VLit (Atom "a"%string); VLit (Atom "a"
                                        [PVar "X"%string; PLit (Integer 0)].
 
 (** From the list of patterns, guards and bodies, this function decides if a value matches the ith clause *)
-Fixpoint match_clause (e : list Value) (l : list (list Pattern * Expression * Expression)) (i : nat) : option (Expression * Expression * list (Var * Value)) :=
+Fixpoint match_clause (e : ValueSequence) (l : list (list Pattern * Expression * Expression)) (i : nat) : option (Expression * Expression * list (Var * Value)) :=
 match l, i with
 | [], _ => None
 | (p,g,exp)::xs, 0 => if match_valuelist_to_patternlist e p then Some (g, exp, (match_valuelist_bind_patternlist e p)) else None
@@ -296,7 +296,12 @@ Compute variable_occurances_set (PTuple [PVar "X"%string ; PVar "X"%string]).
 
 (** Get the used variables of an expression *)
 Fixpoint variables (e : Expression) : list Var :=
-  match e with
+match e with
+| EValues el => flat_map variables_single el
+| ESingle e => variables_single e
+end
+with variables_single (e : SingleExpression) : list Var :=
+match e with
   | ENil => []
   | ELit l => []
   | EVar v => [v]
@@ -306,25 +311,25 @@ Fixpoint variables (e : Expression) : list Var :=
   | ETuple l => flat_map variables l
   | ECall f l => flat_map variables l
   | EApp exp l => app (variables exp) (flat_map variables l)
-  | ECase el l => flat_map variables el ++ fold_right (fun '(a, b, c) r => app (app (variables b) (variables c)) r) [] l
-  | ELet l e => app (fold_right (fun '(a, b) r => app (variables b) r) [] l) (variables e)
+  | ECase e l => variables e ++ fold_right (fun '(a, b, c) r => app (app (variables b) (variables c)) r) [] l
+  | ELet l e1 e2 => l ++ (variables e1) ++ (variables e2)
   | ESeq e1 e2 => app (variables e1) (variables e2)
   | ELetRec l e => variables e 
   | EMap l => fold_right (fun '(a, b) r => app (app (variables a) (variables b)) r) [] l
-  | ETry el e1 e2 vex1 vex2 vex3 => (snd (split el)) ++ [vex1; vex2; vex3] ++ fold_right (fun '(a, b) r => app (variables a) r) [] el ++ variables e1 ++ variables e2
+  | ETry e1 vl1 e2 vl2 e3 => vl1 ++ vl2 ++ variables e1 ++ variables e2 ++ variables e3
 end.
 
-Compute variables (ELet [("X"%string,EVar "Z"%string)] (ELet [("Y"%string,ErrorExp)] (ECall "plus"%string [EVar "X"%string ; EVar "Y"%string]))).
+Compute variables (ELet ["X"%string] (ESingle (EVar "Z"%string)) (ELet ["Y"%string] ErrorExp (ECall "plus"%string [^ EVar "X"%string ; ^EVar "Y"%string]))).
 
 
 (** Building value maps based on the value ordering value_less *)
 Fixpoint map_insert (k v : Value) (kl : list Value) (vl : list Value) : (list Value) * (list Value) :=
 match kl, vl with
 | [], [] => ([k], [v])
-| k'::ks, v'::vs => if value_less k k' 
+| k'::ks, v'::vs => if Value_ltb k k' 
                     then (k::k'::ks, v::v'::vs) 
                     else
-                       if bValue_eq_dec k k' 
+                       if Value_eqb k k' 
                        then (k'::ks, v'::vs) 
                        else (k'::(fst (map_insert k v ks vs)), v'::(snd (map_insert k v ks vs)))
 | _, _ => ([], [])

--- a/src/Core_Erlang_Helpers.v
+++ b/src/Core_Erlang_Helpers.v
@@ -347,4 +347,18 @@ end.
 Compute make_value_map [VLit (Integer 5); VLit (Integer 5); VLit (Atom ""%string)] 
                        [VLit (Integer 5); VLit (Integer 7); VLit (Atom ""%string)].
 
+Fixpoint make_map_exps (l : list (Expression * Expression)) : list Expression :=
+match l with
+| [] => []
+| (x, y)::xs => x::y::(make_map_exps xs)
+end.
+
+Fixpoint make_map_vals (l l' : list Value) : list Value  :=
+match l, l' with
+| [], [] => []
+| k::ks, v::vs => k::v::(make_map_vals ks vs)
+| k::ks, _ => [k]
+| _, _ => []
+end.
+
 End Helpers.

--- a/src/Core_Erlang_Semantics.v
+++ b/src/Core_Erlang_Semantics.v
@@ -43,7 +43,7 @@ Inductive eval_expr : Environment -> nat -> Expression -> SideEffectList -> nat 
      -s> 
     |nth_def ids id 0 (S j), inl [nth j vals ErrorValue], nth_def eff eff1 [] (S j)|
   ) ->
-  |env, last ids id, nth i exps ErrorExp, last eff eff1| -e> |id', inr ex, eff'|
+  |env, last ids id, nth i exps ErrorExp, last eff eff1| -s> |id', inr ex, eff'|
 ->
   |env, id, EValues exps, eff1| -e> |id', inr ex, eff'|
 
@@ -472,6 +472,12 @@ with eval_singleexpr : Environment -> nat -> SingleExpression -> SideEffectList 
 (** Exception in key list *)
 | eval_map_ex (l: list (Expression * Expression)) (vvals kvals : list Value) (env: Environment) (i : nat) (ex : Exception) (eff1 eff2 : SideEffectList) (eff : list SideEffectList) (ids : list nat) (id id' : nat):
   i < 2 * (length l) ->
+  (* This method is simpler to handle in proofs, but not in the tactic:
+
+  (length vvals = length kvals \/ S (length vvals) = length kvals) ->
+  length kvals + length vvals = i ->
+
+  *)
   length vvals = i / 2 ->
   length kvals = i / 2 + i mod 2 ->
   length eff = i ->

--- a/src/Core_Erlang_Semantics.v
+++ b/src/Core_Erlang_Semantics.v
@@ -1,408 +1,12 @@
-Require Core_Erlang_Side_Effects.
+Require Core_Erlang_Auxiliaries.
 
 (** The Semantics of Core Erlang *)
 Module Semantics.
 
-Export Core_Erlang_Side_Effects.Side_Effects.
+Export Core_Erlang_Auxiliaries.Auxiliaries.
 Export Core_Erlang_Environment.Environment.
 
 Import ListNotations.
-
-(** For biuilt-in arithmetic calls *)
-Definition eval_arith (fname : string) (params : list Value) : Value + Exception :=
-match fname, params with
-(** addition *)
-| "+"%string, [VLit (Integer a); VLit (Integer b)] => inl (VLit (Integer (a + b)))
-| "+"%string, [a; b]                               => inr (badarith (VCons a b))
-(** subtraction *)
-| "-"%string, [VLit (Integer a); VLit (Integer b)] => inl (VLit (Integer (a - b)))
-| "-"%string, [a; b]                               => inr (badarith (VCons a b))
-(** unary minus *)
-| "-"%string, [VLit (Integer a)]                   => inl (VLit (Integer (0 - a)))
-| "-"%string, [a]                                  => inr (badarith a)
-(** multiplication *)
-| "*"%string, [VLit (Integer a); VLit (Integer b)] => inl (VLit (Integer (a * b)))
-| "*"%string, [a; b]                               => inr (badarith (VCons a b))
-(** division *)
-| "/"%string, [VLit (Integer a); VLit (Integer b)] => inl (VLit (Integer (a / b)))
-| "/"%string, [a; b]                               => inr (badarith (VCons a b))
-(** rem *)
-| "rem"%string, [VLit (Integer a); VLit (Integer b)] => inl (VLit (Integer (Z.rem a b)))
-| "rem"%string, [a; b]                               => inr (badarith (VCons a b))
-(** div *)
-| "div"%string, [VLit (Integer a); VLit (Integer b)] => inl (VLit (Integer (Z.div a b)))
-| "div"%string, [a; b]                               => inr (badarith (VCons a b))
-(** anything else *)
-| _         , _                                    => inr (undef (VLit (Atom fname)))
-end.
-
-(** For IO maniputaion: *)
-Definition eval_io (fname : string) (params : list Value) (eff : SideEffectList) 
-   : ((Value + Exception) * SideEffectList) :=
-match fname, length params, params with
-(** writing *)
-| "fwrite"%string, 1, _ => (inl ok                                    , eff ++ [(Output, params)])
-(** reading *)
-| "fread"%string , 2, e => (inl (VTuple [ok; nth 1 params ErrorValue]), eff ++ [(Input, params)])
-(** anything else *)
-| _              , _, _ => (inr (undef (VLit (Atom fname)))           , eff)
-end.
-
-Definition eval_logical (fname : string) (params : list Value) : Value + Exception :=
-match fname, params with
-(** logical and *)
-| "and"%string, [a; b] => 
-   match a, b with
-   | VLit (Atom "true") , VLit (Atom "true")    => inl ttrue
-   | VLit (Atom "false"), VLit (Atom "true")    => inl ffalse
-   | VLit (Atom "true") , VLit (Atom "false")   => inl ffalse
-   | VLit (Atom "false"), VLit (Atom "false")   => inl ffalse
-   | _                         , _              => inr (badarg (VCons a b))
-   end
-(** logical or *)
-| "or"%string, [a; b] =>
-   match a, b with
-   | VLit (Atom "true") , VLit (Atom "true")    => inl ttrue
-   | VLit (Atom "false"), VLit (Atom "true")    => inl ttrue
-   | VLit (Atom "true") , VLit (Atom "false")   => inl ttrue
-   | VLit (Atom "false"), VLit (Atom "false")   => inl ffalse
-   | _                         , _              => inr (badarg (VCons a b))
-   end
-(** logical not *)
-| "not"%string, [a] =>
-   match a with
-   | VLit (Atom "true")  => inl ffalse
-   | VLit (Atom "false") => inl ttrue
-   | _                   => inr (badarg a)
-   end
-(** anything else *)
-| _ , _ => inr (undef (VLit (Atom fname)))
-end.
-
-Definition eval_equality (fname : string) (params : list Value) : Value + Exception :=
-match fname, params with
-| "=="%string,  [v1; v2] (* TODO: with floats, this one should be adjusted *)
-| "=:="%string, [v1; v2] => if Value_eqb v1 v2 then inl ttrue else inl ffalse
-| "/="%string,  [v1; v2] (* TODO: with floats, this one should be adjusted *)
-| "=/="%string, [v1; v2] => if Value_eqb v1 v2 then inl ffalse else inl ttrue
-(** anything else *)
-| _ , _ => inr (undef (VLit (Atom fname)))
-end.
-
-Fixpoint is_shallow_proper_list (v : Value) : bool :=
-match v with
-| VNil => true
-| VCons x y => is_shallow_proper_list y
-| _ => false
-end.
-
-Fixpoint eval_append (v1 v2 : Value) : Value + Exception :=
-match v1, v2 with
-| VNil, VNil => inl VNil
-| VNil, VCons x y => inl (VCons x y)
-| VCons x y, VNil => inl (VCons x y)
-| VCons x y, VCons x' y' =>
-  match y with
-  | VCons z w => match eval_append y (VCons x' y') with
-                 | inr ex => inr ex
-                 | inl res => inl (VCons x res)
-                 end
-  | VNil      => inl (VCons x (VCons x' y'))
-  | z         => inr (badarg (VCons v1 v2))
-  end
-| _, _ => inr (badarg (VCons v1 v2))
-end.
-
-Fixpoint subtract_elem (v1 v2 : Value) : Value :=
-match v1 with
-| VNil => VNil
-| VCons x y =>
-  match y with
-  | VNil => if Value_eqb x v2 then VNil else VCons x y
-  | VCons z w => if Value_eqb x v2 then y else VCons x (subtract_elem y v2)
-  | z => if Value_eqb x v2 then VCons z VNil else if Value_eqb z v2 then VCons x VNil else VCons x y
-  end
-| _ => ErrorValue
-end.
-
-Fixpoint eval_subtract (v1 v2 : Value) : Value + Exception :=
-if andb (is_shallow_proper_list v1) (is_shallow_proper_list v2) then
-  match v1, v2 with
-  | VNil, VNil => inl VNil
-  | VNil, VCons x y => inl VNil
-  | VCons x y, VNil => inl (VCons x y)
-  | VCons x y, VCons x' y' => 
-     match y' with
-     | VNil => inl (subtract_elem (VCons x y) x')
-     | VCons z w => eval_subtract (subtract_elem (VCons x y) x') y'
-     | z => inl (subtract_elem (subtract_elem (VCons x y) x') z)
-     end
-  | _        , _         => inr (badarg (VCons v1 v2))
-  end
-else
-  inr (badarg (VCons v1 v2)).
-
-Definition eval_transform_list (fname : string) (params : list Value) : Value + Exception :=
-match fname, params with
-| "++"%string, [v1; v2] => eval_append v1 v2
-| "--"%string, [v1; v2] => eval_subtract v1 v2
-| _ , _ => inr (undef (VLit (Atom fname)))
-end.
-
-Definition transform_tuple (v : Value) : Value + Exception :=
-match v with
-| VTuple l => inl ((fix unfold_list l :=
-                   match l with
-                   | [] => VNil
-                   | x::xs => VCons x (unfold_list xs)
-                   end) l)
-| _        => inr (badarg v)
-end.
-
-Fixpoint transform_list (v : Value) : list Value + Exception :=
-match v with
-| VNil      => inl []
-| VCons x y => match y with
-               | VNil => inl [x]
-               | VCons z w => match (transform_list y) with
-                              | inr ex => inr ex
-                              | inl res => inl (x::res)
-                              end
-               | z => inl [x; z]
-               end
-| _         => inr (badarg v)
-end.
-
-Definition eval_list_tuple (fname : string) (params : list Value) : Value + Exception :=
-match fname, params with
-| "tuple_to_list"%string, [v] => transform_tuple v
-| "list_to_tuple"%string, [v] => match (transform_list v) with
-                                 | inr ex => inr ex
-                                 | inl l => inl (VTuple l)
-                                 end
-| _                     , _   => inr (undef (VLit (Atom fname)))
-end.
-
-Definition eval_cmp (fname : string) (params : list Value) : Value + Exception :=
-match fname, params with
-| "<"%string,  [v1; v2] => if Value_ltb v1 v2 then inl ttrue else inl ffalse
-| "=<"%string, [v1; v2] => if orb (Value_ltb v1 v2) (Value_eqb v1 v2) 
-                           then inl ttrue else inl ffalse
-| ">"%string,  [v1; v2] => if Value_ltb v2 v1 then inl ttrue else inl ffalse
-| ">="%string, [v1; v2] => if orb (Value_ltb v2 v1) (Value_eqb v1 v2) 
-                           then inl ttrue else inl ffalse
-(** anything else *)
-| _ , _ => inr (undef (VLit (Atom fname)))
-end.
-
-Definition eval_length (params : list Value) : Value + Exception :=
-match params with
-| [v] => let res :=
-          (fix len val := match val with
-                         | VNil => inl Z.zero
-                         | VCons x y => let res := len y in
-                                          match res with
-                                          | inl n => inl (Z.add 1 n)
-                                          | inr _ => res
-                                          end
-                         | _ => inr (badarg v)
-                         end) v in
-        match res with
-        | inl n => inl (VLit (Integer n))
-        | inr ex => inr ex
-        end
-| _ => inr (undef (VLit (Atom "length")))
-end.
-
-Definition eval_tuple_size (params : list Value) : Value + Exception :=
-match params with
-| [VTuple l] => inl (VLit (Integer (Z.of_nat (length l))))
-| [v] => inr (badarg v)
-| _ => inr (undef (VLit (Atom "tuple_size")))
-end.
-
-Definition eval_hd_tl (fname : string) (params : list Value) : Value + Exception :=
-match fname, params with
-| "hd"%string, [VCons x y] => inl x
-| "hd"%string, [v] => inr (badarg v)
-| "tl"%string, [VCons x y] => inl y
-| "tl"%string, [v] => inr (badarg v)
-| _, _ => inr (undef (VLit (Atom fname)))
-end.
-
-Fixpoint replace_nth_error {A : Type} (l : list A) (i : nat) (e : A) : option (list A) :=
-match i, l with
-| 0, x::xs => Some (e::xs)
-| _, [] => None
-| S n, x::xs => match (replace_nth_error xs n e) with
-               | None => None
-               | Some l' => Some (x::l')
-               end
-end.
-
-Definition eval_elem_tuple (fname : string) (params : list Value) : Value + Exception :=
-match fname, params with
-| "element"%string, [VLit (Integer i); VTuple l] =>
-    match i with
-    | Z.pos p => match nth_error l (pred (Pos.to_nat p)) with
-                 | None   => inr (badarg (VCons (VLit (Integer i)) (VTuple l)))
-                 | Some v => inl v
-                 end
-    | _       => inr (badarg (VCons (VLit (Integer i)) (VTuple l)))
-    end
-| "element"%string, [v1; v2] => inr (badarg (VCons v1 v2))
-| "setelement"%string, [VLit (Integer i); VTuple l; val] =>
-    match i with
-    | Z.pos p => match replace_nth_error l (pred (Pos.to_nat p)) val with
-                 | None    => inr (badarg (VCons (VLit (Integer i)) (VCons (VTuple l) val)))
-                 | Some l' => inl (VTuple l')
-                 end
-    | _       => inr (badarg (VCons (VLit (Integer i)) (VTuple l)))
-    end
-| "setelement"%string, [v1; v2; v3] => inr (badarg (VCons v1 (VCons v2 v3)))
-| _, _ => inr (undef (VLit (Atom fname)))
-end.
-
-(* TODO: Always can be extended, this function simulates inter-module calls *)
-Definition eval (fname : string) (params : list Value) (eff : SideEffectList) 
-   : ((Value + Exception) * SideEffectList) :=
-match fname with
-| "+"%string      | "-"%string
-| "*"%string      | "/"%string
-| "rem"%string    | "div"%string   => (eval_arith fname params, eff)
-| "fwrite"%string | "fread"%string => eval_io fname params eff
-| "and"%string    | "or"%string
-| "not"%string                     => (eval_logical fname params, eff)
-| "=="%string     | "=:="%string
-| "/="%string     | "=/="%string   => (eval_equality fname params, eff)
-| "++"%string     | "--"%string    => (eval_transform_list fname params, eff)
-| "tuple_to_list"%string
-| "list_to_tuple"%string           => (eval_list_tuple fname params, eff)
-| "<"%string      | ">"%string 
-| "=<"%string     | ">="%string    => (eval_cmp fname params, eff)
-| "length"%string                  => (eval_length params, eff)
-| "tuple_size"%string              => (eval_tuple_size params, eff)
-| "hd"%string     | "tl"%string    => (eval_hd_tl fname params, eff)
-| "element"%string
-| "setelement"%string              => (eval_elem_tuple fname params, eff)
-(** anything else *)
-| _                                => (inr (undef (VLit (Atom fname))), eff)
-end.
-
-(** Tests *)
-
-Compute (eval "+" [VLit (Integer 1); VLit (Integer 2)]) [] = (inl (VLit (Integer 3)), []).
-Compute (eval "-" [VLit (Integer 1); VLit (Integer 2)]) [] = (inl (VLit (Integer (-1))), []).
-Compute (eval "+" [VLit (Atom "foo"); VLit (Integer 2)]) [] 
-    = (inr (badarith (VCons (VLit (Atom "foo")) (VLit (Integer 2)))), []).
-Compute (eval "+" [VLit (Integer 1); VLit (Atom "foo")]) [] 
-    = (inr (badarith (VCons (VLit (Integer 2)) (VLit (Atom "foo")))), []).
-Compute (eval "-" [VLit (Atom "foo"); VLit (Integer 2)]) [] 
-    = (inr (badarith (VCons (VLit (Atom "foo")) (VLit (Integer 2)))), []).
-Compute (eval "-" [VLit (Integer 1); VLit (Atom "foo")]) [] 
-    = (inr (badarith (VCons (VLit (Integer 2)) (VLit (Atom "foo")))), []).
-Compute (eval "-" [VLit (Atom "foo")]) [] 
-    = (inr (badarith (VLit (Atom "foo"))), []).
-Compute (eval "+" [VLit (Atom "foo")]) [] 
-    = (inr (undef (VLit (Atom "+"))), []).
-
-Compute (eval "not" [ttrue]) [] = (inl ffalse, []).
-Compute (eval "not" [ffalse]) [] = (inl ttrue, []).
-Compute (eval "not" [VLit (Integer 5)]) [] = (inr (badarg (VLit (Integer 5))), []).
-Compute (eval "not" [VLit (Integer 5); VEmptyTuple]) [] = (inr (undef (VLit (Atom "not"))), []).
-
-Compute (eval "and" [ttrue; ttrue]) [] = (inl ttrue, []).
-Compute (eval "and" [ttrue; ffalse]) [] = (inl ffalse, []).
-Compute (eval "and" [ffalse; ttrue]) [] = (inl ffalse, []).
-Compute (eval "and" [ffalse; ffalse]) [] = (inl ffalse, []).
-Compute (eval "and" [ttrue; VEmptyTuple]) [] = (inr (badarg (VCons (VLit (Atom "true")) (VTuple []))), []).
-Compute (eval "and" [ttrue]) [] = (inr (undef (VLit (Atom "and"))), []).
-
-Compute (eval "or" [ttrue; ttrue]) [] = (inl ttrue, []).
-Compute (eval "or" [ttrue; ffalse]) [] = (inl ttrue, []).
-Compute (eval "or" [ffalse; ttrue]) [] = (inl ttrue, []).
-Compute (eval "or" [ffalse; ffalse]) [] = (inl ffalse, []).
-Compute (eval "or" [ttrue; VEmptyTuple]) [] = (inr (badarg (VCons (VLit (Atom "true")) (VTuple []))), []).
-Compute (eval "or" [ttrue]) [] = (inr (undef (VLit (Atom "or"))), []).
-
-Compute (eval "fwrite" [ttrue]) [] = (inl ok, [(Output, [ttrue])]).
-Compute (eval "fwrite" [VMap [(ttrue, ttrue)]]) [] = (inl ok, [(Output, [VMap [(ttrue, ttrue)]])]).
-Compute (eval "fwrite" []) [] = (inr (undef (VLit (Atom "fwrite"))), []).
-
-Compute (eval "fread" [VLit (Atom "foo.txt"); ttrue]) [] = 
-   (inl (VTuple [ok; ttrue]), [(Input, [VLit (Atom "foo.txt"); ttrue])]).
-Compute (eval "fread" [VLit (Atom "foo.txt"); VMap [(ttrue, ttrue)]]) [] = 
-   (inl (VTuple [ok; VMap [(ttrue, ttrue)]]), [(Input, [VLit (Atom "foo.txt"); VMap [(ttrue, ttrue)]])]).
-Compute (eval "fread" []) [] = (inr (undef (VLit (Atom "fread"))), []).
-
-Compute (eval "==" [ttrue; ttrue]) [] = (inl ttrue, []).
-Compute (eval "==" [ttrue; ffalse]) [] = (inl ffalse, []).
-Compute (eval "==" [VClos [] [] 1 [] EEmptyMap; ttrue]) [] = (inl ffalse, []).
-Compute (eval "==" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 2 [] EEmptyMap]) [] = (inl ffalse, []).
-Compute (eval "==" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl ttrue, []).
-
-Compute (eval "/=" [ttrue; ttrue]) [] = (inl ffalse, []).
-Compute (eval "/=" [ttrue; ffalse]) [] = (inl ttrue, []).
-Compute (eval "/=" [VClos [] [] 1 [] EEmptyMap; ttrue]) [] = (inl ttrue, []).
-Compute (eval "/=" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 2 [] EEmptyMap]) [] = (inl ttrue, []).
-Compute (eval "/=" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl ffalse, []).
-Compute (eval "/=" [ttrue]) [] = (inr (undef (VLit (Atom "/="))), []).
-
-Definition l1 : Value := VCons ttrue VNil.
-Definition l2 : Value := VCons ttrue ttrue.
-Definition l3 : Value := VCons (VCons ttrue ttrue) ttrue.
-Definition l4 : Value := VCons ttrue (VCons ttrue (VCons ttrue VNil)).
-Definition l5 : Value := VCons ttrue (VCons ttrue ttrue).
-
-Compute (eval "++" [ttrue; ttrue]) [] = (inr (badarg _), []).
-Compute (eval "++" [l1; l1]) [].
-Compute (eval "++" [l1; l2]) [].
-Compute (eval "++" [l1; l3]) [].
-Compute (eval "++" [l3; l3]) [].
-
-Compute (eval "--" [ttrue; ttrue]) [] = (inr (badarg _), []).
-Compute (eval "--" [l1; l1]) [].
-Compute (eval "--" [l1; l2]) [].
-Compute (eval "--" [l1; l3]) [].
-Compute (eval "--" [l3; l3]) [].
-Compute (eval "--" [l3; l1]) [].
-Compute (eval "--" [l4; l4]) [].
-
-Compute (eval "tuple_to_list" [VTuple [ttrue; ttrue; ttrue; l1]] []).
-Compute (eval "tuple_to_list" [VTuple [ttrue; ttrue; l5; l1]] []).
-Compute (eval "tuple_to_list" [VTuple [ttrue; l3; ttrue; l1]] []).
-Compute (eval "tuple_to_list" [VTuple [ttrue; ttrue; l2; l1]] []).
-Compute (eval "tuple_to_list" [ttrue] []).
-
-Compute (eval "list_to_tuple" [l1] []).
-Compute (eval "list_to_tuple" [l2] []).
-Compute (eval "list_to_tuple" [l3] []).
-Compute (eval "list_to_tuple" [l4] []).
-Compute (eval "list_to_tuple" [l5] []).
-
-Compute (eval "<" [ttrue; ttrue]) [] = (inl ffalse, []).
-Compute (eval "<" [ttrue; ffalse]) [] = (inl ffalse, []).
-Compute (eval "<" [VClos [] [] 1 [] EEmptyMap; VEmptyMap]) [] = (inl ttrue, []).
-Compute (eval "<" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 2 [] EEmptyMap]) [] = (inl ttrue, []).
-Compute (eval "<" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl ffalse, []).
-
-Compute (eval "=<" [ttrue; ttrue]) [] = (inl ttrue, []).
-Compute (eval "=<" [ttrue; ffalse]) [] = (inl ffalse, []).
-Compute (eval "=<" [VClos [] [] 1 [] EEmptyMap; VEmptyMap]) [] = (inl ttrue, []).
-Compute (eval "=<" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 2 [] EEmptyMap]) [] = (inl ttrue, []).
-Compute (eval "=<" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl ttrue, []).
-
-Compute (eval ">" [ttrue; ttrue]) [] = (inl ffalse, []).
-Compute (eval ">" [ffalse; ttrue]) [] = (inl ffalse, []).
-Compute (eval ">" [VEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl ttrue, []).
-Compute (eval ">" [VClos [] [] 2 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl ttrue, []).
-Compute (eval ">" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl ffalse, []).
-
-Compute (eval ">=" [ttrue; ttrue]) [] = (inl ttrue, []).
-Compute (eval ">=" [ffalse; ttrue]) [] = (inl ffalse, []).
-Compute (eval ">=" [VEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl ttrue, []).
-Compute (eval ">=" [VClos [] [] 2 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl ttrue, []).
-Compute (eval ">=" [VClos [] [] 1 [] EEmptyMap; VClos [] [] 1 [] EEmptyMap]) [] = (inl ttrue, []).
 
 (** End of tests *)
 
@@ -410,7 +14,8 @@ Reserved Notation "| env , id , e , eff | -e> | id' , e' , eff' |" (at level 70)
 Reserved Notation "| env , id , e , eff | -s> | id' , e' , eff' |" (at level 70).
 Inductive eval_expr : Environment -> nat -> Expression -> SideEffectList -> nat ->
     (ValueSequence + Exception) -> SideEffectList -> Prop :=
-| eval_evalues env exps vals eff ids eff1 id eff' id':
+(* valuelist evaluation *)
+| eval_values env exps vals eff ids eff1 id eff' id':
   length exps = length vals ->
   length exps = length eff ->
   length exps = length ids ->
@@ -418,40 +23,63 @@ Inductive eval_expr : Environment -> nat -> Expression -> SideEffectList -> nat 
     forall i, i < length exps ->
     |env, nth_def ids id 0 i, nth i exps ErrorExp, nth_def eff eff1 [] i|
      -s> 
-    |nth_def ids id 0 (S i), inl (nth i vals ErrorValue), nth_def eff eff1 [] (S i)|
+    |nth_def ids id 0 (S i), inl [nth i vals ErrorValue], nth_def eff eff1 [] (S i)|
   ) ->
   id' = last ids id ->
   eff' = last eff eff1
 ->
-  |env, id, EValues exps, eff1| -e> |id', vals, eff'|
+  |env, id, EValues exps, eff1| -e> |id', inl vals, eff'|
+
+(* valuelist exception *)
+
+| eval_evalues env exps ex vals eff ids eff1 id eff' id' i:
+  i < length exps ->
+  length vals = i ->
+  length eff = i ->
+  length ids = i ->
+  (
+    forall j, j < i ->
+    |env, nth_def ids id 0 j, nth j exps ErrorExp, nth_def eff eff1 [] j|
+     -s> 
+    |nth_def ids id 0 (S j), inl [nth j vals ErrorValue], nth_def eff eff1 [] (S j)|
+  ) ->
+  |env, last ids id, nth i exps ErrorExp, last eff eff1| -e> |id', inr ex, eff'|
+->
+  |env, id, EValues exps, eff1| -e> |id', inr ex, eff'|
+
+
+| eval_single env id e eff1 id' res eff':
+  |env, id, e, eff1| -s> |id', res, eff'|
+->
+  |env, id, ESingle e, eff1| -e> |id', res, eff'|
 
 where "| env , id , e , eff | -e> | id' , e' , eff' |" := (eval_expr env id e eff id' e' eff')
 with eval_singleexpr : Environment -> nat -> SingleExpression -> SideEffectList -> nat ->
     (ValueSequence + Exception) -> SideEffectList -> Prop :=
 
 | eval_nil (env : Environment) (eff : SideEffectList) (id : nat):
-  |env, id, ENil, eff| -e> |id, inl VNil, eff|
+  |env, id, ENil, eff| -s> |id, inl [VNil], eff|
 
 (* literal evaluation rule *)
 | eval_lit (env : Environment) (l : Literal) (eff : SideEffectList) (id : nat):
-  |env, id, ELit l, eff| -e> |id, inl (VLit l), eff|
+  |env, id, ELit l, eff| -s> |id, inl [VLit l], eff|
 
 (* variable evaluation rule *)
-| eval_var (env:Environment) (s: Var) (eff : SideEffectList) (id : nat) (res : Value + Exception) :
+| eval_var (env:Environment) (s: Var) (eff : SideEffectList) (id : nat) (res : ValueSequence + Exception) :
   res = get_value env (inl s)
 ->
-  |env, id, EVar s, eff| -e> |id, res, eff|
+  |env, id, EVar s, eff| -s> |id, res, eff|
 
 (* Function Identifier evaluation rule *)
 | eval_funid (env:Environment) (fid : FunctionIdentifier) (eff : SideEffectList) 
-    (res : Value + Exception) (id : nat):
+    (res : ValueSequence + Exception) (id : nat):
   res = get_value env (inr fid)
 ->
-  |env, id, EFunId fid, eff| -e> |id, res, eff|
+  |env, id, EFunId fid, eff| -s> |id, res, eff|
 
 (* Function evaluation *)
 | eval_fun (env : Environment) (vl : list Var) (e : Expression) (eff : SideEffectList) (id : nat):
-  |env, id, EFun vl e, eff| -e> |S id, inl (VClos env [] id vl e), eff|
+  |env, id, EFun vl e, eff| -s> |S id, inl [VClos env [] id vl e], eff|
 
 (* tuple evaluation rule *)
 | eval_tuple (env: Environment) (exps : list Expression) (vals : list Value) 
@@ -463,49 +91,41 @@ with eval_singleexpr : Environment -> nat -> SingleExpression -> SideEffectList 
     forall i, i < length exps ->
       |env, nth_def ids id 0 i, nth i exps ErrorExp, nth_def eff eff1 [] i| 
      -e> 
-      |nth_def ids id 0 (S i), inl (nth i vals ErrorValue), nth_def eff eff1 [] (S i)|
+      |nth_def ids id 0 (S i), inl [nth i vals ErrorValue], nth_def eff eff1 [] (S i)|
   ) ->
   eff2 = last eff eff1 ->
   id' = last ids id (* if length = 0, then last id = first id *)
 ->
-  |env, id, ETuple exps, eff1| -e> |id' , inl (VTuple vals), eff2|
+  |env, id, ETuple exps, eff1| -s> |id' , inl [VTuple vals], eff2|
 
 (* list evaluation rule *)
 | eval_cons (env:Environment) (hd tl: Expression) (hdv tlv : Value) 
      (eff1 eff2 eff3 : SideEffectList) (id id' id'' : nat) :
-  |env, id, tl, eff1| -e> |id', inl tlv, eff2| ->
-  |env, id', hd, eff2| -e> | id'', inl hdv, eff3|
+  |env, id, tl, eff1| -e> |id', inl [tlv], eff2| ->
+  |env, id', hd, eff2| -e> | id'', inl [hdv], eff3|
 ->
-  |env, id, ECons hd tl, eff1| -e> |id'', inl (VCons hdv tlv), eff3|
+  |env, id, ECons hd tl, eff1| -s> |id'', inl [VCons hdv tlv], eff3|
 
 (* case evaluation rules *)
-| eval_case (env: Environment) (guard exp: Expression) (exps : list Expression) (vals : list Value) (v' : Value + Exception) (l : list (list Pattern * Expression * Expression)) (bindings: list (Var * Value)) (i : nat) (eff : list SideEffectList) (eff1 eff2 : SideEffectList) (ids : list nat) (id id' : nat) :
-  length exps = length vals ->
-  length exps = length eff ->
-  length exps = length ids ->
-  (
-    forall i, i < length exps ->
-    |env, nth_def ids id 0 i, nth i exps ErrorExp, nth_def eff eff1 [] i| 
-     -e> 
-    |nth_def ids id 0 (S i), inl (nth i vals ErrorValue), nth_def eff eff1 [] (S i)|
-  ) ->
+| eval_case (env: Environment) (guard exp: Expression) (e : Expression) (vals : ValueSequence) (res : ValueSequence + Exception) (l : list (list Pattern * Expression * Expression)) (bindings: list (Var * Value)) (i : nat) (eff1 eff2 eff3 : SideEffectList) (id id' id'' : nat) :
+  |env, id, e, eff1| -e> |id', inl vals, eff2| ->
   i < length l ->
   match_clause vals l i = Some (guard, exp, bindings) ->
   (forall j : nat, j < i -> 
 
     (** THESE GUARDS MUST BE SIDE-EFFECT FREE ACCORDING TO 1.0.3 LANGUAGE SPECIFICATION *)
     (forall gg ee bb, match_clause vals l j = Some (gg, ee, bb) -> 
-      (|add_bindings bb env, last ids id, gg, last eff eff1| -e> |last ids id, inl ffalse, last eff eff1| ))
+      (|add_bindings bb env, id', gg, eff2| -e> |id', inl [ffalse], eff2| ))
 
   ) ->
-  |add_bindings bindings env, last ids id, guard, last eff eff1| -e> |last ids id, inl ttrue, last eff eff1| -> 
-  |add_bindings bindings env, last ids id, exp, last eff eff1| -e> |id', v', eff2|
+  |add_bindings bindings env, id', guard, eff2| -e> |id', inl [ttrue], eff2| -> 
+  |add_bindings bindings env, id', exp, eff2| -e> |id'', res, eff3|
 ->
-  |env, id, ECase exps l, eff1| -e> |id', v', eff2|
+  |env, id, ECase e l, eff1| -s> |id'', res, eff3|
 
 
 (* call evaluation rule *)
-| eval_call (env: Environment) (v : Value + Exception) (params : list Expression) 
+| eval_call (env: Environment) (res : ValueSequence + Exception) (params : list Expression) 
      (vals : list Value) (fname: string) (eff1 eff2: SideEffectList) (eff : list SideEffectList) 
      (ids : list nat) (id id' : nat) :
   length params = length vals ->
@@ -515,20 +135,20 @@ with eval_singleexpr : Environment -> nat -> SingleExpression -> SideEffectList 
     forall i, i < length params ->
       |env, nth_def ids id 0 i, nth i params ErrorExp, nth_def eff eff1 [] i| 
      -e>
-      |nth_def ids id 0 (S i), inl (nth i vals ErrorValue), nth_def eff eff1 [] (S i)|
+      |nth_def ids id 0 (S i), inl [nth i vals ErrorValue], nth_def eff eff1 [] (S i)|
   ) ->
-  eval fname vals (last eff eff1) = (v, eff2) ->
+  eval fname vals (last eff eff1) = (res, eff2) ->
   id' = last ids id
 ->
-  |env, id, ECall fname params, eff1| -e> |id', v, eff2|
+  |env, id, ECall fname params, eff1| -s> |id', res, eff2|
 
 (* apply functions*)
 | eval_app (params : list Expression) (vals : list Value) (env : Environment) 
-     (exp : Expression) (body : Expression) (v : Value + Exception) (var_list : list Var) 
+     (exp : Expression) (body : Expression) (res : ValueSequence + Exception) (var_list : list Var) 
      (ref : Environment) (ext : list (nat * FunctionIdentifier * FunctionExpression)) (n : nat)
      (eff1 eff2 eff3 : SideEffectList) (eff : list SideEffectList) (ids : list nat) (id id' id'' : nat) :
   length params = length vals ->
-  |env, id, exp, eff1| -e> |id', inl (VClos ref ext n var_list body), eff2| ->
+  |env, id, exp, eff1| -e> |id', inl [VClos ref ext n var_list body], eff2| ->
   length var_list = length vals
   ->
   length params = length eff ->
@@ -537,7 +157,7 @@ with eval_singleexpr : Environment -> nat -> SingleExpression -> SideEffectList 
     forall i, i < length params ->
       |env, nth_def ids id' 0 i, nth i params ErrorExp, nth_def eff eff2 [] i|
      -e>
-      |nth_def ids id' 0 (S i), inl (nth i vals ErrorValue), nth_def eff eff2 [] (S i)|
+      |nth_def ids id' 0 (S i), inl [nth i vals ErrorValue], nth_def eff eff2 [] (S i)|
   )
   ->
   |append_vars_to_env var_list vals (get_env ref ext), 
@@ -545,43 +165,34 @@ with eval_singleexpr : Environment -> nat -> SingleExpression -> SideEffectList 
    body, 
    last eff eff2|
   -e>
-   |id'', v, eff3|
+   |id'', res, eff3|
 ->
-  |env, id, EApp exp params, eff1| -e> |id'', v, eff3|
+  |env, id, EApp exp params, eff1| -s> |id'', res, eff3|
 
 (* let evaluation rule *)
-| eval_let (env: Environment) (l: list (Var * Expression)) (vals : list Value) (e : Expression) (v : Value + Exception) (eff : list SideEffectList) (eff1 eff2 : SideEffectList) (id id' : nat) (ids : list nat):
+| eval_let (env: Environment) (l: list Var) (vals : ValueSequence) (e1 e2 : Expression) (res : ValueSequence + Exception) (eff1 eff' eff'' : SideEffectList) (id id' id'' : nat) :
+  |env, id, e1, eff1| -e> |id', inl vals, eff'| ->
   length l = length vals ->
-  length l = length eff ->
-  length l = length ids ->
-  (
-    forall i, i < length l ->
-      |env, nth_def ids id 0 i, nth i (snd (split l)) ErrorExp, nth_def eff eff1 [] i| 
-       -e> 
-      | nth_def ids id 0 (S i), inl (nth i vals ErrorValue), nth_def eff eff1 [] (S i)|
-  )
-  ->
-    |append_vars_to_env (fst (split l)) vals env, last ids id, e, last eff eff1|
-     -e>
-    |id', v, eff2|
+  |append_vars_to_env l vals env, id', e2, eff'| -e> |id'', res, eff''|
 ->
-  |env, id, ELet l e, eff1| -e> |id', v, eff2|
+  |env, id, ELet l e1 e2, eff1| -s> |id'', res, eff''|
 
 (* evaluation of sequence (do expressions) *)
-| eval_seq (env : Environment) (e1 e2: Expression) (v1 : Value) (v2 : Value + Exception)
+| eval_seq (env : Environment) (e1 e2: Expression) (v1 : Value) (v2 : ValueSequence + Exception)
      (eff1 eff2 eff3 : SideEffectList) (id id' id'' : nat) :
-  |env, id, e1, eff1| -e> |id', inl v1, eff2| ->
+   (* THE FIRST RESULT SHOULD BE A SINGLE VALUE *)
+  |env, id, e1, eff1| -e> |id', inl [v1], eff2| ->
   |env, id', e2, eff2| -e> |id'', v2, eff3|
 ->
-  | env, id, ESeq e1 e2, eff1 | -e> |id'', v2, eff3|
+  | env, id, ESeq e1 e2, eff1 | -s> |id'', v2, eff3|
 
 (* Letrec evaluation rule *)
-| eval_letrec (env: Environment) (e : Expression)  (l : list (FunctionIdentifier * ((list Var) * Expression))) (v : Value + Exception) (eff1 eff2 : SideEffectList) (id id' : nat) :
+| eval_letrec (env: Environment) (e : Expression)  (l : list (FunctionIdentifier * ((list Var) * Expression))) (res : ValueSequence + Exception) (eff1 eff2 : SideEffectList) (id id' : nat) :
   (
-     |append_funs_to_env l env id, id + length l, e, eff1| -e> | id', v, eff2|
+     |append_funs_to_env l env id, id + length l, e, eff1| -e> | id', res, eff2|
   )
 ->
-  |env, id, ELetRec l e, eff1| -e> | id', v, eff2|
+  |env, id, ELetRec l e, eff1| -s> | id', res, eff2|
 
 
 
@@ -595,13 +206,13 @@ with eval_singleexpr : Environment -> nat -> SingleExpression -> SideEffectList 
     forall i : nat, i < length l ->
     |env, nth_def ids id 0 (2 * i), nth i (fst (split l)) ErrorExp, nth_def eff eff1 [] (2 * i)| 
      -e>
-    | nth_def ids id 0 (S (2 * i)), inl (nth i kvals ErrorValue), nth_def eff eff1 [] (S (2*i))|
+    | nth_def ids id 0 (S (2 * i)), inl [nth i kvals ErrorValue], nth_def eff eff1 [] (S (2*i))|
   ) ->
   (
     forall i : nat, i < length l ->
     |env, nth_def ids id 0 (S (2 * i)), nth i (snd (split l)) ErrorExp, nth_def eff eff1 [] (S (2* i))|
      -e>
-    |nth_def ids id 0 (S (S (2 * i))), inl (nth i vvals ErrorValue), nth_def eff eff1 [] (S (S (2*i)))|
+    |nth_def ids id 0 (S (S (2 * i))), inl [nth i vvals ErrorValue], nth_def eff eff1 [] (S (S (2*i)))|
 
   ) ->
   make_value_map kvals vvals = (kvals', vvals') ->
@@ -610,9 +221,9 @@ with eval_singleexpr : Environment -> nat -> SingleExpression -> SideEffectList 
   eff2 = last eff eff1 ->
   id' = last ids id
 ->
-  |env, id, EMap l, eff1| -e> |id', inl (VMap lv), eff2|
+  |env, id, EMap l, eff1| -s> |id', inl [VMap lv], eff2|
 
-
+(*
   (* EXCEPTIONS *)
 (* list tail exception *)
 | eval_cons_tl_ex (env: Environment) (hd tl : Expression) (ex : Exception) 
@@ -887,9 +498,43 @@ with eval_singleexpr : Environment -> nat -> SingleExpression -> SideEffectList 
 ->
   |env, id, EMap l, eff1| -e> |id'', inr ex, eff3|
 
-
+*)
 where "| env , id , e , eff | -s> | id' , e' , eff' |" := (eval_singleexpr env id e eff id' e' eff')
 .
+
+(* Open Scope string_scope.
+
+Definition let_expr :=
+  ELet ["X"; "Y"] (ELet ["X"] (ErrorExp) (EValues [ErrorExp; ErrorExp; ErrorExp])) (EVar "X").
+
+Goal
+  valid_expression let_expr = true ->
+  |[], 0, let_expr, []| -e> |0, inl [ErrorValue], []|.
+Proof.
+  intros. simpl in H.
+  unfold let_expr.
+  apply eval_single. eapply eval_let.
+  * apply eval_single. eapply eval_let.
+    - apply eval_single, eval_lit.
+    - auto.
+    - simpl. apply eval_values with (ids := [0;0;0]) (eff := [[];[];[]]) (vals := [ErrorValue; ErrorValue]); auto.
+      + intros. inversion H0. 2: inversion H2. 3: inversion H4. all: apply eval_lit.
+  * simpl. apply eval_single, eval_var. simpl. reflexivity.
+Qed. *)
+
+
+(* Goal
+  valid_expression (ETuple [^ErrorExp; EValues [ErrorExp; ErrorExp] ]) = true ->
+  |[], 0, ETuple [^ErrorExp; EValues [ErrorExp; ErrorExp] ], []| -e> |0, inl [VTuple [ErrorValue; ErrorValue]], []|.
+Proof.
+  intro A. simpl in A.
+  apply eval_single.
+  apply eval_tuple with (vals := [ErrorValue; ErrorValue]) (eff := [[];[]]) (ids := [0;0]); auto.
+  * intros. inversion H. 2: inversion H1. 3: inversion H3.
+    - simpl. eapply eval_values with (eff := [[];[]]) (ids := [0;0]); auto. ad i
+      + intros. inversion H0. 2: inversion H3. apply eval_lit.
+    - simpl. apply eval_single. apply eval_lit.
+Qed. *)
 
 
 (* These are the initialization function before evaluating a module *)
@@ -914,5 +559,20 @@ Fixpoint initialize_proving_closures (module : ErlModule) : Closures :=
 match module with
 | ErlMod s fl => add_elements_to_closure fl module
 end. *)
+
+Reserved Notation "e --e-> v" (at level 50).
+Inductive eval_to_result : Expression -> ValueSequence + Exception -> Prop :=
+| eval_expr_intro e v : (exists n eff, | [], 0, e, [] | -e> |n, v, eff|) -> e --e-> v
+where "e --e-> v" := (eval_to_result e v).
+
+Definition valid_result (res : ValueSequence + Exception) :=
+match res with
+| inl vals => length vals =? 1
+| _ => true
+end.
+
+Definition eval_to e :=
+  exists res, e --e-> res /\ valid_expression e = true /\ valid_result res = true.
+
 
 End Semantics.

--- a/src/Core_Erlang_Semantics.v
+++ b/src/Core_Erlang_Semantics.v
@@ -512,13 +512,20 @@ with eval_singleexpr : Environment -> nat -> SingleExpression -> SideEffectList 
 where "| env , id , e , eff | -s> | id' , e' , eff' |" := (eval_singleexpr env id e eff id' e' eff')
 .
 
+(* Check eval_expr_ind.
+Check eval_singleexpr_ind. *)
 
-(* Scheme eval_expr_ind2 := Induction for eval_expr Sort Prop
+
+Scheme eval_expr_ind2 := Induction for eval_expr Sort Prop
 with eval_singleexpr_ind2 := Induction for eval_singleexpr Sort Prop.
 
-Check eval_expr_ind.
+(* Check eval_expr_ind.
 
 Check eval_expr_ind2. *)
+
+Combined Scheme eval_ind from eval_expr_ind2, eval_singleexpr_ind2.
+
+(* Check eval_ind. *)
 
 (* Open Scope string_scope.
 

--- a/src/Core_Erlang_Semantics.v
+++ b/src/Core_Erlang_Semantics.v
@@ -8,8 +8,6 @@ Export Core_Erlang_Environment.Environment.
 
 Import ListNotations.
 
-(** End of tests *)
-
 Reserved Notation "| env , id , e , eff | -e> | id' , e' , eff' |" (at level 70).
 Reserved Notation "| env , id , e , eff | -s> | id' , e' , eff' |" (at level 70).
 Inductive eval_expr : Environment -> nat -> Expression -> SideEffectList -> nat ->
@@ -531,7 +529,7 @@ Check eval_expr_ind2. *)
 
 Combined Scheme eval_ind from eval_expr_ind2, eval_singleexpr_ind2.
 
-(* Check eval_ind. *)
+Check eval_ind.
 
 (* Open Scope string_scope.
 

--- a/src/Core_Erlang_Side_Effect_Tests.v
+++ b/src/Core_Erlang_Side_Effect_Tests.v
@@ -6,200 +6,199 @@ Import Core_Erlang_Semantics.Semantics.
 
 Import ListNotations.
 
-
+Open Scope string_scope.
 
 Example tuple_eff :
-  |[], 0, ETuple [ECall "fwrite"%string [ELit (Atom "a"%string)];
-               ECall "fwrite"%string [ELit (Atom "b"%string)];
-               ECall "fread"%string [ELit (Atom ""%string) ; ELit (Atom "c"%string)]], []|
+  |[], 0, ETuple [^ECall "fwrite" [^ELit (Atom "a")];
+               ^ECall "fwrite" [^ELit (Atom "b")];
+               ^ECall "fread" [^ELit (Atom "") ; ^ELit (Atom "c")]], []|
 -e>
-  |0, inl (VTuple [ok;ok; VTuple [ok; VLit (Atom "c"%string)]]), 
-     [(Output, [VLit (Atom "a"%string)]); (Output, [VLit (Atom "b"%string)]);
-      (Input, [VLit (Atom ""%string); VLit (Atom "c"%string)])]|.
+  |0, inl [VTuple [ok;ok; VTuple [ok; VLit (Atom "c")]]], 
+     [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]);
+      (Input, [VLit (Atom ""); VLit (Atom "c")])]|.
 Proof.
-  apply eval_tuple with (eff := [[(Output, [VLit (Atom "a"%string)])]; 
+  apply eval_single, eval_tuple with (eff := [[(Output, [VLit (Atom "a")])]; 
                                  [(Output, [VLit (Atom "a")]); 
-                                  (Output, [VLit (Atom "b"%string)])]; 
+                                  (Output, [VLit (Atom "b")])]; 
                                  [(Output, [VLit (Atom "a")]);
                                   (Output, [VLit (Atom "b")]);
-                                  (Input, [VLit (Atom ""%string); 
-                                           VLit (Atom "c"%string)])]])
+                                  (Input, [VLit (Atom ""); 
+                                           VLit (Atom "c")])]])
                         (ids := [0;0;0]); auto.
   * intros. inversion H.
-    - subst. simpl. apply eval_call with (vals := [VLit (Atom ""%string); 
-                                                   VLit (Atom "c"%string)])
+    - subst. simpl. apply eval_single, eval_call with (vals := [VLit (Atom ""); 
+                                                   VLit (Atom "c")])
                                          (eff := [ [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]; 
                                                    [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])] ])
                                          (ids := [0 ; 0]); auto.
       + intros. inversion H0.
-        ** subst. simpl. apply eval_lit. 
+        ** subst. simpl. apply eval_single, eval_lit. 
         ** inversion H2.
-          -- simpl. apply eval_lit.
+          -- simpl. apply eval_single, eval_lit.
           -- inversion H4.
-    - inversion H1. simpl. apply eval_call with (vals := [VLit (Atom "b"%string)])
+    - inversion H1. simpl. apply eval_single, eval_call with (vals := [VLit (Atom "b")])
                                                 (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [0]); auto.
       + intros. inversion H2.
-        ** apply eval_lit.
+        ** apply eval_single, eval_lit.
         ** inversion H5.
-      + inversion H3. simpl. apply eval_call with (vals := [VLit (Atom "a"%string)])
+      + inversion H3. simpl. apply eval_single, eval_call with (vals := [VLit (Atom "a")])
                                                   (eff := [[]]) (ids := [0]); auto.
         ** intros. inversion H4.
-          -- apply eval_lit.
+          -- apply eval_single, eval_lit.
           -- inversion H7.
         ** inversion H5.
 Qed.
 
 Example list_eff :
-  |[], 0, ECons (ECall "fwrite"%string [ELit (Atom "a")])
-             (ECons (ECall "fwrite"%string [ELit (Atom "b")]) ENil), []|
+  |[], 0, ECons (ECall "fwrite" [^ELit (Atom "a")])
+             (ECons (ECall "fwrite" [^ELit (Atom "b")]) ENil), []|
 -e> 
-  | 0, inl (VCons ok (VCons ok VNil)), 
+  | 0, inl [VCons ok (VCons ok VNil)], 
      [(Output, [VLit (Atom "b")]); (Output, [VLit (Atom "a")])]|.
 Proof.
-  eapply eval_cons with (eff2 := [(Output, [VLit (Atom "b")])]).
-  * simpl. eapply eval_cons with (eff2 := []).
-    - apply eval_nil.
-    - eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]) (ids := [0]); auto.
-      + intros. inversion H. 2: inversion H1. apply eval_lit.
-  * simpl. eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[(Output, [VLit (Atom "b")])]]) (ids := [0]); auto.
-    - intros. inversion H. 2: inversion H1. apply eval_lit.
+  eapply eval_single, eval_cons with (eff2 := [(Output, [VLit (Atom "b")])]).
+  * simpl. eapply eval_single, eval_cons with (eff2 := []).
+    - apply eval_single, eval_nil.
+    - eapply eval_single, eval_call with (vals := [VLit (Atom "b")]) (eff := [[]]) (ids := [0]); auto.
+      + intros. inversion H. 2: inversion H1. apply eval_single, eval_lit.
+  * simpl. eapply eval_single, eval_call with (vals := [VLit (Atom "a")]) (eff := [[(Output, [VLit (Atom "b")])]]) (ids := [0]); auto.
+    - intros. inversion H. 2: inversion H1. apply eval_single, eval_lit.
 Qed.
 
 Example case_eff : 
-  |[], 0, ECase [ECall "fwrite"%string [ELit (Atom "a")]]
-      [([PVar "X"%string], ELit (Atom "false"), (ECall "fwrite"%string [ELit (Atom "b")])); 
-       ([PLit (Integer 5)], ELit (Atom "true"), ELit (Integer 2)); 
-       ([PVar "Y"%string], ELit (Atom "true"), (ECall "fwrite"%string [ELit (Atom "c")]))]
+  |[], 0, ECase (ECall "fwrite" [^ELit (Atom "a")])
+      [([PVar "X"], ^ELit (Atom "false"), ^(ECall "fwrite" [^ELit (Atom "b")])); 
+       ([PLit (Integer 5)], ^ELit (Atom "true"), ^ELit (Integer 2)); 
+       ([PVar "Y"], ^ELit (Atom "true"), ^(ECall "fwrite" [^ELit (Atom "c")]))]
   , []|
 -e>
-  |0, inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
+  |0, inl [ok], [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "c")])]|.
 Proof.
-  eapply eval_case with (i := 2) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [0]) (vals := [ok]); auto.
-  * intros. inversion H.
-    - eapply eval_call with (vals := [VLit (Atom "a")]) (eff :=[[]]) (ids := [0]); auto.
-      + intros. inversion H0. 2: inversion H3. apply eval_lit.
-    - inversion H1.
+  eapply eval_single, eval_case with (i := 2); auto.
+  * eapply eval_single, eval_call with (vals := [VLit (Atom "a")]) (eff :=[[]]) (ids := [0]); auto.
+    - intros. inversion H. 2: inversion H1. apply eval_single, eval_lit.
+    - simpl. reflexivity.
   * simpl. reflexivity.
   * intros. inversion H. 2: inversion H2. 3: inversion H4.
     - subst. inversion H0.
-    - subst. inversion H0. apply eval_lit.
-  * simpl. apply eval_lit.
-  * simpl. eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [0]); auto.
-    - intros. inversion H. 2: inversion H1. simpl. apply eval_lit.
+    - subst. inversion H0. apply eval_single, eval_lit.
+  * simpl. apply eval_single, eval_lit.
+  * simpl. eapply eval_single, eval_call with (vals := [VLit (Atom "c")]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [0]); auto.
+    - intros. inversion H. 2: inversion H1. simpl. apply eval_single, eval_lit.
 Qed.
 
 Example call_eff :
-  |[], 0, ECall "fwrite"%string [ECall "fwrite"%string [ELit (Atom "a")]], []|
+  |[], 0, ECall "fwrite" [^ECall "fwrite" [^ELit (Atom "a")]], []|
 -e>
-  | 0, inl ok, [(Output, [VLit (Atom "a")]); (Output, [ok])]|.
+  | 0, inl [ok], [(Output, [VLit (Atom "a")]); (Output, [ok])]|.
 Proof.
-  eapply eval_call with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [0]); auto.
+  eapply eval_single, eval_call with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [0]); auto.
   * intros. inversion H. 2: inversion H1. simpl. 
-    eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
-    - intros. inversion H0. 2: inversion H3. simpl. apply eval_lit.
+    eapply eval_single, eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
+    - intros. inversion H0. 2: inversion H3. simpl. apply eval_single, eval_lit.
 Qed.
 
 Example apply_eff : 
-  |[(inl "Y"%string, VClos [] [] 0 ["Z"%string] (ECall "fwrite"%string [ELit (Atom "c")]))], 1, 
-    EApp (ELet [("X"%string, ECall "fwrite"%string [ELit (Atom "a")])] 
-             (EVar "Y"%string))
-           [ECall "fwrite" [ELit (Atom "b")] ], []|
+  |[(inl "Y", VClos [] [] 0 ["Z"] (ECall "fwrite" [^ELit (Atom "c")]))], 1, 
+    EApp (ELet ["X"] (ECall "fwrite" [^ELit (Atom "a")]) 
+             (EVar "Y"))
+           [^ECall "fwrite" [^ELit (Atom "b")] ], []|
 -e>
-  |1, inl ok, 
+  |1, inl [ok], 
    [(Output, [VLit (Atom "a")]);
     (Output, [VLit (Atom "b")]);
     (Output, [VLit (Atom "c")])]|.
 Proof.
-  eapply eval_app with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]]) 
-                       (ref := []) (ext := []) (var_list := ["Z"%string]) (n := 0)
-                       (body := ECall "fwrite"%string [ELit (Atom "c")]) (ids := [1]); auto.
-  * eapply eval_let with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [1]); auto.
-    - intros. inversion H. 2: inversion H1. 
-      eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [1]); auto.
-      + intros. inversion H0. 2: inversion H3. apply eval_lit.
-    - simpl. apply eval_var. reflexivity.
+  eapply eval_single, eval_app with (vals := [ok]) (eff := [[(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]]) 
+                       (ref := []) (ext := []) (var_list := ["Z"]) (n := 0)
+                       (body := ECall "fwrite" [^ELit (Atom "c")]) (ids := [1]); auto.
+  * eapply eval_single, eval_let; auto.
+    - eapply eval_single, eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [1]); auto.
+      + intros. inversion H. 2: inversion H1. apply eval_single, eval_lit.
+      + reflexivity.
+    - auto.
+    - simpl. apply eval_single, eval_var. reflexivity.
   * intros. inversion H. 2: inversion H1. simpl. 
-    apply eval_call with (vals := [VLit (Atom "b")]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [1]); auto.
-    - intros. inversion H0. 2: inversion H3. simpl. apply eval_lit.
-  * simpl. eapply eval_call with (vals := [VLit (Atom "c")]) (eff := [[(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]]) (ids := [1]); auto.
-    - intros. inversion H. 2: inversion H1. simpl. apply eval_lit.
+    apply eval_single, eval_call with (vals := [VLit (Atom "b")]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [1]); auto.
+    - intros. inversion H0. 2: inversion H3. simpl. apply eval_single, eval_lit.
+  * simpl. eapply eval_single, eval_call with (vals := [VLit (Atom "c")]) (eff := [[(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]]) (ids := [1]); auto.
+    - intros. inversion H. 2: inversion H1. simpl. apply eval_single, eval_lit.
 Qed.
 
 Example let_eff : 
-  |[], 0, ELet [("X"%string, ECall "fwrite"%string [ELit (Atom "a")]); 
-                ("Y"%string, EFun [] (ECall "fwrite"%string [ELit (Atom "b")]))]
-          (EApp (EVar "Y"%string) []), []|
+  |[], 0, ELet ["X"; "Y"] 
+     (EValues [ECall "fwrite" [^ELit (Atom "a")]; EFun [] (ECall "fwrite" [^ELit (Atom "b")])])
+          (EApp (EVar "Y") []), []|
 -e>
-  |1, inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
+  |1, inl [ok], [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]|.
 Proof.
-  eapply eval_let with (vals := [ok;
-                                 VClos [] [] 0 [] (ECall "fwrite"%string [ELit (Atom "b")])])
-                       (eff := [[(Output, [VLit (Atom "a")])]; [(Output, [VLit (Atom "a")])]])
-                       (ids := [0;1]); auto.
-  * intros. inversion H. 2: inversion H1. 3: inversion H3.
-    - simpl. apply eval_fun.
-    - simpl. eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
-      + intros. inversion H2. 2: inversion H5. apply eval_lit.
-  * eapply eval_app with (vals := []) (var_list := []) (ids := [])
+  eapply eval_single, eval_let; auto.
+  * apply eval_values with (eff := [[(Output, [VLit (Atom "a")])]; [(Output, [VLit (Atom "a")])]]) (ids := [0;1]) (vals := [ok; VClos [] [] 0 [] (ECall "fwrite"%string [^ELit (Atom "b")])]); auto.
+    - intros. inversion H. 2: inversion H1. 3: inversion H3.
+      + simpl. apply eval_fun.
+      + simpl. eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [0]); auto.
+        ** intros. inversion H2. 2: inversion H5. apply eval_single, eval_lit.
+  * auto.
+  * eapply eval_single, eval_app with (vals := []) (var_list := []) (ids := [])
                          (ref := []) (ext := []) (n := 0)
-                         (body := ECall "fwrite"%string [ELit (Atom "b")]) 
+                         (body := ECall "fwrite" [^ELit (Atom "b")]) 
                          (eff := []); auto.
-    - simpl. apply eval_var. reflexivity.
+    - simpl. apply eval_single, eval_var. reflexivity.
     - intros. inversion H.
-    - simpl. eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [1]); auto.
-      + intros. inversion H. 2: inversion H1. apply eval_lit.
+    - simpl. eapply eval_single, eval_call with (vals := [VLit (Atom "b")]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [1]); auto.
+      + intros. inversion H. 2: inversion H1. apply eval_single, eval_lit.
 Qed.
 
 Example letrec_eff : 
-  |[], 0, ELetRec [(("f1"%string, 0), ([], ECall "fwrite"%string [ELit (Atom "a")]))]
-           (EApp (EFunId ("f1"%string, 0)) []), []|
+  |[], 0, ELetRec [(("f1", 0), ([], ^ECall "fwrite" [^ELit (Atom "a")]))]
+           (EApp (EFunId ("f1", 0)) []), []|
 -e>
-  |1, inl ok, [(Output, [VLit (Atom "a")])]|.
+  |1, inl [ok], [(Output, [VLit (Atom "a")])]|.
 Proof.
-  eapply eval_letrec; auto.
-  * simpl. eapply eval_app with (vals := []) (eff := []) (ref := []) (ids := [])
-                                (ext := [(0, ("f1"%string, 0),
-                                          ([], ECall "fwrite" [ELit (Atom "a")]))]) 
+  eapply eval_single, eval_letrec; auto.
+  * simpl. eapply eval_single, eval_app with (vals := []) (eff := []) (ref := []) (ids := [])
+                                (ext := [(0, ("f1", 0),
+                                          ([], ^ECall "fwrite" [^ELit (Atom "a")]))]) 
                                 (var_list := []) (n := 0)
-                                (body := ECall "fwrite"%string [ELit (Atom "a")]); auto.
-    - apply eval_funid. reflexivity.
+                                (body := ECall "fwrite" [^ELit (Atom "a")]); auto.
+    - apply eval_single, eval_funid. reflexivity.
     - intros. inversion H.
-    - simpl. apply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [1]); auto.
-      + intros. inversion H. 2: inversion H1. apply eval_lit.
+    - simpl. apply eval_single, eval_call with (vals := [VLit (Atom "a")]) (eff := [[]]) (ids := [1]); auto.
+      + intros. inversion H. 2: inversion H1. apply eval_single, eval_lit.
 Qed.
 
 Example map_eff : 
-  |[], 0, EMap [(ECall "fwrite"%string [ELit (Atom "a"%string)], ECall "fwrite"%string [ELit (Atom "b"%string)]);
-                (ECall "fwrite"%string [ELit (Atom "c"%string)], ELit (Integer 5))]
+  |[], 0, EMap [(^ECall "fwrite" [^ELit (Atom "a")], ^ECall "fwrite" [^ELit (Atom "b")]);
+                (^ECall "fwrite" [^ELit (Atom "c")], ^ELit (Integer 5))]
   , []| 
 -e> 
-  | 0, inl (VMap [(ok, VLit (Integer 5))]),
-      [(Output, [VLit (Atom "a"%string)]);
-       (Output, [VLit (Atom "b"%string)]);
-       (Output, [VLit (Atom "c"%string)])]|.
+  | 0, inl [VMap [(ok, VLit (Integer 5))]],
+      [(Output, [VLit (Atom "a")]);
+       (Output, [VLit (Atom "b")]);
+       (Output, [VLit (Atom "c")])]|.
 Proof.
-  eapply eval_map with (kvals := [ok; ok]) (vvals := [ok; VLit (Integer 5)])
+  eapply eval_single, eval_map with (kvals := [ok; ok]) (vvals := [ok; VLit (Integer 5)])
                        (eff := [[(Output, [VLit (Atom "a")])]; 
                                 [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]; 
                                 [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); (Output, [VLit (Atom "c")])]; 
                                 [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); (Output, [VLit (Atom "c")])]])
                        (ids := [0;0;0;0]); auto.
   * intros. inversion H.
-    - apply eval_call with (vals := [VLit (Atom "c")]) (eff := 
+    - apply eval_single, eval_call with (vals := [VLit (Atom "c")]) (eff := 
            [[(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])]]) (ids := [0]); auto.
       + intros. inversion H0.
-        ** simpl. apply eval_lit.
+        ** simpl. apply eval_single, eval_lit.
         ** inversion H3.
     - inversion H1.
-      + simpl. apply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]])
+      + simpl. apply eval_single, eval_call with (vals := [VLit (Atom "a")]) (eff := [[]])
                                     (ids := [0]); auto.
-        ** intros. inversion H2. 2: inversion H5. simpl. apply eval_lit.
+        ** intros. inversion H2. 2: inversion H5. simpl. apply eval_single, eval_lit.
       + inversion H3.
   * intros. inversion H.
-    - simpl. apply eval_lit.
+    - simpl. apply eval_single, eval_lit.
     - inversion H1.
-      + apply eval_call with (vals := [VLit (Atom "b")]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [0]); auto.
-        ** intros. inversion H2. 2: inversion H5. simpl. apply eval_lit.
+      + apply eval_single, eval_call with (vals := [VLit (Atom "b")]) (eff := [[(Output, [VLit (Atom "a")])]]) (ids := [0]); auto.
+        ** intros. inversion H2. 2: inversion H5. simpl. apply eval_single, eval_lit.
       + inversion H3.
   * reflexivity.
   * reflexivity.
@@ -207,20 +206,20 @@ Proof.
 Qed.
 
 Example seq_eff :
-  | [], 0, ESeq (ECall "fwrite"%string [ELit (Atom "a"%string)])
-                (ECall "fwrite"%string [ELit (Atom "b"%string)])
+  | [], 0, ESeq (ECall "fwrite" [^ELit (Atom "a")])
+                (ECall "fwrite" [^ELit (Atom "b")])
    , [] |
 -e>
-  | 0, inl ok, [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])] |.
+  | 0, inl [ok], [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")])] |.
 Proof.
-  eapply eval_seq; auto.
-  * eapply eval_call with (vals := [VLit (Atom "a")]) (eff := [[]])
+  eapply eval_single, eval_seq; auto.
+  * eapply eval_single, eval_call with (vals := [VLit (Atom "a")]) (eff := [[]])
                          (ids := [0]); auto.
-    - intros. inversion H. 2: inversion H1. apply eval_lit.
+    - intros. inversion H. 2: inversion H1. apply eval_single, eval_lit.
     - reflexivity.
-  * eapply eval_call with (vals := [VLit (Atom "b")]) (eff := [[(Output, [VLit (Atom "a")])]])
+  * eapply eval_single, eval_call with (vals := [VLit (Atom "b")]) (eff := [[(Output, [VLit (Atom "a")])]])
                          (ids := [0]); auto.
-    - intros. inversion H. 2: inversion H1. apply eval_lit.
+    - intros. inversion H. 2: inversion H1. apply eval_single, eval_lit.
 Qed.
 
 End Side_Effect_Tests.

--- a/src/Core_Erlang_Side_Effects.v
+++ b/src/Core_Erlang_Side_Effects.v
@@ -36,8 +36,6 @@ Compute nth_def [ [(Input, [VLit (Atom "a"%string)] )];
                   [(Input, [VLit (Atom "a"%string)] ); (Input, [VLit (Atom "b"%string)] )]; 
                   [(Input, [VLit (Atom "a"%string)] ); (Input, [VLit (Atom "b"%string)] ); (Input, [VLit (Atom "c"%string)] )]] [] [] 2 = [(Input, [VLit (Atom "a"%string)] ); (Input, [VLit (Atom "b"%string)] )].
 
-Import Omega.
-
 Lemma nth_def_eq {A : Type} (l : list A) (i : nat) (e1 def err : A):
   nth_def (e1::l) def err (S i) = nth_def l e1 err i.
 Proof.

--- a/src/Core_Erlang_Syntax.v
+++ b/src/Core_Erlang_Syntax.v
@@ -54,12 +54,12 @@ with SingleExpression : Type :=
 | EMap    (l : list (Expression * Expression))
 | ETry    (e1 : Expression) (vl1 : list Var) (e2 : Expression) (vl2 : list Var) (e2 : Expression).
 
-Coercion ESingle : SingleExpression >-> Expression.
-Notation "^ e" := (ESingle e) (at level 20).
-
 (** TODO: This is not enough: *)
 Scheme Expression_ind2 := Induction for Expression Sort Type
 with SingleExpression_ind2 := Induction for SingleExpression Sort Type.
+
+Coercion ESingle : SingleExpression >-> Expression.
+Notation "^ e" := (ESingle e) (at level 20).
 
 Definition EEmptyMap : SingleExpression := EMap [].
 Definition EEmptyTuple : SingleExpression := ETuple [].
@@ -94,6 +94,7 @@ Definition VEmptyMap : Value := VMap [].
 Definition VEmptyTuple : Value := VTuple [].
 
 Definition ErrorValue : Value := (VLit (Atom "error"%string)).
+Definition ErrorExp2 : Expression := ESingle (ELit (Atom "error"%string)).
 Definition ErrorExp : SingleExpression := (ELit (Atom "error"%string)).
 Definition ErrorPat : Pattern := PLit(Atom "error"%string).
 Definition ttrue : Value := VLit (Atom "true").
@@ -168,8 +169,6 @@ match e with
  | ETry e1 vl1 e2 vl2 e3 => max_degree (degree e2) (degree e3)
 end.
 
-Compute degree (ETry ENil [] ENil [] (EValues [ENil])).
-
 Definition match_degree (d1 d2 : degree_num) : bool :=
 match d1, d2 with
 | Num n1, Num n2 => Nat.eqb n1 n2
@@ -220,11 +219,6 @@ match e with
  | EValues el => false
  | ESingle e => valid_single_expression e
 end.
-
-Compute valid_expression (ECase (EValues [ENil; ENil]) [([PNil; PNil], ^ELit (Atom "true"%string), ^ENil);
-                                                        ([PNil; PNil], ^ELit (Atom "true"%string), EValues [ENil; ENil])]).
-
-
 
 End Syntax.
 

--- a/src/Core_Erlang_Syntax.v
+++ b/src/Core_Erlang_Syntax.v
@@ -31,28 +31,38 @@ Definition PEmptyTuple : Pattern := PTuple [].
 Definition FunctionIdentifier : Type := string * nat.
 
 Inductive Expression : Type :=
+| EValues (el : list SingleExpression)
+| ESingle (e : SingleExpression)
+with SingleExpression : Type :=
 | ENil
-| ELit (l : Literal)
-| EVar     (v : Var)
+| ELit    (l : Literal)
+| EVar    (v : Var)
 | EFunId  (f : FunctionIdentifier)
-| EFun     (vl : list Var) (e : Expression)
-| ECons  (hd tl : Expression)
-| ETuple (l : list Expression)
-(** Initially: for built-in functions and primitive operations : *)
-| ECall  (f: string)     (l : list Expression)
+| EFun    (vl : list Var) (e : Expression)
+| ECons   (hd tl : Expression)
+| ETuple  (l : list Expression)
+(** Initially: for built-in functions : *)
+| ECall   (f : string)    (l : list Expression)
+| EPrimOp (f : string)    (l : list Expression)
 (** For function applications: *)
-| EApp (exp: Expression)     (l : list Expression)
-| ECase  (el : list Expression) (l : list ((list Pattern) * Expression * Expression))
-| ELet   (l : list (Var * Expression)) (e : Expression)
+| EApp    (exp: Expression)     (l : list Expression)
+| ECase   (e : Expression) (l : list ((list Pattern) * Expression * Expression))
+| ELet    (l : list Var) (e1 e2 : Expression)
 (** For sequencing: do expressions (ESeq) *)
-| ESeq (e1 e2 : Expression)
+| ESeq    (e1 e2 : Expression)
 | ELetRec (l : list (FunctionIdentifier * ((list Var) * Expression))) (e : Expression)
-| EMap   (l : list (Expression * Expression))
-(** Try binds only one variable when no exception occured, and three otherwise *)
-| ETry   (el : list (Expression * Var)) (e1 e2 : Expression) (vex1 vex2 vex3 : Var).
+| EMap    (l : list (Expression * Expression))
+| ETry    (e1 : Expression) (vl1 : list Var) (e2 : Expression) (vl2 : list Var) (e2 : Expression).
 
-Definition EEmptyMap : Expression := EMap [].
-Definition EEmptyTuple : Expression := ETuple [].
+Coercion ESingle : SingleExpression >-> Expression.
+Notation "^ e" := (ESingle e) (at level 20).
+
+(** TODO: This is not enough: *)
+Scheme Expression_ind2 := Induction for Expression Sort Type
+with SingleExpression_ind2 := Induction for SingleExpression Sort Type.
+
+Definition EEmptyMap : SingleExpression := EMap [].
+Definition EEmptyTuple : SingleExpression := ETuple [].
 
 (** In the future to simulate modules: *)
 Inductive ErlFunction : Type := TopLevelFun (id : FunctionIdentifier) (vl : list Var) (body :  Expression).
@@ -61,7 +71,9 @@ Inductive ErlModule : Type := ErlMod (name : string) (fl : list ErlFunction).
 
 Definition FunctionExpression : Type := list Var * Expression.
 
-(** What expressions are in normal form *)
+(** What expressions are in normal form 
+    According to CE lang spec. value sequences cannot be nested
+*)
 Inductive Value : Type :=
 | VNil
 | VLit     (l : Literal)
@@ -74,12 +86,15 @@ Inductive Value : Type :=
 | VTuple   (vl : list Value)
 | VMap     (l : list (Value * Value)).
 
+(** Semantic domain *)
+Definition ValueSequence := list Value.
+
 (** Helper definitions *)
 Definition VEmptyMap : Value := VMap [].
 Definition VEmptyTuple : Value := VTuple [].
 
 Definition ErrorValue : Value := (VLit (Atom "error"%string)).
-Definition ErrorExp : Expression := (ELit (Atom "error"%string)).
+Definition ErrorExp : SingleExpression := (ELit (Atom "error"%string)).
 Definition ErrorPat : Pattern := PLit(Atom "error"%string).
 Definition ttrue : Value := VLit (Atom "true").
 Definition ffalse : Value := VLit (Atom "false").
@@ -90,7 +105,7 @@ Inductive ExceptionClass : Type :=
 | Error | Throw | Exit.
 
 (** Exception class to value converter *)
-Fixpoint exclass_to_value (ex : ExceptionClass) : Value :=
+Definition exclass_to_value (ex : ExceptionClass) : Value :=
 match ex with
 | Error => VLit (Atom "error"%string)
 | Throw => VLit (Atom "throw"%string)
@@ -115,6 +130,101 @@ Definition badarity (v : Value) : Exception :=
 Definition if_clause : Exception := 
   (Error, VLit (Atom "if_clause"%string), ErrorValue).
 
+Inductive degree_num : Set :=
+| Num (n : nat)
+| Any.
+
+Definition max_degree (d1 d2 : degree_num) : degree_num :=
+match d1, d2 with
+| Num n1, Num n2 => Num (max n1 n2)
+| Any, Num n => Num n
+| Num n, Any => Num n
+| Any, Any => Any
+end.
+
+
+Fixpoint degree (e : Expression) : degree_num :=
+match e with
+| EValues l => (Num (length l))
+| ESingle e => single_degree e
+end
+with single_degree (e : SingleExpression) : degree_num :=
+match e with
+ | ENil => Num 1
+ | ELit l => Num 1
+ | EVar v => Num 1
+ | EFunId f => Num 1
+ | EFun vl e => Num 1
+ | ECons hd tl => Num 1
+ | ETuple l => Num 1
+ | ECall f l => Num 1
+ | EPrimOp f l => Any
+ | EApp exp l => Num 1
+ | ECase e l => fold_right (fun '(a, b, c) r => max_degree r (degree c)) Any l
+ | ELet l e1 e2 => degree e2
+ | ESeq e1 e2 => degree e2
+ | ELetRec l e => degree e
+ | EMap l => Num 1
+ | ETry e1 vl1 e2 vl2 e3 => max_degree (degree e2) (degree e3)
+end.
+
+Compute degree (ETry ENil [] ENil [] (EValues [ENil])).
+
+Definition match_degree (d1 d2 : degree_num) : bool :=
+match d1, d2 with
+| Num n1, Num n2 => Nat.eqb n1 n2
+| _, _ => true
+end.
+
+Compute match_degree (Num 4) (Num 5).
+
+Definition which_degree (d1 d2 : degree_num) : option degree_num :=
+match d1, d2 with
+| Num n1, Num n2 => if Nat.eqb n1 n2 then Some (Num n1) else None
+| Num n, Any => Some (Num n)
+| Any, Num n => Some (Num n)
+| Any, Any => Some Any
+end.
+
+
+Compute which_degree (Num 4) (Num 5).
+Compute which_degree (Num 4) (Num 4).
+Compute which_degree Any (Num 4).
+Compute which_degree (Num 4) Any.
+Compute which_degree Any Any.
+
+
+Fixpoint valid_expression (e : Expression) : bool :=
+match e with
+ | EValues el => false
+ | ESingle e => valid_single_expression e
+end
+with valid_single_expression (e : SingleExpression) : bool :=
+match e with
+ | ENil => true
+ | ELit l => true
+ | EVar v => true
+ | EFunId f => true
+ | EFun vl e => match_degree (degree e) (Num 1)
+ | ECons hd tl => match_degree (degree hd) (Num 1) && match_degree (degree tl) (Num 1)
+ | ETuple l => fold_right (fun 'x r => andb r (match_degree (degree x) (Num 1))) true l
+ | ECall f l => fold_right (fun 'x r => andb r (match_degree (degree x) (Num 1))) true l
+ | EPrimOp f l => fold_right (fun 'x r => andb r (match_degree (degree x) (Num 1))) true l
+ | EApp exp l => match_degree (degree exp) (Num 1) && 
+                 fold_right (fun 'x r => andb r (match_degree (degree x) (Num 1))) true l
+ | ECase e l => let maxim := fold_right max_degree Any (map degree (map snd l)) in 
+                  fold_right (fun '(x, y, z) r => andb r (match_degree (degree z) maxim)) true l
+ | ELet l e1 e2 => match_degree (degree e1) (Num (length l))
+ | ESeq e1 e2 => match_degree (degree e1) (Num 1)
+ | ELetRec l e => true
+ | EMap l => true
+ | ETry e1 vl1 e2 vl2 e3 => match_degree (degree e2) (degree e3)
+end.
+
+Compute valid_expression (ECase (EValues [ENil; ENil]) [([PNil; PNil], ^ELit (Atom "true"%string), ^ENil);
+                                                        ([PNil; PNil], ^ELit (Atom "true"%string), EValues [ENil; ENil])]).
+
+
 
 End Syntax.
 
@@ -133,8 +243,14 @@ Notation "@[ @]" := (VNil) (at level 1).
 Notation "@[ a | b @]" := (VCons a b) (at level 50).
 
 Notation "x ==> x'" := (@pair Value Value x x') (at level 70).
-Notation "#{ }" := (VTuple []) (at level 1).
+Notation "#{ }" := (VMap []) (at level 1).
 Notation "#{ x , y , .. , z }" := (VMap (cons x (cons y .. (cons z nil) .. ))) (at level 50).
+
+(* Notation "< x , y , .. , z >" := (cons x (cons y .. (cons z nil) .. )) (at level 50). *)
+
+Check VTuple [].
+
+Check VCons '"asd" VNil.
 
 Check VMap [('"asd", '"asd"); ('"asd", '"asd"); ('"asd", VLit (Integer 7))].
 Check VCons '"asd" (VCons '"asd" VNil).

--- a/src/Core_Erlang_Syntax.v
+++ b/src/Core_Erlang_Syntax.v
@@ -193,13 +193,7 @@ Compute which_degree Any (Num 4).
 Compute which_degree (Num 4) Any.
 Compute which_degree Any Any.
 
-
-Fixpoint valid_expression (e : Expression) : bool :=
-match e with
- | EValues el => false
- | ESingle e => valid_single_expression e
-end
-with valid_single_expression (e : SingleExpression) : bool :=
+Definition valid_single_expression (e : SingleExpression) : bool :=
 match e with
  | ENil => true
  | ELit l => true
@@ -219,6 +213,12 @@ match e with
  | ELetRec l e => true
  | EMap l => true
  | ETry e1 vl1 e2 vl2 e3 => match_degree (degree e2) (degree e3)
+end.
+
+Definition valid_expression (e : Expression) : bool :=
+match e with
+ | EValues el => false
+ | ESingle e => valid_single_expression e
 end.
 
 Compute valid_expression (ECase (EValues [ENil; ENil]) [([PNil; PNil], ^ELit (Atom "true"%string), ^ENil);

--- a/src/Core_Erlang_Tactics.v
+++ b/src/Core_Erlang_Tactics.v
@@ -8,7 +8,8 @@ Module Tactics.
   should not be used (use `ETuple []` instead).
 *)
 
-Import Core_Erlang_Semantics.Semantics.
+Export Core_Erlang_Semantics.Semantics.
+Export Core_Erlang_Helpers.Helpers.
 Import ListNotations.
 
 Section Helper_Theorems.
@@ -210,14 +211,14 @@ unfold nth_def; simpl;
 match goal with
 | |- | ?env, ?id, ESingle _, ?eff | -e> | ?id', ?res, ?eff'| => apply eval_single; solve
 | |- | ?env, ?id, EValues _, ?eff | -e> | ?id', ?res, ?eff'| =>
-     eapply eval_values; 
+     (eapply eval_values; 
      unfold_list2;
      unfold_elements;
      solve_inners;
      try(simpl;reflexivity);
-     auto
-
-
+     auto)
+     +
+     valuelist_exception_solver 0
 
 | |- | ?env, ?id, ENil, ?eff | -s> | ?id', ?res, ?eff'| => finishing_tactic
 | |- | ?env, ?id, ENil, ?eff | -s> | ?id', ?res, ?eff'| => finishing_tactic
@@ -234,36 +235,39 @@ match goal with
      solve_inners;
      try(simpl;reflexivity);
      auto)
-     (* + tuple_exception_solver 0 *)
+     + tuple_exception_solver 0
 | |- | ?env, ?id, ECons _ _, ?eff | -s> | ?id', ?res, ?eff'| =>
      (* (apply quick_list_eval; simpl; reflexivity)
      + *)
      (eapply eval_cons; solve_inners)
-     (* +
+     +
      (eapply eval_cons_tl_ex; solve_inners)
      +
-     (eapply eval_cons_hd_ex; solve_inners) *)
+     (eapply eval_cons_hd_ex; solve_inners)
 | |- | ?env, ?id, ECase _ _, ?eff | -s> | ?id', ?res, ?eff'| =>
      case_solver 0
-     (* +
-     (case_exception_solver 0)
+     +
+     (eapply eval_case_pat_ex;
+      solve_inners)
      +
      (eapply eval_case_clause_ex;
-      unfold_list2;
+      (* unfold_list2;
       match goal with
       | |- forall i, i < length _ -> |_, _, _, _| -e> |_, _, _| =>
                                             unfold_elements;
                                             try(solve_inners)
       | _ => idtac
-      end;
+      end; *)
+      solve_inners;
       intros;
       unfold_elements;
       match goal with
+      
       | [H : match_clause _ _ _ = Some _ |- _] => inversion H
       | _ => idtac
       end;
       try(simpl;reflexivity);
-      solve_inners) *)
+      solve_inners)
 | |- | ?env, ?id, ECall _ ?l, ?eff | -s> | ?id', ?res, ?eff'| =>
      (eapply eval_call;
      unfold_list2;
@@ -275,8 +279,21 @@ match goal with
      | _ => idtac
      end;
      auto)
-     (* +
-     (call_exception_solver 0) *)
+     +
+     (call_exception_solver 0)
+| |- | ?env, ?id, EPrimOp _ ?l, ?eff | -s> | ?id', ?res, ?eff'| =>
+     (eapply eval_call;
+     unfold_list2;
+     solve_inners;
+     unfold_elements;
+     solve_inners;
+     match goal with
+     | |- eval _ _ _ = _ => tryif reflexivity then idtac else fail 1
+     | _ => idtac
+     end;
+     auto)
+     +
+     (primop_exception_solver 0)
 | |- | ?env, ?id, EApp _ _, ?eff | -s> | ?id', ?res, ?eff'| => 
      (eapply eval_app;
      unfold_list2;
@@ -284,7 +301,7 @@ match goal with
      solve_inners;
      try(simpl;reflexivity);
      auto)
-     (* +
+     +
      (eapply eval_app_closure_ex; solve_inners)
      +
      (app_param_exception_solver 0)
@@ -303,18 +320,19 @@ match goal with
       solve_inners;
       try(simpl;reflexivity);
       try(congruence)
-     ) *)
+     )
 | |- | ?env, ?id, ELet _ _ _, ?eff | -s> | ?id', ?res, ?eff'| =>
      (eapply eval_let;
-     try solve_inners;
+     solve_inners;
      try(simpl;reflexivity);
      auto)
-     (* +
-     (let_exception_solver 0) *)
+     +
+     (eapply eval_let_ex;
+      solve_inners)
 | |- | ?env, ?id, ESeq _ _, ?eff | -s> | ?id', ?res, ?eff'| =>
      (eapply eval_seq; solve_inners)
-     (* +
-     (eapply eval_seq_ex; solve_inners) *)
+     +
+     (eapply eval_seq_ex; solve_inners)
 | |- | ?env, ?id, ELetRec _ _, ?eff | -s> | ?id', ?res, ?eff'| =>
      eapply eval_letrec;
      solve_inners
@@ -325,17 +343,18 @@ match goal with
      solve_inners;
      try(simpl;reflexivity);
      auto)
-     (* +
-     (map_key_exception_solver 0) *)
-(* | |- | ?env, ?id, ETry _ _ _ _ _ _, ?eff | -e> | ?id', ?res, ?eff'| =>
-     (eapply eval_try;
-     unfold_list2;
-     unfold_elements;
-     solve_inners;
-     try(simpl;reflexivity);
-     auto)
      +
-     catch_solver 0 *)
+     (map_key_exception_solver 0)
+| |- | ?env, ?id, ETry _ _ _ _ _, ?eff | -s> | ?id', ?res, ?eff'| =>
+     (eapply eval_try;
+      unfold_list2;
+      solve_inners
+      auto)
+     +
+     (
+      eapply eval_catch;
+      solve_inners
+     )
 end
 with unfold_list2 :=
 match goal with
@@ -386,29 +405,10 @@ case_solver num :=
   then idtac
   else
      case_solver (S num)
-(* with
-case_exception_solver num :=
-  match goal with
-  | |- |_, _, _, _| -e> | _, inl _, _ | => fail 1
-  | _ =>
-  tryif
-    eapply eval_case_pat_ex with (i := num);
-    match goal with
-    | |- _ < _ => tryif simpl; lia then idtac else fail 2
-    | _ => idtac
-    end;
-    unfold_list2;
-    unfold_elements;
-    solve_inners
-  then
-    idtac
-  else
-    case_exception_solver (S num)
-  end
 with
 tuple_exception_solver num :=
   match goal with
-  | |- |_, _, _, _| -e> | _, inl _, _ | => fail 1
+  | |- |_, _, _, _| -s> | _, inl _, _ | => fail 1
   | _ =>
   tryif
     eapply eval_tuple_ex with (i := num);
@@ -425,9 +425,12 @@ tuple_exception_solver num :=
     tuple_exception_solver (S num)
   end
 with
-catch_solver num :=
+valuelist_exception_solver num :=
+  match goal with
+  | |- |_, _, _, _| -e> | _, inl _, _ | => fail 1
+  | _ =>
   tryif
-    eapply eval_catch with (i := num);
+    eapply eval_values_ex with (i := num);
     match goal with
     | |- _ < _ => tryif simpl; lia then idtac else fail 2
     | _ => idtac
@@ -438,30 +441,12 @@ catch_solver num :=
   then
     idtac
   else
-    catch_solver (S num)
-with
-let_exception_solver num :=
-  match goal with
-  | |- |_, _, _, _| -e> | _, inl _, _ | => fail 1
-  | _ =>
-    tryif
-      eapply eval_let_ex with (i := num);
-      match goal with
-      | |- _ < _ => tryif simpl; lia then idtac else fail 2
-      | _ => idtac
-      end;
-      unfold_list2;
-      unfold_elements;
-      solve_inners
-    then
-      idtac
-    else
-      let_exception_solver (S num)
+    valuelist_exception_solver (S num)
   end
 with
 app_param_exception_solver num :=
   match goal with
-  | |- |_, _, _, _| -e> | _, inl _, _ | => fail 1
+  | |- |_, _, _, _| -s> | _, inl _, _ | => fail 1
   | _ =>
     tryif
       eapply eval_app_param_ex with (i := num);
@@ -480,7 +465,7 @@ app_param_exception_solver num :=
 with
 map_key_exception_solver num :=
   match goal with
-  | |- |_, _, _, _| -e> | _, inl _, _ | => fail 1
+  | |- |_, _, _, _| -s> | _, inl _, _ | => fail 1
   | _ =>
     tryif
       eapply eval_map_key_ex with (i := num);
@@ -499,7 +484,7 @@ map_key_exception_solver num :=
 with
 map_value_exception_solver num :=
   match goal with
-  | |- |_, _, _, _| -e> | _, inl _, _ | => fail 1
+  | |- |_, _, _, _| -s> | _, inl _, _ | => fail 1
   | _ =>
     tryif
       eapply eval_map_val_ex with (i := num);
@@ -518,7 +503,7 @@ map_value_exception_solver num :=
 with
 call_exception_solver num :=
   match goal with
-  | |- |_, _, _, _| -e> | _, inl _, _ | => fail 1
+  | |- |_, _, _, _| -s> | _, inl _, _ | => fail 1
   | _ =>
     tryif
       eapply eval_call_ex with (i := num);
@@ -533,9 +518,26 @@ call_exception_solver num :=
       idtac
     else
       call_exception_solver (S num)
-  end *)
+  end
+with
+primop_exception_solver num :=
+  match goal with
+  | |- |_, _, _, _| -s> | _, inl _, _ | => fail 1
+  | _ =>
+    tryif
+      eapply eval_call_ex with (i := num);
+      match goal with
+      | |- _ < _ => tryif simpl; lia then idtac else fail 2
+      | _ => idtac
+      end;
+      unfold_list2;
+      unfold_elements;
+      solve_inners
+    then
+      idtac
+    else
+      primop_exception_solver (S num)
+  end
 .
-Open Scope string_scope.
-
 
 End Tactics.

--- a/src/Core_Erlang_Tactics.v
+++ b/src/Core_Erlang_Tactics.v
@@ -468,7 +468,7 @@ map_key_exception_solver num :=
   | |- |_, _, _, _| -s> | _, inl _, _ | => fail 1
   | _ =>
     tryif
-      eapply eval_map_key_ex with (i := num);
+      eapply eval_map_ex with (i := num);
       match goal with
       | |- _ < _ => tryif simpl; lia then idtac else fail 2
       | _ => idtac
@@ -479,9 +479,9 @@ map_key_exception_solver num :=
     then
       idtac
     else
-      map_value_exception_solver num
+      map_key_exception_solver (S num)
   end
-with
+(* with
 map_value_exception_solver num :=
   match goal with
   | |- |_, _, _, _| -s> | _, inl _, _ | => fail 1
@@ -499,7 +499,7 @@ map_value_exception_solver num :=
       idtac
     else
       map_key_exception_solver (S num)
-  end
+  end *)
 with
 call_exception_solver num :=
   match goal with
@@ -540,4 +540,20 @@ primop_exception_solver num :=
   end
 .
 
+(* Open Scope string_scope.
+
+Example eval_map_value:
+  | [], 0, EMap [(^ECall "fwrite" [^ELit (Atom "a")], ^ECall "fwrite" [^ELit (Atom "b")]);
+                 (^ECall "fwrite" [^ELit (Atom "c")], ^ELet
+   ["X"%string] (ECall "fwrite" [^ELit (Atom "d")])
+      (EApp (ELit (Integer 0)) []))]
+  , []|
+-e>
+  | 0, inr (badfun (VLit (Integer 0))), 
+        [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); 
+         (Output, [VLit (Atom "c")]); (Output, [VLit (Atom "d")])]|.
+Proof.
+  solve.
+Qed.
+ *)
 End Tactics.

--- a/src/Core_Erlang_Tactics.v
+++ b/src/Core_Erlang_Tactics.v
@@ -481,25 +481,6 @@ map_key_exception_solver num :=
     else
       map_key_exception_solver (S num)
   end
-(* with
-map_value_exception_solver num :=
-  match goal with
-  | |- |_, _, _, _| -s> | _, inl _, _ | => fail 1
-  | _ =>
-    tryif
-      eapply eval_map_val_ex with (i := num);
-      match goal with
-      | |- _ < _ => tryif simpl; lia then idtac else fail 2
-      | _ => idtac
-      end;
-      unfold_list2;
-      unfold_elements;
-      solve_inners
-    then
-      idtac
-    else
-      map_key_exception_solver (S num)
-  end *)
 with
 call_exception_solver num :=
   match goal with
@@ -540,20 +521,18 @@ primop_exception_solver num :=
   end
 .
 
-(* Open Scope string_scope.
+Open Scope string_scope.
 
-Example eval_map_value:
-  | [], 0, EMap [(^ECall "fwrite" [^ELit (Atom "a")], ^ECall "fwrite" [^ELit (Atom "b")]);
-                 (^ECall "fwrite" [^ELit (Atom "c")], ^ELet
-   ["X"%string] (ECall "fwrite" [^ELit (Atom "d")])
-      (EApp (ELit (Integer 0)) []))]
-  , []|
+Example map_eval_ex_key :
+  |[], 0, EMap [(^ELit (Atom "error"%string), ^ ELit (Atom "error"%string)); 
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string));
+                (^ECall "+" [^ELit (Integer 5); ^ETuple []], ^ELit (Atom "error"%string));
+                (^ELit (Atom "error"%string), ^ELit (Atom "error"%string))], []|
 -e>
-  | 0, inr (badfun (VLit (Integer 0))), 
-        [(Output, [VLit (Atom "a")]); (Output, [VLit (Atom "b")]); 
-         (Output, [VLit (Atom "c")]); (Output, [VLit (Atom "d")])]|.
+  |0, inr (badarith (VCons (VLit (Integer 5)) (VTuple []))), []|.
 Proof.
   solve.
+  
 Qed.
- *)
+
 End Tactics.

--- a/src/Core_Erlang_Tactics.v
+++ b/src/Core_Erlang_Tactics.v
@@ -521,7 +521,7 @@ primop_exception_solver num :=
   end
 .
 
-Open Scope string_scope.
+(* Open Scope string_scope.
 
 Example map_eval_ex_key :
   |[], 0, EMap [(^ELit (Atom "error"%string), ^ ELit (Atom "error"%string)); 
@@ -533,6 +533,6 @@ Example map_eval_ex_key :
 Proof.
   solve.
   
-Qed.
+Qed. *)
 
 End Tactics.

--- a/src/Core_Erlang_Tactics.v
+++ b/src/Core_Erlang_Tactics.v
@@ -531,9 +531,4 @@ call_exception_solver num :=
   end
 .
 
-Reserved Notation "e --e-> v" (at level 50).
-Inductive eval_to_result : Expression -> Value + Exception -> Prop :=
-| eval_expr_intro e v : (exists n eff, | [], 0, e, [] | -e> |n, v, eff|) -> e --e-> v
-where "e --e-> v" := (eval_to_result e v).
-
 End Tactics.

--- a/src/_CoqProject
+++ b/src/_CoqProject
@@ -5,6 +5,7 @@ Core_Erlang_Expression_Eq_Dec.v
 Core_Erlang_Helpers.v
 Core_Erlang_Environment.v
 Core_Erlang_Side_Effects.v
+Core_Erlang_Auxiliaries.v
 Core_Erlang_Semantics.v
 Core_Erlang_Tactics.v
 Core_Erlang_Automated_Tests.v


### PR DESCRIPTION
This pull request includes the formalisation of _value lists_, and a functional big-step semantics for Core Erlang. The main changes are the following:

- Expression syntax is mutually inductive
- Semantics domain is list of values
- Relational semantics is also mutually inductive
- Combined scheme for mutual induction for the semantics
- Adjustment of proofs, concepts, examples, tactics
- Map evaluation rule changed, instead of handling a pair of lists, only one list is enough, which allowed reducing the number of helper theorems